### PR TITLE
feat: e2b reconnect

### DIFF
--- a/apps/sandagent-example/app/api/ai/route.ts
+++ b/apps/sandagent-example/app/api/ai/route.ts
@@ -177,11 +177,11 @@ export async function POST(request: Request) {
 
   // Create sandbox based on provider
   let sandbox;
+  const sandboxName = `sandagent-${template}`;
 
   if (SANDBOX_PROVIDER === "daytona") {
     // For Daytona, use template as sandbox name to enable sandbox reuse
     // Sandboxes with the same name will be reused instead of creating new ones
-    const sandboxName = `sandagent-${template}`;
 
     sandbox = new DaytonaSandbox({
       apiKey: DAYTONA_API_KEY,
@@ -208,6 +208,7 @@ export async function POST(request: Request) {
       apiKey: E2B_API_KEY,
       runnerBundlePath: RUNNER_BUNDLE_PATH,
       templatesPath: path.join(TEMPLATES_PATH, template),
+      name: sandboxName,
     });
   }
 

--- a/apps/sandagent-example/app/api/approval/submit/route.ts
+++ b/apps/sandagent-example/app/api/approval/submit/route.ts
@@ -13,6 +13,7 @@ import { SandockSandbox } from "@sandagent/sandbox-sandock";
  *   toolCallId: string,
  *   questions: Array<{ question: string }>,
  *   answers: Record<string, any>,  // All collected answers
+ *   template?: string,           // Template name for sandbox naming
  *   E2B_API_KEY?: string,        // Client-provided E2B key
  *   SANDOCK_API_KEY?: string,    // Client-provided Sandock key
  *   SANDBOX_PROVIDER?: string    // 'e2b' or 'sandock'
@@ -30,10 +31,14 @@ export async function POST(request: Request) {
     toolCallId,
     questions,
     answers,
+    template = "default",
     E2B_API_KEY,
     SANDOCK_API_KEY,
     SANDBOX_PROVIDER = "e2b",
   } = await request.json();
+
+  // Generate sandbox name to match ai/route.ts
+  const sandboxName = `sandagent-${template}`;
 
   if (!sessionId || !toolCallId || !questions || !answers) {
     return Response.json(
@@ -85,6 +90,7 @@ export async function POST(request: Request) {
         : new E2BSandbox({
             apiKey: E2B_API_KEY,
             runnerBundlePath: RUNNER_BUNDLE_PATH,
+            name: sandboxName,
           });
 
     const handle = await sandbox.attach(sessionId);

--- a/apps/sandagent-example/app/claude-tools/AskUserQuestionUI.tsx
+++ b/apps/sandagent-example/app/claude-tools/AskUserQuestionUI.tsx
@@ -188,6 +188,7 @@ export function AskUserQuestionUI({
         toolCallId: part.toolCallId,
         questions,
         answers: answersMap,
+        template: config.template || "default",
         E2B_API_KEY: config.E2B_API_KEY,
         SANDOCK_API_KEY: config.SANDOCK_API_KEY,
         SANDBOX_PROVIDER: config.SANDBOX_PROVIDER || "e2b",

--- a/apps/sandagent-example/app/page.tsx
+++ b/apps/sandagent-example/app/page.tsx
@@ -209,7 +209,7 @@ export default function Home() {
                 key={message.id}
                 message={message}
                 sessionId={sessionId}
-                config={clientConfig}
+                config={{ ...clientConfig, template: selectedTemplate }}
               />
             ))
           )}

--- a/packages/sandbox-e2b/src/__tests__/e2b-sandbox.test.ts
+++ b/packages/sandbox-e2b/src/__tests__/e2b-sandbox.test.ts
@@ -122,19 +122,20 @@ describe("E2BSandbox Configuration", () => {
     }
   });
 
-  it("should use template and name together for differentiation", () => {
+  it("should use name for sandbox identification (business-defined)", () => {
+    // Name is determined by business layer and can include template info if needed
     const sandbox1 = new E2BSandbox({
-      name: "my-sandbox",
+      name: "project-base-user123",
       template: "base",
     });
     const sandbox2 = new E2BSandbox({
-      name: "my-sandbox",
+      name: "project-python-user123",
       template: "python",
     });
 
     expect(sandbox1).toBeInstanceOf(E2BSandbox);
     expect(sandbox2).toBeInstanceOf(E2BSandbox);
-    // These would create/connect to different sandboxes due to different templates
+    // Different names means different sandboxes
   });
 });
 
@@ -198,16 +199,16 @@ describe("E2BSandbox Metadata Usage", () => {
   it("should document metadata fields used for querying", () => {
     // The sandbox uses these metadata fields:
     // - sandagentId: The session/agent ID
-    // - sandagentName: The sandbox name for reuse (if provided)
-    // - template: The template name for differentiation
+    // - sandagentName: The sandbox name for reuse (if provided, business-defined)
 
     const sandbox = new E2BSandbox({
-      name: "test-sandbox",
+      name: "my-project-python-user123", // Name includes all info needed for identification
       template: "python",
     });
 
     expect(sandbox).toBeInstanceOf(E2BSandbox);
     // When creating, metadata will include:
-    // { sandagentId: "...", sandagentName: "test-sandbox", template: "python" }
+    // { sandagentId: "...", sandagentName: "my-project-python-user123" }
+    // The name is used for sandbox reuse, determined by business layer
   });
 });

--- a/packages/sandbox-e2b/src/__tests__/e2b-sandbox.test.ts
+++ b/packages/sandbox-e2b/src/__tests__/e2b-sandbox.test.ts
@@ -23,7 +23,7 @@ describe("E2BSandbox", () => {
       const sandbox = new E2BSandbox({
         apiKey: "test-api-key",
         template: "python",
-        timeout: 120000,
+        timeout: 7200, // 2 hours in seconds
       });
       expect(sandbox).toBeInstanceOf(E2BSandbox);
     });
@@ -32,6 +32,15 @@ describe("E2BSandbox", () => {
       process.env.E2B_API_KEY = "env-api-key";
 
       const sandbox = new E2BSandbox();
+      expect(sandbox).toBeInstanceOf(E2BSandbox);
+    });
+
+    it("should accept name option for sandbox reuse", () => {
+      const sandbox = new E2BSandbox({
+        apiKey: "test-api-key",
+        name: "my-sandbox",
+        template: "base",
+      });
       expect(sandbox).toBeInstanceOf(E2BSandbox);
     });
   });
@@ -96,230 +105,109 @@ describe("E2BSandbox Configuration", () => {
     }
   });
 
-  it("should support custom timeouts", () => {
-    const timeouts = [30000, 60000, 120000, 300000];
+  it("should support custom timeouts in seconds", () => {
+    // E2B timeout is now in seconds (for API clarity)
+    const timeouts = [1800, 3600, 7200, 86400]; // 30min, 1hr, 2hr, 24hr
     for (const timeout of timeouts) {
       const sandbox = new E2BSandbox({ timeout });
       expect(sandbox).toBeInstanceOf(E2BSandbox);
     }
   });
-});
 
-describe("E2BSandbox Instance Caching (Persistence)", () => {
-  // Access private static members for testing
-  const getInstances = () =>
-    (E2BSandbox as unknown as { instances: Map<string, unknown> }).instances;
-  const getInitializedInstances = () =>
-    (E2BSandbox as unknown as { initializedInstances: Set<string> })
-      .initializedInstances;
-
-  beforeEach(() => {
-    // Clear cache before each test
-    getInstances().clear();
-    getInitializedInstances().clear();
+  it("should support name for sandbox reuse", () => {
+    const names = ["sandbox-1", "my-project-sandbox", "user-123-sandbox"];
+    for (const name of names) {
+      const sandbox = new E2BSandbox({ name });
+      expect(sandbox).toBeInstanceOf(E2BSandbox);
+    }
   });
 
-  describe("cache structure", () => {
-    it("should have a static instances Map", () => {
-      const instances = getInstances();
-      expect(instances).toBeInstanceOf(Map);
+  it("should use template and name together for differentiation", () => {
+    const sandbox1 = new E2BSandbox({
+      name: "my-sandbox",
+      template: "base",
+    });
+    const sandbox2 = new E2BSandbox({
+      name: "my-sandbox",
+      template: "python",
     });
 
-    it("should have a static initializedInstances Set", () => {
-      const initialized = getInitializedInstances();
-      expect(initialized).toBeInstanceOf(Set);
-    });
-
-    it("should share cache across multiple E2BSandbox instances", () => {
-      const sandbox1 = new E2BSandbox({ apiKey: "key1" });
-      const sandbox2 = new E2BSandbox({ apiKey: "key2" });
-
-      // Both should reference the same static cache
-      const instances1 = getInstances();
-      const instances2 = getInstances();
-      expect(instances1).toBe(instances2);
-    });
-  });
-
-  describe("cache constants", () => {
-    it("should have MAX_CACHE_SIZE of 50", () => {
-      const maxSize = (E2BSandbox as unknown as { MAX_CACHE_SIZE: number })
-        .MAX_CACHE_SIZE;
-      expect(maxSize).toBe(50);
-    });
-
-    it("should have INSTANCE_TTL_MS of 60 minutes", () => {
-      const ttl = (E2BSandbox as unknown as { INSTANCE_TTL_MS: number })
-        .INSTANCE_TTL_MS;
-      expect(ttl).toBe(60 * 60 * 1000);
-    });
-  });
-
-  describe("LRU eviction", () => {
-    it("evictOldestIfNeeded should be a static method", () => {
-      const evictMethod = (
-        E2BSandbox as unknown as { evictOldestIfNeeded: () => void }
-      ).evictOldestIfNeeded;
-      expect(typeof evictMethod).toBe("function");
-    });
-  });
-
-  describe("cleanup mechanism", () => {
-    it("cleanupExpiredInstances should be a static method", () => {
-      const cleanupMethod = (
-        E2BSandbox as unknown as { cleanupExpiredInstances: () => void }
-      ).cleanupExpiredInstances;
-      expect(typeof cleanupMethod).toBe("function");
-    });
+    expect(sandbox1).toBeInstanceOf(E2BSandbox);
+    expect(sandbox2).toBeInstanceOf(E2BSandbox);
+    // These would create/connect to different sandboxes due to different templates
   });
 });
 
-describe("E2BSandbox Cache Behavior (Mock)", () => {
-  // Mock E2B Sandbox for testing cache behavior
-  const mockSandboxInstance = {
-    sandboxId: "mock-sandbox-id",
-    commands: {
-      run: vi.fn().mockResolvedValue({ exitCode: 0, stdout: "", stderr: "" }),
-    },
-    files: {
-      write: vi.fn().mockResolvedValue(undefined),
-      makeDir: vi.fn().mockResolvedValue(undefined),
-    },
-    kill: vi.fn().mockResolvedValue(undefined),
-  };
+describe("E2BSandbox Name-based Reuse", () => {
+  it("should support all options together", () => {
+    const sandbox = new E2BSandbox({
+      apiKey: "test-key",
+      template: "nodejs",
+      timeout: 3600,
+      name: "my-project",
+      runnerBundlePath: "/path/to/runner.js",
+      templatesPath: "/path/to/templates",
+    });
 
-  const getInstances = () =>
-    (
-      E2BSandbox as unknown as {
-        instances: Map<string, { instance: unknown; lastAccessTime: number }>;
-      }
-    ).instances;
-  const getInitializedInstances = () =>
-    (E2BSandbox as unknown as { initializedInstances: Set<string> })
-      .initializedInstances;
-
-  beforeEach(() => {
-    getInstances().clear();
-    getInitializedInstances().clear();
-    vi.clearAllMocks();
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
   });
 
-  it("should update lastAccessTime when reusing cached instance", () => {
-    const instances = getInstances();
-    const testId = "test-session-123";
-    const oldTime = Date.now() - 10000;
-
-    // Manually add a cached instance
-    instances.set(testId, {
-      instance: mockSandboxInstance,
-      lastAccessTime: oldTime,
+  it("should create sandbox without name (no reuse)", () => {
+    // When no name is provided, a new sandbox is always created
+    const sandbox = new E2BSandbox({
+      apiKey: "test-key",
+      template: "base",
     });
 
-    // Verify initial state
-    expect(instances.get(testId)?.lastAccessTime).toBe(oldTime);
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
   });
 
-  it("should track initialized instances separately", () => {
-    const instances = getInstances();
-    const initialized = getInitializedInstances();
-    const testId = "test-session-456";
-
-    // Add to cache
-    instances.set(testId, {
-      instance: mockSandboxInstance,
-      lastAccessTime: Date.now(),
+  it("should support name with special characters", () => {
+    const sandbox = new E2BSandbox({
+      name: "project-user_123-dev",
     });
 
-    // Initially not in initialized set
-    expect(initialized.has(testId)).toBe(false);
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
+  });
+});
 
-    // Mark as initialized
-    initialized.add(testId);
-    expect(initialized.has(testId)).toBe(true);
+describe("E2BSandbox Timeout Configuration", () => {
+  it("should default to 1 hour (3600 seconds)", () => {
+    // The default timeout aligns with E2B hobby tier limits
+    const sandbox = new E2BSandbox();
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
   });
 
-  it("should find oldest instance for LRU eviction", () => {
-    const instances = getInstances();
-    const now = Date.now();
-
-    // Add multiple instances with different access times
-    instances.set("session-1", {
-      instance: { ...mockSandboxInstance, sandboxId: "1" },
-      lastAccessTime: now - 3000, // oldest
+  it("should accept timeout for pro tier (up to 24 hours)", () => {
+    // Pro tier supports up to 24 hours continuous runtime
+    const sandbox = new E2BSandbox({
+      timeout: 86400, // 24 hours in seconds
     });
-    instances.set("session-2", {
-      instance: { ...mockSandboxInstance, sandboxId: "2" },
-      lastAccessTime: now - 1000,
-    });
-    instances.set("session-3", {
-      instance: { ...mockSandboxInstance, sandboxId: "3" },
-      lastAccessTime: now - 2000,
-    });
-
-    // Find oldest manually (simulating evictOldestIfNeeded logic)
-    let oldestId: string | null = null;
-    let oldestTime = Number.POSITIVE_INFINITY;
-
-    for (const [id, cached] of instances) {
-      if (cached.lastAccessTime < oldestTime) {
-        oldestTime = cached.lastAccessTime;
-        oldestId = id;
-      }
-    }
-
-    expect(oldestId).toBe("session-1");
-    expect(oldestTime).toBe(now - 3000);
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
   });
 
-  it("should identify expired instances", () => {
-    const instances = getInstances();
-    const now = Date.now();
-    const TTL = 30 * 60 * 1000; // 30 minutes
-
-    // Add instances: one fresh, one expired
-    instances.set("fresh-session", {
-      instance: mockSandboxInstance,
-      lastAccessTime: now - 1000, // 1 second ago
+  it("should handle short timeouts", () => {
+    const sandbox = new E2BSandbox({
+      timeout: 300, // 5 minutes
     });
-    instances.set("expired-session", {
-      instance: mockSandboxInstance,
-      lastAccessTime: now - TTL - 1000, // 30 minutes + 1 second ago
-    });
-
-    // Find expired instances (simulating cleanupExpiredInstances logic)
-    const expiredIds: string[] = [];
-    for (const [id, cached] of instances) {
-      if (now - cached.lastAccessTime > TTL) {
-        expiredIds.push(id);
-      }
-    }
-
-    expect(expiredIds).toContain("expired-session");
-    expect(expiredIds).not.toContain("fresh-session");
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
   });
+});
 
-  it("should remove instance from both caches on destroy", () => {
-    const instances = getInstances();
-    const initialized = getInitializedInstances();
-    const testId = "destroy-test-session";
+describe("E2BSandbox Metadata Usage", () => {
+  it("should document metadata fields used for querying", () => {
+    // The sandbox uses these metadata fields:
+    // - sandagentId: The session/agent ID
+    // - sandagentName: The sandbox name for reuse (if provided)
+    // - template: The template name for differentiation
 
-    // Setup: add to both caches
-    instances.set(testId, {
-      instance: mockSandboxInstance,
-      lastAccessTime: Date.now(),
+    const sandbox = new E2BSandbox({
+      name: "test-sandbox",
+      template: "python",
     });
-    initialized.add(testId);
 
-    // Verify setup
-    expect(instances.has(testId)).toBe(true);
-    expect(initialized.has(testId)).toBe(true);
-
-    // Simulate destroy callback (onDestroy in E2BHandle)
-    instances.delete(testId);
-    initialized.delete(testId);
-
-    // Verify cleanup
-    expect(instances.has(testId)).toBe(false);
-    expect(initialized.has(testId)).toBe(false);
+    expect(sandbox).toBeInstanceOf(E2BSandbox);
+    // When creating, metadata will include:
+    // { sandagentId: "...", sandagentName: "test-sandbox", template: "python" }
   });
 });

--- a/packages/sandbox-e2b/src/e2b-sandbox.ts
+++ b/packages/sandbox-e2b/src/e2b-sandbox.ts
@@ -80,10 +80,13 @@ export class E2BSandbox implements SandboxAdapter {
   }
 
   /**
-   * Find an existing sandbox by name (via metadata query)
-   * Returns the sandbox ID if found, null otherwise
+   * Find an existing sandbox by name and connect to it.
+   * Sandbox.connect() will automatically resume if paused.
+   * See: https://e2b.dev/docs/sandbox/persistence
+   *
+   * @returns Connected sandbox instance if found, null otherwise
    */
-  private async findSandboxByName(name: string): Promise<string | null> {
+  private async findSandboxByName(name: string): Promise<Sandbox | null> {
     try {
       // Use Sandbox.list() with metadata query
       const paginator = Sandbox.list({
@@ -98,21 +101,28 @@ export class E2BSandbox implements SandboxAdapter {
       // Get the first page of results
       const sandboxes: SandboxInfo[] = await paginator.nextItems();
 
-      if (sandboxes.length > 0) {
-        // Return the first matching sandbox (prefer running over paused)
-        const runningSandbox = sandboxes.find((s) => s.state === "running");
-        const sandbox = runningSandbox ?? sandboxes[0];
-
-        console.log(
-          `[E2B] Found existing sandbox by name: ${name}, id: ${sandbox.sandboxId}, state: ${sandbox.state}`,
-        );
-        return sandbox.sandboxId;
+      if (sandboxes.length === 0) {
+        console.log(`[E2B] No existing sandbox found for name: ${name}`);
+        return null;
       }
 
-      console.log(`[E2B] No existing sandbox found for name: ${name}`);
-      return null;
+      const sandboxInfo = sandboxes[0];
+      console.log(
+        `[E2B] Found existing sandbox by name: ${name}, id: ${sandboxInfo.sandboxId}, state: ${sandboxInfo.state}`,
+      );
+
+      // Connect to sandbox (will auto-resume if paused)
+      const sandbox = await Sandbox.connect(sandboxInfo.sandboxId, {
+        apiKey: this.apiKey,
+        timeoutMs: this.timeout,
+      });
+
+      console.log(
+        `[E2B] Successfully connected to sandbox: ${sandboxInfo.sandboxId}`,
+      );
+      return sandbox;
     } catch (error) {
-      console.warn(`[E2B] Failed to list sandboxes:`, error);
+      console.warn(`[E2B] Failed to find/connect sandbox by name:`, error);
       return null;
     }
   }
@@ -127,37 +137,16 @@ export class E2BSandbox implements SandboxAdapter {
     let instance: Sandbox;
     let needsInit = false;
 
-    // If name is provided, try to find existing sandbox by name
+    // If name is provided, try to find and connect to existing sandbox
     if (this.name) {
       console.log(`[E2B] Looking for existing sandbox with name: ${this.name}`);
 
-      const existingSandboxId = await this.findSandboxByName(this.name);
+      const existingSandbox = await this.findSandboxByName(this.name);
 
-      if (existingSandboxId) {
-        // Connect to existing sandbox (will auto-resume if paused)
-        try {
-          console.log(
-            `[E2B] Connecting to existing sandbox: ${existingSandboxId}`,
-          );
-          instance = await Sandbox.connect(existingSandboxId, {
-            apiKey: this.apiKey,
-            timeoutMs: this.timeout,
-          });
-
-          console.log(
-            `[E2B] Successfully connected to sandbox: ${existingSandboxId}`,
-          );
-        } catch (error) {
-          console.warn(
-            `[E2B] Failed to connect to sandbox ${existingSandboxId}:`,
-            error,
-          );
-          // If connection fails, create a new sandbox
-          instance = await this.createNewSandbox(id);
-          needsInit = true;
-        }
+      if (existingSandbox) {
+        instance = existingSandbox;
       } else {
-        // No existing sandbox found, create new one
+        // No existing sandbox found or connection failed, create new one
         instance = await this.createNewSandbox(id);
         needsInit = true;
       }

--- a/packages/sandbox-e2b/src/e2b-sandbox.ts
+++ b/packages/sandbox-e2b/src/e2b-sandbox.ts
@@ -35,8 +35,8 @@ export interface E2BSandboxOptions {
    * If not found, creates a new sandbox with this name stored in metadata.
    * If not provided, a new sandbox is always created.
    *
-   * The name is stored in metadata as "sandagentName" for querying.
-   * Template is also stored in metadata for differentiation.
+   * The name should be determined by the business layer and can include
+   * template/user/project information as needed for differentiation.
    */
   name?: string;
 }
@@ -83,10 +83,7 @@ export class E2BSandbox implements SandboxAdapter {
    * Find an existing sandbox by name (via metadata query)
    * Returns the sandbox ID if found, null otherwise
    */
-  private async findSandboxByName(
-    name: string,
-    template: string,
-  ): Promise<string | null> {
+  private async findSandboxByName(name: string): Promise<string | null> {
     try {
       // Use Sandbox.list() with metadata query
       const paginator = Sandbox.list({
@@ -94,7 +91,6 @@ export class E2BSandbox implements SandboxAdapter {
         query: {
           metadata: {
             sandagentName: name,
-            template: template,
           },
         },
       });
@@ -135,10 +131,7 @@ export class E2BSandbox implements SandboxAdapter {
     if (this.name) {
       console.log(`[E2B] Looking for existing sandbox with name: ${this.name}`);
 
-      const existingSandboxId = await this.findSandboxByName(
-        this.name,
-        this.template,
-      );
+      const existingSandboxId = await this.findSandboxByName(this.name);
 
       if (existingSandboxId) {
         // Connect to existing sandbox (will auto-resume if paused)
@@ -191,10 +184,9 @@ export class E2BSandbox implements SandboxAdapter {
   private async createNewSandbox(id: string): Promise<Sandbox> {
     const metadata: Record<string, string> = {
       sandagentId: id,
-      template: this.template,
     };
 
-    // Add name to metadata if provided
+    // Add name to metadata if provided (for sandbox reuse)
     if (this.name) {
       metadata.sandagentName = this.name;
     }

--- a/packages/sandbox-e2b/src/e2b-sandbox.ts
+++ b/packages/sandbox-e2b/src/e2b-sandbox.ts
@@ -5,7 +5,7 @@ import type {
   SandboxAdapter,
   SandboxHandle,
 } from "@sandagent/core";
-import { Sandbox } from "e2b";
+import { Sandbox, type SandboxInfo } from "e2b";
 
 /**
  * Options for creating an E2BSandbox instance
@@ -39,67 +39,6 @@ export interface E2BSandboxOptions {
    * Template is also stored in metadata for differentiation.
    */
   name?: string;
-}
-
-/**
- * Sandbox info returned from E2B list API
- */
-interface SandboxInfo {
-  sandboxId: string;
-  templateId: string;
-  clientId: string;
-  startedAt: Date;
-  metadata?: Record<string, string>;
-}
-
-/**
- * Type definitions for E2B SDK (e2b package)
- */
-interface E2BSandboxInstance {
-  sandboxId: string;
-  commands: {
-    run(
-      cmd: string,
-      opts?: {
-        cwd?: string;
-        envs?: Record<string, string>;
-        onStdout?: (data: string) => void;
-        onStderr?: (data: string) => void;
-        timeoutMs?: number;
-        requestTimeoutMs?: number;
-      },
-    ): Promise<{
-      exitCode: number;
-      stdout: string;
-      stderr: string;
-    }>;
-  };
-  files: {
-    write(path: string, content: string | ArrayBuffer): Promise<void>;
-    makeDir(path: string): Promise<void>;
-    read(path: string): Promise<string>;
-    list(
-      path: string,
-    ): Promise<Array<{ name: string; type: "file" | "dir"; path: string }>>;
-  };
-  kill(): Promise<void>;
-  setTimeout(timeoutMs: number): Promise<void>;
-}
-
-interface E2BSandboxStatic {
-  create(
-    template: string,
-    opts?: {
-      apiKey?: string;
-      timeoutMs?: number;
-      metadata?: Record<string, string>;
-    },
-  ): Promise<E2BSandboxInstance>;
-  connect(
-    sandboxId: string,
-    opts?: { apiKey?: string },
-  ): Promise<E2BSandboxInstance>;
-  list(opts?: { apiKey?: string }): Promise<SandboxInfo[]>;
 }
 
 /**
@@ -149,22 +88,29 @@ export class E2BSandbox implements SandboxAdapter {
     template: string,
   ): Promise<string | null> {
     try {
-      // List all running sandboxes
-      const sandboxes = (await (Sandbox as unknown as E2BSandboxStatic).list({
+      // Use Sandbox.list() with metadata query
+      const paginator = Sandbox.list({
         apiKey: this.apiKey,
-      })) as SandboxInfo[];
+        query: {
+          metadata: {
+            sandagentName: name,
+            template: template,
+          },
+        },
+      });
 
-      // Find sandbox with matching name and template in metadata
-      for (const sandbox of sandboxes) {
-        if (
-          sandbox.metadata?.sandagentName === name &&
-          sandbox.metadata?.template === template
-        ) {
-          console.log(
-            `[E2B] Found existing sandbox by name: ${name}, id: ${sandbox.sandboxId}`,
-          );
-          return sandbox.sandboxId;
-        }
+      // Get the first page of results
+      const sandboxes: SandboxInfo[] = await paginator.nextItems();
+
+      if (sandboxes.length > 0) {
+        // Return the first matching sandbox (prefer running over paused)
+        const runningSandbox = sandboxes.find((s) => s.state === "running");
+        const sandbox = runningSandbox ?? sandboxes[0];
+
+        console.log(
+          `[E2B] Found existing sandbox by name: ${name}, id: ${sandbox.sandboxId}, state: ${sandbox.state}`,
+        );
+        return sandbox.sandboxId;
       }
 
       console.log(`[E2B] No existing sandbox found for name: ${name}`);
@@ -182,7 +128,7 @@ export class E2BSandbox implements SandboxAdapter {
       );
     }
 
-    let instance: E2BSandboxInstance;
+    let instance: Sandbox;
     let needsInit = false;
 
     // If name is provided, try to find existing sandbox by name
@@ -195,18 +141,16 @@ export class E2BSandbox implements SandboxAdapter {
       );
 
       if (existingSandboxId) {
-        // Connect to existing sandbox
+        // Connect to existing sandbox (will auto-resume if paused)
         try {
           console.log(
             `[E2B] Connecting to existing sandbox: ${existingSandboxId}`,
           );
-          instance = (await (Sandbox as unknown as E2BSandboxStatic).connect(
-            existingSandboxId,
-            { apiKey: this.apiKey },
-          )) as E2BSandboxInstance;
+          instance = await Sandbox.connect(existingSandboxId, {
+            apiKey: this.apiKey,
+            timeoutMs: this.timeout,
+          });
 
-          // Extend timeout to keep sandbox alive
-          await instance.setTimeout(this.timeout);
           console.log(
             `[E2B] Successfully connected to sandbox: ${existingSandboxId}`,
           );
@@ -244,7 +188,7 @@ export class E2BSandbox implements SandboxAdapter {
   /**
    * Create a new sandbox with metadata for later querying
    */
-  private async createNewSandbox(id: string): Promise<E2BSandboxInstance> {
+  private async createNewSandbox(id: string): Promise<Sandbox> {
     const metadata: Record<string, string> = {
       sandagentId: id,
       template: this.template,
@@ -259,14 +203,11 @@ export class E2BSandbox implements SandboxAdapter {
       `[E2B] Creating new sandbox with template "${this.template}"${this.name ? `, name "${this.name}"` : ""}, timeout=${this.timeout / 1000}s`,
     );
 
-    const instance = (await (Sandbox as unknown as E2BSandboxStatic).create(
-      this.template,
-      {
-        apiKey: this.apiKey,
-        timeoutMs: this.timeout,
-        metadata,
-      },
-    )) as E2BSandboxInstance;
+    const instance = await Sandbox.create(this.template, {
+      apiKey: this.apiKey,
+      timeoutMs: this.timeout,
+      metadata,
+    });
 
     console.log(`[E2B] Sandbox created: ${instance.sandboxId}`);
     return instance;
@@ -356,9 +297,9 @@ export class E2BSandbox implements SandboxAdapter {
  * Handle for an active E2B sandbox
  */
 class E2BHandle implements SandboxHandle {
-  private readonly instance: E2BSandboxInstance;
+  private readonly instance: Sandbox;
 
-  constructor(instance: E2BSandboxInstance) {
+  constructor(instance: Sandbox) {
     this.instance = instance;
   }
 
@@ -487,7 +428,6 @@ class E2BHandle implements SandboxHandle {
           cwd: opts?.cwd,
           envs: envWithNodePath,
           timeoutMs: 0, // 0 = no timeout for LLM operations
-          requestTimeoutMs: 0, // 0 = no request timeout
           onStdout: (data: string) => {
             const chunk = new TextEncoder().encode(data);
             chunks.push(chunk);

--- a/packages/sandbox-e2b/src/e2b-sandbox.ts
+++ b/packages/sandbox-e2b/src/e2b-sandbox.ts
@@ -15,12 +15,41 @@ export interface E2BSandboxOptions {
   apiKey?: string;
   /** E2B template to use (default: "base") */
   template?: string;
-  /** Timeout for sandbox operations in milliseconds (default: 0 = no timeout) */
+  /**
+   * Timeout for sandbox in seconds.
+   * This is the maximum time the sandbox can run continuously.
+   * - Hobby tier: max 1 hour (3600s)
+   * - Pro tier: max 24 hours (86400s)
+   * Default: 3600 (1 hour)
+   *
+   * Note: Sandbox can be paused for up to 30 days with E2B's persistence feature.
+   */
   timeout?: number;
   /** Path to runner bundle.js (required for running sandagent) */
   runnerBundlePath?: string;
   /** Path to template directory to upload */
   templatesPath?: string;
+  /**
+   * Sandbox name for reuse (similar to Daytona).
+   * If provided, will try to find an existing sandbox by name (via metadata) first.
+   * If not found, creates a new sandbox with this name stored in metadata.
+   * If not provided, a new sandbox is always created.
+   *
+   * The name is stored in metadata as "sandagentName" for querying.
+   * Template is also stored in metadata for differentiation.
+   */
+  name?: string;
+}
+
+/**
+ * Sandbox info returned from E2B list API
+ */
+interface SandboxInfo {
+  sandboxId: string;
+  templateId: string;
+  clientId: string;
+  startedAt: Date;
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -54,31 +83,41 @@ interface E2BSandboxInstance {
     ): Promise<Array<{ name: string; type: "file" | "dir"; path: string }>>;
   };
   kill(): Promise<void>;
+  setTimeout(timeoutMs: number): Promise<void>;
 }
 
 interface E2BSandboxStatic {
-  create(opts?: {
-    apiKey?: string;
-    template?: string;
-    timeoutMs?: number;
-    metadata?: Record<string, string>;
-  }): Promise<E2BSandboxInstance>;
+  create(
+    template: string,
+    opts?: {
+      apiKey?: string;
+      timeoutMs?: number;
+      metadata?: Record<string, string>;
+    },
+  ): Promise<E2BSandboxInstance>;
   connect(
     sandboxId: string,
     opts?: { apiKey?: string },
   ): Promise<E2BSandboxInstance>;
-}
-
-/**
- * Cached sandbox instance with metadata
- */
-interface CachedInstance {
-  instance: E2BSandboxInstance;
-  lastAccessTime: number;
+  list(opts?: { apiKey?: string }): Promise<SandboxInfo[]>;
 }
 
 /**
  * E2B-based sandbox implementation.
+ *
+ * This adapter supports sandbox reuse based on sandbox name (similar to Daytona).
+ * When a name is provided, it will attempt to find an existing sandbox
+ * by that name (stored in metadata) first. If not found, creates a new sandbox
+ * with that name in metadata.
+ *
+ * If no name is provided, a new sandbox is always created.
+ *
+ * Note on E2B limitations (as of beta):
+ * - Sandbox can be paused for up to 30 days
+ * - Continuous runtime depends on tier:
+ *   - Hobby: max 1 hour
+ *   - Pro: max 24 hours
+ * - See: https://e2b.dev/docs/sandbox/persistence#limitations-while-in-beta
  */
 export class E2BSandbox implements SandboxAdapter {
   private readonly apiKey?: string;
@@ -86,100 +125,53 @@ export class E2BSandbox implements SandboxAdapter {
   private readonly timeout: number;
   private readonly runnerBundlePath?: string;
   private readonly templatesPath?: string;
+  private readonly name?: string;
 
-  /** Global cache for sandbox instances (shared across all E2BSandbox instances) */
-  private static readonly instances: Map<string, CachedInstance> = new Map();
-  private static readonly initializedInstances: Set<string> = new Set();
-
-  /** Maximum number of cached instances */
-  private static readonly MAX_CACHE_SIZE = 50;
-  /** Instance expiration time in milliseconds (default: 60 minutes) */
-  private static readonly INSTANCE_TTL_MS = 60 * 60 * 1000;
-  /** Cleanup interval timer (lazy initialized on first cache write) */
-  private static cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  /** Default timeout in seconds (1 hour for hobby tier) */
+  private static readonly DEFAULT_TIMEOUT_SEC = 3600;
 
   constructor(options: E2BSandboxOptions = {}) {
     this.apiKey = options.apiKey ?? process.env.E2B_API_KEY;
     this.template = options.template ?? "base";
-    this.timeout = options.timeout ?? E2BSandbox.INSTANCE_TTL_MS;
+    // Default to 1 hour (hobby tier limit), convert to milliseconds for E2B SDK
+    this.timeout = (options.timeout ?? E2BSandbox.DEFAULT_TIMEOUT_SEC) * 1000;
     this.runnerBundlePath = options.runnerBundlePath;
     this.templatesPath = options.templatesPath;
+    this.name = options.name;
   }
 
   /**
-   * Ensure cleanup timer is running (lazy initialization)
+   * Find an existing sandbox by name (via metadata query)
+   * Returns the sandbox ID if found, null otherwise
    */
-  private static ensureCleanupTimer(): void {
-    if (E2BSandbox.cleanupTimer) return;
+  private async findSandboxByName(
+    name: string,
+    template: string,
+  ): Promise<string | null> {
+    try {
+      // List all running sandboxes
+      const sandboxes = (await (Sandbox as unknown as E2BSandboxStatic).list({
+        apiKey: this.apiKey,
+      })) as SandboxInfo[];
 
-    E2BSandbox.cleanupTimer = setInterval(
-      () => {
-        E2BSandbox.cleanupExpiredInstances();
-      },
-      5 * 60 * 1000,
-    ); // Run every 5 minutes
-
-    // Don't prevent process exit
-    if (E2BSandbox.cleanupTimer.unref) {
-      E2BSandbox.cleanupTimer.unref();
-    }
-  }
-
-  /**
-   * Remove expired instances from cache
-   */
-  private static cleanupExpiredInstances(): void {
-    const now = Date.now();
-    const expiredIds: string[] = [];
-
-    for (const [id, cached] of E2BSandbox.instances) {
-      if (now - cached.lastAccessTime > E2BSandbox.INSTANCE_TTL_MS) {
-        expiredIds.push(id);
+      // Find sandbox with matching name and template in metadata
+      for (const sandbox of sandboxes) {
+        if (
+          sandbox.metadata?.sandagentName === name &&
+          sandbox.metadata?.template === template
+        ) {
+          console.log(
+            `[E2B] Found existing sandbox by name: ${name}, id: ${sandbox.sandboxId}`,
+          );
+          return sandbox.sandboxId;
+        }
       }
-    }
 
-    for (const id of expiredIds) {
-      const cached = E2BSandbox.instances.get(id);
-      if (cached) {
-        console.log(`[E2B] Removing expired sandbox instance: ${id}`);
-        cached.instance.kill().catch((e) => {
-          console.error(`[E2B] Error killing expired sandbox ${id}:`, e);
-        });
-        E2BSandbox.instances.delete(id);
-        E2BSandbox.initializedInstances.delete(id);
-      }
-    }
-  }
-
-  /**
-   * Evict oldest instance if cache is full
-   */
-  private static evictOldestIfNeeded(): void {
-    // Lazy start cleanup timer on first cache write
-    E2BSandbox.ensureCleanupTimer();
-
-    if (E2BSandbox.instances.size < E2BSandbox.MAX_CACHE_SIZE) return;
-
-    let oldestId: string | null = null;
-    let oldestTime = Number.POSITIVE_INFINITY;
-
-    for (const [id, cached] of E2BSandbox.instances) {
-      if (cached.lastAccessTime < oldestTime) {
-        oldestTime = cached.lastAccessTime;
-        oldestId = id;
-      }
-    }
-
-    if (oldestId) {
-      const cached = E2BSandbox.instances.get(oldestId);
-      if (cached) {
-        console.log(`[E2B] Evicting oldest sandbox instance: ${oldestId}`);
-        cached.instance.kill().catch((e) => {
-          console.error(`[E2B] Error killing evicted sandbox ${oldestId}:`, e);
-        });
-        E2BSandbox.instances.delete(oldestId);
-        E2BSandbox.initializedInstances.delete(oldestId);
-      }
+      console.log(`[E2B] No existing sandbox found for name: ${name}`);
+      return null;
+    } catch (error) {
+      console.warn(`[E2B] Failed to list sandboxes:`, error);
+      return null;
     }
   }
 
@@ -190,46 +182,94 @@ export class E2BSandbox implements SandboxAdapter {
       );
     }
 
-    const cached = E2BSandbox.instances.get(id);
-    let instance = cached?.instance;
-
+    let instance: E2BSandboxInstance;
     let needsInit = false;
 
-    if (instance) {
-      // Update last access time
-      E2BSandbox.instances.set(id, {
-        instance,
-        lastAccessTime: Date.now(),
-      });
-      console.log(`[E2B] Reusing cached sandbox instance: ${id}`);
-    } else {
-      // Evict oldest if cache is full before adding new instance
-      E2BSandbox.evictOldestIfNeeded();
+    // If name is provided, try to find existing sandbox by name
+    if (this.name) {
+      console.log(`[E2B] Looking for existing sandbox with name: ${this.name}`);
 
-      instance = (await Sandbox.create(this.template, {
-        apiKey: this.apiKey,
-        timeoutMs: this.timeout,
-        metadata: { sandagentId: id },
-      })) as unknown as E2BSandboxInstance;
-      E2BSandbox.instances.set(id, {
-        instance,
-        lastAccessTime: Date.now(),
-      });
+      const existingSandboxId = await this.findSandboxByName(
+        this.name,
+        this.template,
+      );
+
+      if (existingSandboxId) {
+        // Connect to existing sandbox
+        try {
+          console.log(
+            `[E2B] Connecting to existing sandbox: ${existingSandboxId}`,
+          );
+          instance = (await (Sandbox as unknown as E2BSandboxStatic).connect(
+            existingSandboxId,
+            { apiKey: this.apiKey },
+          )) as E2BSandboxInstance;
+
+          // Extend timeout to keep sandbox alive
+          await instance.setTimeout(this.timeout);
+          console.log(
+            `[E2B] Successfully connected to sandbox: ${existingSandboxId}`,
+          );
+        } catch (error) {
+          console.warn(
+            `[E2B] Failed to connect to sandbox ${existingSandboxId}:`,
+            error,
+          );
+          // If connection fails, create a new sandbox
+          instance = await this.createNewSandbox(id);
+          needsInit = true;
+        }
+      } else {
+        // No existing sandbox found, create new one
+        instance = await this.createNewSandbox(id);
+        needsInit = true;
+      }
+    } else {
+      // No name provided - always create new sandbox
+      console.log(`[E2B] No name provided, creating new sandbox`);
+      instance = await this.createNewSandbox(id);
       needsInit = true;
     }
 
-    const handle = new E2BHandle(instance, () => {
-      E2BSandbox.instances.delete(id);
-      E2BSandbox.initializedInstances.delete(id);
-    });
+    const handle = new E2BHandle(instance);
 
-    // Upload runner and templates on first attach
-    if (needsInit && !E2BSandbox.initializedInstances.has(id)) {
+    // Initialize sandbox if it's new (upload files, install dependencies)
+    if (needsInit) {
       await this.initializeSandbox(handle, id);
-      E2BSandbox.initializedInstances.add(id);
     }
 
     return handle;
+  }
+
+  /**
+   * Create a new sandbox with metadata for later querying
+   */
+  private async createNewSandbox(id: string): Promise<E2BSandboxInstance> {
+    const metadata: Record<string, string> = {
+      sandagentId: id,
+      template: this.template,
+    };
+
+    // Add name to metadata if provided
+    if (this.name) {
+      metadata.sandagentName = this.name;
+    }
+
+    console.log(
+      `[E2B] Creating new sandbox with template "${this.template}"${this.name ? `, name "${this.name}"` : ""}, timeout=${this.timeout / 1000}s`,
+    );
+
+    const instance = (await (Sandbox as unknown as E2BSandboxStatic).create(
+      this.template,
+      {
+        apiKey: this.apiKey,
+        timeoutMs: this.timeout,
+        metadata,
+      },
+    )) as E2BSandboxInstance;
+
+    console.log(`[E2B] Sandbox created: ${instance.sandboxId}`);
+    return instance;
   }
 
   private async initializeSandbox(
@@ -317,11 +357,16 @@ export class E2BSandbox implements SandboxAdapter {
  */
 class E2BHandle implements SandboxHandle {
   private readonly instance: E2BSandboxInstance;
-  private readonly onDestroy: () => void;
 
-  constructor(instance: E2BSandboxInstance, onDestroy: () => void) {
+  constructor(instance: E2BSandboxInstance) {
     this.instance = instance;
-    this.onDestroy = onDestroy;
+  }
+
+  /**
+   * Get the sandbox ID (useful for external tracking)
+   */
+  getSandboxId(): string {
+    return this.instance.sandboxId;
   }
 
   /**
@@ -547,7 +592,11 @@ class E2BHandle implements SandboxHandle {
   }
 
   async destroy(): Promise<void> {
-    await this.instance.kill();
-    this.onDestroy();
+    // Note: We don't kill the sandbox here to allow reuse
+    // The sandbox will auto-terminate based on the configured timeout
+    // or can be paused for up to 30 days with E2B's persistence feature
+    console.log(
+      `[E2B] Sandbox ${this.instance.sandboxId} handle destroyed (sandbox continues running for reuse)`,
+    );
   }
 }


### PR DESCRIPTION
Optimize E2B sandbox by removing memory caching and implementing name-based reuse with metadata for improved persistence and resource management.

This change moves away from local memory-based caching to leverage E2B's native persistence features. Sandboxes can now be identified and reused based on a configurable `name` and `template` stored in metadata, similar to Daytona's pattern. This reduces local resource consumption and allows for more robust, persistent sandbox environments, with timeouts configured in seconds to align with E2B's API and tier limitations.

---
<a href="https://cursor.com/background-agent?bcId=bc-53754584-de5d-4f21-bf31-3972fe9a9555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-53754584-de5d-4f21-bf31-3972fe9a9555"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

