### PR TITLE
feat: daytona sandbox recover

### DIFF
--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -179,24 +179,24 @@ export async function POST(request: Request) {
   let sandbox;
 
   if (SANDBOX_PROVIDER === "daytona") {
-    // For Daytona, use template as reuseKey to enable sandbox reuse
-    // Sandboxes with the same template will be reused instead of creating new ones
-    const reuseKey = `template-${template}`;
+    // For Daytona, use template as sandbox name to enable sandbox reuse
+    // Sandboxes with the same name will be reused instead of creating new ones
+    const sandboxName = `sandagent-${template}`;
 
     sandbox = new DaytonaSandbox({
       apiKey: DAYTONA_API_KEY,
       runnerBundlePath: RUNNER_BUNDLE_PATH,
       templatesPath: path.join(TEMPLATES_PATH, template),
-      volumeName: `sandagent-${template}`,
-      // Reuse key enables sandbox reuse - same template = same sandbox
-      reuseKey,
+      volumeName: sandboxName,
+      // Name enables sandbox reuse - same name = same sandbox
+      name: sandboxName,
       // Auto-stop after 15 minutes of inactivity
       autoStopInterval: 15,
       // Disable auto-delete (sandbox persists until manually deleted)
       autoDeleteInterval: -1,
     });
 
-    console.log(`[API] Daytona sandbox configured with reuseKey: ${reuseKey}`);
+    console.log(`[API] Daytona sandbox configured with name: ${sandboxName}`);
   } else if (SANDBOX_PROVIDER === "sandock") {
     sandbox = new SandockSandbox({
       apiKey: SANDOCK_API_KEY,

--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -33,8 +33,6 @@ const TEMPLATES_PATH = path.join(MONOREPO_ROOT, "templates");
  *   E2B_API_KEY?: string,                // Client-provided E2B key
  *   SANDOCK_API_KEY?: string,            // Client-provided Sandock key
  *   SANDBOX_PROVIDER?: string,           // 'e2b', 'sandock', or 'daytona'
- *   DAYTONA_AUTO_STOP_INTERVAL?: number, // Daytona auto-stop interval in minutes (default: 15)
- *   DAYTONA_AUTO_DELETE_INTERVAL?: number, // Daytona auto-delete interval in minutes (default: -1, disabled)
  *   workspace?: { path?: string }
  * }
  *
@@ -54,8 +52,6 @@ export async function POST(request: Request) {
     E2B_API_KEY,
     SANDOCK_API_KEY,
     DAYTONA_API_KEY,
-    DAYTONA_AUTO_STOP_INTERVAL,
-    DAYTONA_AUTO_DELETE_INTERVAL,
     SANDBOX_PROVIDER = "e2b",
   } = body;
 
@@ -73,16 +69,6 @@ export async function POST(request: Request) {
   console.log("[API] Has SANDOCK_API_KEY:", !!SANDOCK_API_KEY);
   console.log("[API] Has DAYTONA_API_KEY:", !!DAYTONA_API_KEY);
   console.log("[API] SANDBOX_PROVIDER:", SANDBOX_PROVIDER);
-  if (SANDBOX_PROVIDER === "daytona") {
-    console.log(
-      "[API] DAYTONA_AUTO_STOP_INTERVAL:",
-      DAYTONA_AUTO_STOP_INTERVAL ?? "15 (default)",
-    );
-    console.log(
-      "[API] DAYTONA_AUTO_DELETE_INTERVAL:",
-      DAYTONA_AUTO_DELETE_INTERVAL ?? "-1 (disabled, default)",
-    );
-  }
 
   // Validate required fields
   if (!sessionId) {
@@ -204,10 +190,10 @@ export async function POST(request: Request) {
       volumeName: `sandagent-${template}`,
       // Reuse key enables sandbox reuse - same template = same sandbox
       reuseKey,
-      // Configurable auto-stop interval (default: 15 minutes)
-      autoStopInterval: DAYTONA_AUTO_STOP_INTERVAL ?? 15,
-      // Configurable auto-delete interval (default: -1, disabled)
-      autoDeleteInterval: DAYTONA_AUTO_DELETE_INTERVAL ?? -1,
+      // Auto-stop after 15 minutes of inactivity
+      autoStopInterval: 15,
+      // Disable auto-delete (sandbox persists until manually deleted)
+      autoDeleteInterval: -1,
     });
 
     console.log(`[API] Daytona sandbox configured with reuseKey: ${reuseKey}`);

--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -32,7 +32,9 @@ const TEMPLATES_PATH = path.join(MONOREPO_ROOT, "templates");
  *   AWS_BEARER_TOKEN_BEDROCK?: string,   // Client-provided AWS Bedrock token (optional)
  *   E2B_API_KEY?: string,                // Client-provided E2B key
  *   SANDOCK_API_KEY?: string,            // Client-provided Sandock key
- *   SANDBOX_PROVIDER?: string,           // 'e2b' or 'sandock'
+ *   SANDBOX_PROVIDER?: string,           // 'e2b', 'sandock', or 'daytona'
+ *   DAYTONA_AUTO_STOP_INTERVAL?: number, // Daytona auto-stop interval in minutes (default: 15)
+ *   DAYTONA_AUTO_DELETE_INTERVAL?: number, // Daytona auto-delete interval in minutes (default: -1, disabled)
  *   workspace?: { path?: string }
  * }
  *
@@ -52,6 +54,8 @@ export async function POST(request: Request) {
     E2B_API_KEY,
     SANDOCK_API_KEY,
     DAYTONA_API_KEY,
+    DAYTONA_AUTO_STOP_INTERVAL,
+    DAYTONA_AUTO_DELETE_INTERVAL,
     SANDBOX_PROVIDER = "e2b",
   } = body;
 
@@ -69,6 +73,16 @@ export async function POST(request: Request) {
   console.log("[API] Has SANDOCK_API_KEY:", !!SANDOCK_API_KEY);
   console.log("[API] Has DAYTONA_API_KEY:", !!DAYTONA_API_KEY);
   console.log("[API] SANDBOX_PROVIDER:", SANDBOX_PROVIDER);
+  if (SANDBOX_PROVIDER === "daytona") {
+    console.log(
+      "[API] DAYTONA_AUTO_STOP_INTERVAL:",
+      DAYTONA_AUTO_STOP_INTERVAL ?? "15 (default)",
+    );
+    console.log(
+      "[API] DAYTONA_AUTO_DELETE_INTERVAL:",
+      DAYTONA_AUTO_DELETE_INTERVAL ?? "-1 (disabled, default)",
+    );
+  }
 
   // Validate required fields
   if (!sessionId) {
@@ -179,12 +193,24 @@ export async function POST(request: Request) {
   let sandbox;
 
   if (SANDBOX_PROVIDER === "daytona") {
+    // For Daytona, use template as reuseKey to enable sandbox reuse
+    // Sandboxes with the same template will be reused instead of creating new ones
+    const reuseKey = `template-${template}`;
+
     sandbox = new DaytonaSandbox({
       apiKey: DAYTONA_API_KEY,
       runnerBundlePath: RUNNER_BUNDLE_PATH,
       templatesPath: path.join(TEMPLATES_PATH, template),
       volumeName: `sandagent-${template}`,
+      // Reuse key enables sandbox reuse - same template = same sandbox
+      reuseKey,
+      // Configurable auto-stop interval (default: 15 minutes)
+      autoStopInterval: DAYTONA_AUTO_STOP_INTERVAL ?? 15,
+      // Configurable auto-delete interval (default: -1, disabled)
+      autoDeleteInterval: DAYTONA_AUTO_DELETE_INTERVAL ?? -1,
     });
+
+    console.log(`[API] Daytona sandbox configured with reuseKey: ${reuseKey}`);
   } else if (SANDBOX_PROVIDER === "sandock") {
     sandbox = new SandockSandbox({
       apiKey: SANDOCK_API_KEY,

--- a/packages/sandbox-daytona/src/daytona-sandbox.ts
+++ b/packages/sandbox-daytona/src/daytona-sandbox.ts
@@ -53,11 +53,6 @@ export interface DaytonaSandboxOptions {
 }
 
 /**
- * Label key to mark that a sandbox has been initialized
- */
-const INITIALIZED_LABEL = "sandagent-initialized";
-
-/**
  * Daytona-based sandbox implementation.
  *
  * This adapter supports sandbox reuse based on sandbox name.
@@ -87,8 +82,8 @@ export class DaytonaSandbox implements SandboxAdapter {
     this.volumeMountPath = options.volumeMountPath ?? "/sandagent";
     // Default auto-stop to 15 minutes
     this.autoStopInterval = options.autoStopInterval ?? 15;
-    // Default auto-delete to disabled (-1)
-    this.autoDeleteInterval = options.autoDeleteInterval ?? -1;
+    // Default auto-delete to disabled (-1),
+    this.autoDeleteInterval = options.autoDeleteInterval ?? 0;
     this.name = options.name;
   }
 
@@ -207,16 +202,8 @@ export class DaytonaSandbox implements SandboxAdapter {
           needsInit = true;
         }
 
-        // Check if sandbox was already initialized (using labels)
-        if (
-          !needsInit &&
-          existingSandbox.labels[INITIALIZED_LABEL] !== "true"
-        ) {
-          console.log(
-            `[Daytona] Sandbox exists but not initialized, will initialize`,
-          );
-          needsInit = true;
-        }
+        // If sandbox exists, it's already initialized (files are in volume)
+        // Only initialize if we're creating a new sandbox
       } catch (error) {
         // get() throws if not found, create new sandbox with the name
         console.log(
@@ -237,16 +224,9 @@ export class DaytonaSandbox implements SandboxAdapter {
     const handle = new DaytonaHandle(sandbox);
 
     // Initialize sandbox if needed (upload files, install dependencies)
+    // Files are stored in volume, so existing sandboxes don't need re-initialization
     if (needsInit) {
       await this.initializeSandbox(handle, id);
-
-      // Mark sandbox as initialized using labels (for named sandboxes)
-      if (this.name) {
-        await sandbox.setLabels({
-          ...sandbox.labels,
-          [INITIALIZED_LABEL]: "true",
-        });
-      }
     }
 
     return handle;

--- a/packages/sandbox-daytona/src/daytona-sandbox.ts
+++ b/packages/sandbox-daytona/src/daytona-sandbox.ts
@@ -30,10 +30,45 @@ export interface DaytonaSandboxOptions {
   volumeName?: string;
   /** Mount path for the volume (default: /sandagent) */
   volumeMountPath?: string;
+  /**
+   * Auto-stop interval in minutes (0 means disabled).
+   * Default is 15 minutes.
+   * The sandbox will automatically stop after being idle for this duration.
+   */
+  autoStopInterval?: number;
+  /**
+   * Auto-delete interval in minutes.
+   * - Negative value: disabled (default)
+   * - 0: delete immediately upon stopping
+   * - Positive value: delete after being stopped for this many minutes
+   */
+  autoDeleteInterval?: number;
+  /**
+   * Reuse key for sandbox identification.
+   * Sandboxes with the same reuse key will be reused instead of creating new ones.
+   * If not provided, a new sandbox is always created.
+   * This key is stored as a label on the sandbox for lookup without in-memory caching.
+   */
+  reuseKey?: string;
 }
 
 /**
+ * Label key used to store the reuse key on sandboxes
+ */
+const REUSE_KEY_LABEL = "sandagent-reuse-key";
+
+/**
+ * Label key to mark that a sandbox has been initialized
+ */
+const INITIALIZED_LABEL = "sandagent-initialized";
+
+/**
  * Daytona-based sandbox implementation.
+ *
+ * This adapter supports sandbox reuse based on a reuse key.
+ * When a reuse key is provided, it will attempt to find and reuse
+ * an existing sandbox with the same key instead of creating a new one.
+ * All state is stored in Daytona labels - no in-memory caching is used.
  */
 export class DaytonaSandbox implements SandboxAdapter {
   private readonly apiKey?: string;
@@ -43,9 +78,9 @@ export class DaytonaSandbox implements SandboxAdapter {
   private readonly templatesPath?: string;
   private readonly volumeName?: string;
   private readonly volumeMountPath: string;
-
-  /** Track which volumes have been initialized (files uploaded) */
-  private static readonly initializedVolumes: Set<string> = new Set();
+  private readonly autoStopInterval: number;
+  private readonly autoDeleteInterval: number;
+  private readonly reuseKey?: string;
 
   constructor(options: DaytonaSandboxOptions = {}) {
     this.apiKey = options.apiKey ?? process.env.DAYTONA_API_KEY;
@@ -55,6 +90,11 @@ export class DaytonaSandbox implements SandboxAdapter {
     this.templatesPath = options.templatesPath;
     this.volumeName = options.volumeName;
     this.volumeMountPath = options.volumeMountPath ?? "/sandagent";
+    // Default auto-stop to 15 minutes
+    this.autoStopInterval = options.autoStopInterval ?? 15;
+    // Default auto-delete to disabled (-1)
+    this.autoDeleteInterval = options.autoDeleteInterval ?? -1;
+    this.reuseKey = options.reuseKey;
   }
 
   async attach(id: string): Promise<SandboxHandle> {
@@ -69,7 +109,7 @@ export class DaytonaSandbox implements SandboxAdapter {
       apiUrl: this.apiUrl,
     });
 
-    console.log(`[Daytona] Creating sandbox for agent: ${id}`);
+    console.log(`[Daytona] Attaching sandbox for agent: ${id}`);
 
     // Get or create volume if volumeName is provided
     let volumes: VolumeConfig[] | undefined;
@@ -98,23 +138,167 @@ export class DaytonaSandbox implements SandboxAdapter {
       );
     }
 
+    let sandbox: Sandbox;
+    let needsInit = false;
+
+    // Try to find existing sandbox by reuse key
+    if (this.reuseKey) {
+      console.log(
+        `[Daytona] Looking for existing sandbox with reuse key: ${this.reuseKey}`,
+      );
+
+      try {
+        const existingSandbox = await daytona.findOne({
+          labels: { [REUSE_KEY_LABEL]: this.reuseKey },
+        });
+
+        if (existingSandbox) {
+          console.log(
+            `[Daytona] Found existing sandbox: ${existingSandbox.id}, state: ${existingSandbox.state}`,
+          );
+
+          // Handle different sandbox states
+          if (existingSandbox.state === "started") {
+            // Sandbox is ready to use
+            console.log(
+              `[Daytona] Reusing running sandbox: ${existingSandbox.id}`,
+            );
+            sandbox = existingSandbox;
+            // Refresh activity to prevent auto-stop
+            await sandbox.refreshActivity();
+          } else if (
+            existingSandbox.state === "stopped" ||
+            existingSandbox.state === "stopping"
+          ) {
+            // Sandbox needs to be started
+            console.log(
+              `[Daytona] Starting stopped sandbox: ${existingSandbox.id}`,
+            );
+            await existingSandbox.start(this.timeout);
+            sandbox = existingSandbox;
+          } else if (existingSandbox.state === "archived") {
+            // Archived sandbox - start it (Daytona will unarchive automatically)
+            console.log(
+              `[Daytona] Starting archived sandbox: ${existingSandbox.id}`,
+            );
+            await existingSandbox.start(this.timeout);
+            sandbox = existingSandbox;
+          } else if (existingSandbox.state === "error") {
+            // Error state - check if recoverable
+            if (existingSandbox.recoverable) {
+              console.log(
+                `[Daytona] Recovering sandbox from error: ${existingSandbox.id}`,
+              );
+              await existingSandbox.recover(this.timeout);
+              sandbox = existingSandbox;
+            } else {
+              // Non-recoverable error - delete and create new
+              console.log(
+                `[Daytona] Deleting non-recoverable sandbox: ${existingSandbox.id}`,
+              );
+              await existingSandbox.delete();
+              sandbox = await this.createNewSandbox(daytona, volumes);
+              needsInit = true;
+            }
+          } else if (existingSandbox.state === "starting") {
+            // Wait for it to finish starting
+            console.log(
+              `[Daytona] Waiting for sandbox to start: ${existingSandbox.id}`,
+            );
+            await existingSandbox.waitUntilStarted(this.timeout);
+            sandbox = existingSandbox;
+          } else {
+            // Unknown state - create new sandbox
+            console.log(
+              `[Daytona] Unknown sandbox state: ${existingSandbox.state}, creating new sandbox`,
+            );
+            sandbox = await this.createNewSandbox(daytona, volumes);
+            needsInit = true;
+          }
+
+          // Check if sandbox was already initialized (using labels)
+          if (
+            !needsInit &&
+            existingSandbox.labels[INITIALIZED_LABEL] !== "true"
+          ) {
+            console.log(
+              `[Daytona] Sandbox exists but not initialized, will initialize`,
+            );
+            needsInit = true;
+          }
+        } else {
+          // No existing sandbox found, create new
+          console.log(`[Daytona] No existing sandbox found, creating new one`);
+          sandbox = await this.createNewSandbox(daytona, volumes);
+          needsInit = true;
+        }
+      } catch (error) {
+        // findOne throws if not found, create new sandbox
+        console.log(
+          `[Daytona] No existing sandbox found (error: ${error}), creating new one`,
+        );
+        sandbox = await this.createNewSandbox(daytona, volumes);
+        needsInit = true;
+      }
+    } else {
+      // No reuse key - always create new sandbox
+      console.log(`[Daytona] No reuse key provided, creating new sandbox`);
+      sandbox = await this.createNewSandbox(daytona, volumes);
+      needsInit = true;
+    }
+
+    console.log(`[Daytona] Sandbox ${sandbox.id} ready`);
+
+    const handle = new DaytonaHandle(sandbox);
+
+    // Initialize sandbox if needed (upload files, install dependencies)
+    if (needsInit) {
+      await this.initializeSandbox(handle, id);
+
+      // Mark sandbox as initialized using labels
+      if (this.reuseKey) {
+        await sandbox.setLabels({
+          ...sandbox.labels,
+          [INITIALIZED_LABEL]: "true",
+        });
+      }
+    }
+
+    return handle;
+  }
+
+  /**
+   * Create a new sandbox with the configured settings
+   */
+  private async createNewSandbox(
+    daytona: Daytona,
+    volumes?: VolumeConfig[],
+  ): Promise<Sandbox> {
+    const labels: Record<string, string> = {};
+
+    // Add reuse key label if provided
+    if (this.reuseKey) {
+      labels[REUSE_KEY_LABEL] = this.reuseKey;
+    }
+
+    console.log(
+      `[Daytona] Creating new sandbox with autoStopInterval=${this.autoStopInterval}min, autoDeleteInterval=${this.autoDeleteInterval}min`,
+    );
+
     const sandbox = await daytona.create(
       {
         language: "typescript",
         volumes,
-        autoDeleteInterval: 0,
-        autoStopInterval: 5,
+        labels,
+        autoStopInterval: this.autoStopInterval,
+        autoDeleteInterval: this.autoDeleteInterval,
       },
       { timeout: this.timeout },
     );
     await sandbox.start();
 
-    console.log(`[Daytona] Sandbox ${sandbox.id} started`);
-
-    const handle = new DaytonaHandle(sandbox);
-    await this.initializeSandbox(handle, id);
-
-    return handle;
+    console.log(`[Daytona] Sandbox ${sandbox.id} created and started`);
+    return sandbox;
   }
 
   private async initializeSandbox(
@@ -197,6 +381,13 @@ class DaytonaHandle implements SandboxHandle {
 
   constructor(sandbox: Sandbox) {
     this.sandbox = sandbox;
+  }
+
+  /**
+   * Get the sandbox ID (useful for external tracking)
+   */
+  getSandboxId(): string {
+    return this.sandbox.id;
   }
 
   /**
@@ -428,5 +619,6 @@ class DaytonaHandle implements SandboxHandle {
 
   async destroy(): Promise<void> {
     // Daytona sandbox lifecycle is managed by the platform, no manual cleanup needed
+    // The sandbox will auto-stop and auto-delete based on configured intervals
   }
 }

--- a/packages/sandbox-daytona/src/daytona-sandbox.ts
+++ b/packages/sandbox-daytona/src/daytona-sandbox.ts
@@ -44,18 +44,13 @@ export interface DaytonaSandboxOptions {
    */
   autoDeleteInterval?: number;
   /**
-   * Reuse key for sandbox identification.
-   * Sandboxes with the same reuse key will be reused instead of creating new ones.
-   * If not provided, a new sandbox is always created.
-   * This key is stored as a label on the sandbox for lookup without in-memory caching.
+   * Sandbox name for reuse.
+   * If provided, will try to get existing sandbox by name first.
+   * If not found, creates a new sandbox with this name.
+   * If not provided, a new sandbox is always created (without a name).
    */
-  reuseKey?: string;
+  name?: string;
 }
-
-/**
- * Label key used to store the reuse key on sandboxes
- */
-const REUSE_KEY_LABEL = "sandagent-reuse-key";
 
 /**
  * Label key to mark that a sandbox has been initialized
@@ -65,10 +60,10 @@ const INITIALIZED_LABEL = "sandagent-initialized";
 /**
  * Daytona-based sandbox implementation.
  *
- * This adapter supports sandbox reuse based on a reuse key.
- * When a reuse key is provided, it will attempt to find and reuse
- * an existing sandbox with the same key instead of creating a new one.
- * All state is stored in Daytona labels - no in-memory caching is used.
+ * This adapter supports sandbox reuse based on sandbox name.
+ * When a name is provided, it will attempt to get an existing sandbox
+ * by that name first. If not found, creates a new sandbox with that name.
+ * If no name is provided, a new sandbox is always created.
  */
 export class DaytonaSandbox implements SandboxAdapter {
   private readonly apiKey?: string;
@@ -80,7 +75,7 @@ export class DaytonaSandbox implements SandboxAdapter {
   private readonly volumeMountPath: string;
   private readonly autoStopInterval: number;
   private readonly autoDeleteInterval: number;
-  private readonly reuseKey?: string;
+  private readonly name?: string;
 
   constructor(options: DaytonaSandboxOptions = {}) {
     this.apiKey = options.apiKey ?? process.env.DAYTONA_API_KEY;
@@ -94,7 +89,7 @@ export class DaytonaSandbox implements SandboxAdapter {
     this.autoStopInterval = options.autoStopInterval ?? 15;
     // Default auto-delete to disabled (-1)
     this.autoDeleteInterval = options.autoDeleteInterval ?? -1;
-    this.reuseKey = options.reuseKey;
+    this.name = options.name;
   }
 
   async attach(id: string): Promise<SandboxHandle> {
@@ -141,108 +136,98 @@ export class DaytonaSandbox implements SandboxAdapter {
     let sandbox: Sandbox;
     let needsInit = false;
 
-    // Try to find existing sandbox by reuse key
-    if (this.reuseKey) {
+    // Try to get existing sandbox by name
+    if (this.name) {
       console.log(
-        `[Daytona] Looking for existing sandbox with reuse key: ${this.reuseKey}`,
+        `[Daytona] Looking for existing sandbox with name: ${this.name}`,
       );
 
       try {
-        const existingSandbox = await daytona.findOne({
-          labels: { [REUSE_KEY_LABEL]: this.reuseKey },
-        });
+        const existingSandbox = await daytona.get(this.name);
+        console.log(
+          `[Daytona] Found existing sandbox: ${existingSandbox.id}, state: ${existingSandbox.state}`,
+        );
 
-        if (existingSandbox) {
+        // Handle different sandbox states
+        if (existingSandbox.state === "started") {
+          // Sandbox is ready to use
           console.log(
-            `[Daytona] Found existing sandbox: ${existingSandbox.id}, state: ${existingSandbox.state}`,
+            `[Daytona] Reusing running sandbox: ${existingSandbox.id}`,
           );
-
-          // Handle different sandbox states
-          if (existingSandbox.state === "started") {
-            // Sandbox is ready to use
+          sandbox = existingSandbox;
+          // Refresh activity to prevent auto-stop
+          await sandbox.refreshActivity();
+        } else if (
+          existingSandbox.state === "stopped" ||
+          existingSandbox.state === "stopping"
+        ) {
+          // Sandbox needs to be started
+          console.log(
+            `[Daytona] Starting stopped sandbox: ${existingSandbox.id}`,
+          );
+          await existingSandbox.start(this.timeout);
+          sandbox = existingSandbox;
+        } else if (existingSandbox.state === "archived") {
+          // Archived sandbox - start it (Daytona will unarchive automatically)
+          console.log(
+            `[Daytona] Starting archived sandbox: ${existingSandbox.id}`,
+          );
+          await existingSandbox.start(this.timeout);
+          sandbox = existingSandbox;
+        } else if (existingSandbox.state === "error") {
+          // Error state - check if recoverable
+          if (existingSandbox.recoverable) {
             console.log(
-              `[Daytona] Reusing running sandbox: ${existingSandbox.id}`,
+              `[Daytona] Recovering sandbox from error: ${existingSandbox.id}`,
             );
-            sandbox = existingSandbox;
-            // Refresh activity to prevent auto-stop
-            await sandbox.refreshActivity();
-          } else if (
-            existingSandbox.state === "stopped" ||
-            existingSandbox.state === "stopping"
-          ) {
-            // Sandbox needs to be started
-            console.log(
-              `[Daytona] Starting stopped sandbox: ${existingSandbox.id}`,
-            );
-            await existingSandbox.start(this.timeout);
-            sandbox = existingSandbox;
-          } else if (existingSandbox.state === "archived") {
-            // Archived sandbox - start it (Daytona will unarchive automatically)
-            console.log(
-              `[Daytona] Starting archived sandbox: ${existingSandbox.id}`,
-            );
-            await existingSandbox.start(this.timeout);
-            sandbox = existingSandbox;
-          } else if (existingSandbox.state === "error") {
-            // Error state - check if recoverable
-            if (existingSandbox.recoverable) {
-              console.log(
-                `[Daytona] Recovering sandbox from error: ${existingSandbox.id}`,
-              );
-              await existingSandbox.recover(this.timeout);
-              sandbox = existingSandbox;
-            } else {
-              // Non-recoverable error - delete and create new
-              console.log(
-                `[Daytona] Deleting non-recoverable sandbox: ${existingSandbox.id}`,
-              );
-              await existingSandbox.delete();
-              sandbox = await this.createNewSandbox(daytona, volumes);
-              needsInit = true;
-            }
-          } else if (existingSandbox.state === "starting") {
-            // Wait for it to finish starting
-            console.log(
-              `[Daytona] Waiting for sandbox to start: ${existingSandbox.id}`,
-            );
-            await existingSandbox.waitUntilStarted(this.timeout);
+            await existingSandbox.recover(this.timeout);
             sandbox = existingSandbox;
           } else {
-            // Unknown state - create new sandbox
+            // Non-recoverable error - delete and create new
             console.log(
-              `[Daytona] Unknown sandbox state: ${existingSandbox.state}, creating new sandbox`,
+              `[Daytona] Deleting non-recoverable sandbox: ${existingSandbox.id}`,
             );
+            await existingSandbox.delete();
             sandbox = await this.createNewSandbox(daytona, volumes);
             needsInit = true;
           }
-
-          // Check if sandbox was already initialized (using labels)
-          if (
-            !needsInit &&
-            existingSandbox.labels[INITIALIZED_LABEL] !== "true"
-          ) {
-            console.log(
-              `[Daytona] Sandbox exists but not initialized, will initialize`,
-            );
-            needsInit = true;
-          }
+        } else if (existingSandbox.state === "starting") {
+          // Wait for it to finish starting
+          console.log(
+            `[Daytona] Waiting for sandbox to start: ${existingSandbox.id}`,
+          );
+          await existingSandbox.waitUntilStarted(this.timeout);
+          sandbox = existingSandbox;
         } else {
-          // No existing sandbox found, create new
-          console.log(`[Daytona] No existing sandbox found, creating new one`);
+          // Unknown state - create new sandbox
+          console.log(
+            `[Daytona] Unknown sandbox state: ${existingSandbox.state}, creating new sandbox`,
+          );
           sandbox = await this.createNewSandbox(daytona, volumes);
           needsInit = true;
         }
+
+        // Check if sandbox was already initialized (using labels)
+        if (
+          !needsInit &&
+          existingSandbox.labels[INITIALIZED_LABEL] !== "true"
+        ) {
+          console.log(
+            `[Daytona] Sandbox exists but not initialized, will initialize`,
+          );
+          needsInit = true;
+        }
       } catch (error) {
-        // findOne throws if not found, create new sandbox
+        // get() throws if not found, create new sandbox with the name
         console.log(
-          `[Daytona] No existing sandbox found (error: ${error}), creating new one`,
+          `[Daytona] Sandbox "${this.name}" not found, creating new one`,
         );
         sandbox = await this.createNewSandbox(daytona, volumes);
         needsInit = true;
       }
     } else {
-      // No reuse key - always create new sandbox
-      console.log(`[Daytona] No reuse key provided, creating new sandbox`);
+      // No name provided - always create new sandbox
+      console.log(`[Daytona] No name provided, creating new sandbox`);
       sandbox = await this.createNewSandbox(daytona, volumes);
       needsInit = true;
     }
@@ -255,8 +240,8 @@ export class DaytonaSandbox implements SandboxAdapter {
     if (needsInit) {
       await this.initializeSandbox(handle, id);
 
-      // Mark sandbox as initialized using labels
-      if (this.reuseKey) {
+      // Mark sandbox as initialized using labels (for named sandboxes)
+      if (this.name) {
         await sandbox.setLabels({
           ...sandbox.labels,
           [INITIALIZED_LABEL]: "true",
@@ -274,22 +259,15 @@ export class DaytonaSandbox implements SandboxAdapter {
     daytona: Daytona,
     volumes?: VolumeConfig[],
   ): Promise<Sandbox> {
-    const labels: Record<string, string> = {};
-
-    // Add reuse key label if provided
-    if (this.reuseKey) {
-      labels[REUSE_KEY_LABEL] = this.reuseKey;
-    }
-
     console.log(
-      `[Daytona] Creating new sandbox with autoStopInterval=${this.autoStopInterval}min, autoDeleteInterval=${this.autoDeleteInterval}min`,
+      `[Daytona] Creating new sandbox${this.name ? ` with name "${this.name}"` : ""}, autoStopInterval=${this.autoStopInterval}min, autoDeleteInterval=${this.autoDeleteInterval}min`,
     );
 
     const sandbox = await daytona.create(
       {
+        name: this.name,
         language: "typescript",
         volumes,
-        labels,
         autoStopInterval: this.autoStopInterval,
         autoDeleteInterval: this.autoDeleteInterval,
       },


### PR DESCRIPTION
为 Daytona sandbox 实现 sandbox 复用功能，相同模板使用相同的 sandbox，避免每次请求都创建新的 sandbox。因为有总的内存限制，所以在开发的时候可以复用同一个sandbox

Changes
packages/sandbox-daytona/src/daytona-sandbox.ts
新增配置项：

name: Sandbox 名称，用于复用。传入 name 时会先尝试获取已存在的 sandbox，不存在则创建新的
autoStopInterval: 自动停止间隔（分钟），默认 15 分钟
autoDeleteInterval: 自动删除间隔（分钟），默认 0（立即删除）
复用逻辑：

如果传入了 name，调用 daytona.get(name) 获取已存在的 sandbox
根据 sandbox 状态处理：
started: 直接复用，刷新活动时间防止自动停止
stopped/stopping: 重新启动
archived: 启动（Daytona 自动解档）
error: 可恢复则恢复，否则删除后创建新的
starting: 等待启动完成
如果找不到 sandbox，创建新的并设置该 name
如果没有传入 name，每次都创建新的 sandbox
无内存缓存：

所有状态通过 Daytona API 获取，不在内存中缓存
文件存储在 volume 中，已存在的 sandbox 无需重新初始化
apps/sandagent-example/app/api/ai/route.ts
使用 sandagent-${template} 作为 sandbox name
相同模板复用相同 sandbox