### PR TITLE
Sandbox volume ID 重用

### DIFF
--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { SandAgent } from "@sandagent/core";
-import { DaytonaSandbox } from "@sandagent/sandbox-daytona";
+import { DaytonaSandbox, getClaudeSessionId } from "@sandagent/sandbox-daytona";
 import { E2BSandbox } from "@sandagent/sandbox-e2b";
 import { SandockSandbox } from "@sandagent/sandbox-sandock";
 import {
@@ -177,6 +177,9 @@ export async function POST(request: Request) {
 
   // Create sandbox based on provider
   let sandbox;
+  // For Daytona with persistence, try to get stored Claude session ID for conversation history
+  let effectiveResume = resume;
+  
   if (SANDBOX_PROVIDER === "daytona") {
     sandbox = new DaytonaSandbox({
       apiKey: DAYTONA_API_KEY,
@@ -186,6 +189,16 @@ export async function POST(request: Request) {
       enablePersistence: true,
       persistenceMountPath: "/sandagent-data",
     });
+    
+    // If no resume parameter provided, try to get stored Claude session ID
+    // This enables automatic conversation history restoration when using the same sessionId
+    if (!effectiveResume) {
+      const storedClaudeSessionId = getClaudeSessionId(sessionId);
+      if (storedClaudeSessionId) {
+        effectiveResume = storedClaudeSessionId;
+        console.log(`[API] Using stored Claude session ID for resume: ${storedClaudeSessionId}`);
+      }
+    }
   } else if (SANDBOX_PROVIDER === "sandock") {
     sandbox = new SandockSandbox({
       apiKey: SANDOCK_API_KEY,
@@ -232,7 +245,7 @@ export async function POST(request: Request) {
   return agent.stream({
     messages: normalizedMessages,
     workspace: { path: "/sandagent" },
-    resume,
+    resume: effectiveResume,
     signal, // Pass signal to SandAgent
   });
 }

--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -182,6 +182,9 @@ export async function POST(request: Request) {
       apiKey: DAYTONA_API_KEY,
       runnerBundlePath: RUNNER_BUNDLE_PATH,
       templatesPath: path.join(TEMPLATES_PATH, template),
+      // Enable volume-based persistence to reuse sandbox across requests
+      enablePersistence: true,
+      persistenceMountPath: "/sandagent-data",
     });
   } else if (SANDBOX_PROVIDER === "sandock") {
     sandbox = new SandockSandbox({

--- a/apps/sandagent-example/next-env.d.ts
+++ b/apps/sandagent-example/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/sandbox-daytona/src/daytona-sandbox.ts
+++ b/packages/sandbox-daytona/src/daytona-sandbox.ts
@@ -7,6 +7,51 @@ import type {
   SandboxHandle,
 } from "@sandagent/core";
 
+/**
+ * Type alias for VolumeMount configuration
+ */
+type VolumeConfig = VolumeMount;
+
+/**
+ * In-memory store for session -> sandbox/volume mapping
+ * This enables sandbox persistence across requests
+ */
+interface SessionState {
+  sandboxId: string;
+  volumeId: string;
+  volumeName: string;
+}
+
+// Global in-memory store for session states
+const sessionStore = new Map<string, SessionState>();
+
+/**
+ * Get stored session state
+ */
+export function getSessionState(sessionId: string): SessionState | undefined {
+  return sessionStore.get(sessionId);
+}
+
+/**
+ * Set session state
+ */
+export function setSessionState(sessionId: string, state: SessionState): void {
+  sessionStore.set(sessionId, state);
+}
+
+/**
+ * Clear session state
+ */
+export function clearSessionState(sessionId: string): void {
+  sessionStore.delete(sessionId);
+}
+
+/**
+ * List all stored sessions
+ */
+export function listSessions(): Map<string, SessionState> {
+  return new Map(sessionStore);
+}
 
 /**
  * Options for creating a DaytonaSandbox instance
@@ -23,7 +68,11 @@ export interface DaytonaSandboxOptions {
   /** Path to template directory to upload */
   templatesPath?: string;
   /** Optional volumes to attach to the sandbox */
-  volumes?: VolumeMount[];
+  volumes?: VolumeConfig[];
+  /** Enable volume-based persistence for sandbox state */
+  enablePersistence?: boolean;
+  /** Mount path for the persistence volume (default: /sandagent-data) */
+  persistenceMountPath?: string;
 }
 
 /**
@@ -36,6 +85,8 @@ export class DaytonaSandbox implements SandboxAdapter {
   private readonly runnerBundlePath?: string;
   private readonly templatesPath?: string;
   private readonly volumes?: VolumeConfig[];
+  private readonly enablePersistence: boolean;
+  private readonly persistenceMountPath: string;
 
   constructor(options: DaytonaSandboxOptions = {}) {
     this.apiKey = options.apiKey ?? process.env.DAYTONA_API_KEY;
@@ -44,6 +95,8 @@ export class DaytonaSandbox implements SandboxAdapter {
     this.runnerBundlePath = options.runnerBundlePath;
     this.templatesPath = options.templatesPath;
     this.volumes = options.volumes;
+    this.enablePersistence = options.enablePersistence ?? false;
+    this.persistenceMountPath = options.persistenceMountPath ?? "/sandagent-data";
   }
 
   async attach(id: string): Promise<SandboxHandle> {
@@ -58,18 +111,109 @@ export class DaytonaSandbox implements SandboxAdapter {
       apiUrl: this.apiUrl,
     });
 
+    // Check if we have a stored session state for this agent
+    const storedState = getSessionState(id);
+    
+    if (this.enablePersistence && storedState) {
+      // Try to restore existing sandbox
+      console.log(`[Daytona] Found stored session for agent: ${id}`);
+      console.log(`[Daytona] Attempting to restore sandbox: ${storedState.sandboxId}`);
+      
+      try {
+        const existingSandbox = await daytona.get(storedState.sandboxId);
+        
+        // Check sandbox state and start if needed
+        if (existingSandbox.state === "stopped" || existingSandbox.state === "archived") {
+          console.log(`[Daytona] Sandbox ${existingSandbox.id} is ${existingSandbox.state}, starting...`);
+          await existingSandbox.start(this.timeout || 60);
+        } else if (existingSandbox.state === "started") {
+          console.log(`[Daytona] Sandbox ${existingSandbox.id} is already running`);
+        } else {
+          console.log(`[Daytona] Sandbox ${existingSandbox.id} is in state: ${existingSandbox.state}`);
+          await existingSandbox.waitUntilStarted(this.timeout || 60);
+        }
+        
+        console.log(`[Daytona] Restored sandbox ${existingSandbox.id} with volume ${storedState.volumeId}`);
+        return new DaytonaHandle(existingSandbox);
+      } catch (err) {
+        console.warn(`[Daytona] Failed to restore sandbox: ${err instanceof Error ? err.message : String(err)}`);
+        console.log(`[Daytona] Creating new sandbox with existing volume...`);
+        // Clear the invalid session state, but keep the volume for new sandbox
+        clearSessionState(id);
+        
+        // Create new sandbox with the existing volume
+        return this.createNewSandbox(daytona, id, storedState.volumeId, storedState.volumeName);
+      }
+    }
+
+    // Create new sandbox (with or without persistence)
+    return this.createNewSandbox(daytona, id);
+  }
+
+  /**
+   * Create a new sandbox, optionally with persistence volume
+   */
+  private async createNewSandbox(
+    daytona: Daytona, 
+    id: string, 
+    existingVolumeId?: string,
+    existingVolumeName?: string
+  ): Promise<SandboxHandle> {
     console.log(`[Daytona] Creating sandbox for agent: ${id}`);
+
+    let volumesToMount = this.volumes ? [...this.volumes] : [];
+    let volumeId = existingVolumeId;
+    let volumeName = existingVolumeName;
+
+    // Set up persistence volume if enabled
+    if (this.enablePersistence) {
+      if (!volumeId) {
+        // Create a new volume for this session
+        // Use a sanitized version of the session ID as the volume name
+        volumeName = `sandagent-${id.replace(/[^a-zA-Z0-9-]/g, "-").toLowerCase()}`;
+        console.log(`[Daytona] Creating/getting persistence volume: ${volumeName}`);
+        
+        try {
+          // get() with create=true will create the volume if it doesn't exist
+          const volume = await daytona.volume.get(volumeName, true);
+          volumeId = volume.id;
+          console.log(`[Daytona] Got volume: ${volumeId} (${volumeName})`);
+        } catch (err) {
+          console.error(`[Daytona] Failed to create volume: ${err instanceof Error ? err.message : String(err)}`);
+          // Continue without persistence if volume creation fails
+        }
+      }
+
+      if (volumeId && volumeName) {
+        // Add the persistence volume to the mount list
+        volumesToMount.push({
+          volumeId,
+          mountPath: this.persistenceMountPath,
+        });
+        console.log(`[Daytona] Mounting volume ${volumeId} at ${this.persistenceMountPath}`);
+      }
+    }
 
     const sandbox = await daytona.create(
       {
         language: "typescript",
-        volumes: this.volumes,
+        volumes: volumesToMount.length > 0 ? volumesToMount : undefined,
       },
       { timeout: this.timeout },
     );
     await sandbox.start();
 
     console.log(`[Daytona] Sandbox ${sandbox.id} started`);
+
+    // Store the session state if persistence is enabled
+    if (this.enablePersistence && volumeId && volumeName) {
+      setSessionState(id, {
+        sandboxId: sandbox.id,
+        volumeId,
+        volumeName,
+      });
+      console.log(`[Daytona] Stored session state for agent: ${id}`);
+    }
 
     const handle = new DaytonaHandle(sandbox);
     await this.initializeSandbox(handle, id);

--- a/packages/sandbox-daytona/src/daytona-sandbox.ts
+++ b/packages/sandbox-daytona/src/daytona-sandbox.ts
@@ -15,11 +15,20 @@ type VolumeConfig = VolumeMount;
 /**
  * In-memory store for session -> sandbox/volume mapping
  * This enables sandbox persistence across requests
+ * 
+ * Note: For full conversation history restoration, you need BOTH:
+ * 1. volumeId - to restore filesystem state (files, code, data)
+ * 2. claudeSessionId - to restore conversation history (via Claude Agent SDK's resume parameter)
  */
 interface SessionState {
+  /** Daytona sandbox ID */
   sandboxId: string;
+  /** Daytona volume ID for filesystem persistence */
   volumeId: string;
+  /** Volume name */
   volumeName: string;
+  /** Claude Agent SDK session ID for conversation history (optional) */
+  claudeSessionId?: string;
 }
 
 // Global in-memory store for session states
@@ -51,6 +60,30 @@ export function clearSessionState(sessionId: string): void {
  */
 export function listSessions(): Map<string, SessionState> {
   return new Map(sessionStore);
+}
+
+/**
+ * Update Claude session ID for an existing session
+ * This should be called after receiving the session_id from Claude Agent SDK response
+ * 
+ * The Claude session ID is needed to resume conversation history across sandbox restarts.
+ * Without it, only filesystem state (files, code) will be restored, not conversation history.
+ */
+export function updateClaudeSessionId(sessionId: string, claudeSessionId: string): void {
+  const state = sessionStore.get(sessionId);
+  if (state) {
+    state.claudeSessionId = claudeSessionId;
+    sessionStore.set(sessionId, state);
+    console.log(`[Daytona] Updated Claude session ID for ${sessionId}: ${claudeSessionId}`);
+  }
+}
+
+/**
+ * Get Claude session ID for resuming conversation
+ * Returns undefined if no session exists or no Claude session ID has been stored
+ */
+export function getClaudeSessionId(sessionId: string): string | undefined {
+  return sessionStore.get(sessionId)?.claudeSessionId;
 }
 
 /**

--- a/packages/sandbox-daytona/src/index.ts
+++ b/packages/sandbox-daytona/src/index.ts
@@ -6,4 +6,7 @@ export {
   setSessionState,
   clearSessionState,
   listSessions,
+  // Claude session ID management for conversation history
+  updateClaudeSessionId,
+  getClaudeSessionId,
 } from "./daytona-sandbox.js";

--- a/packages/sandbox-daytona/src/index.ts
+++ b/packages/sandbox-daytona/src/index.ts
@@ -1,4 +1,9 @@
 export {
   DaytonaSandbox,
   type DaytonaSandboxOptions,
+  // Session state management for persistence
+  getSessionState,
+  setSessionState,
+  clearSessionState,
+  listSessions,
 } from "./daytona-sandbox.js";


### PR DESCRIPTION
Implements volume-based persistence for Daytona sandboxes to enable session state recovery across requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-83e8d35d-90e9-4522-aa27-236ac35563fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-83e8d35d-90e9-4522-aa27-236ac35563fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

