### PR TITLE
fix: move GoogleAnalytics inside body tag to resolve hydration issues

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -26,8 +26,8 @@ export default function Layout({ children }: LayoutProps<"/">) {
     <html lang="en" className={inter.className} suppressHydrationWarning>
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>
+        <GoogleAnalytics gaId="G-B1FLZ40NXT" />
       </body>
-      <GoogleAnalytics gaId="G-B1FLZ40NXT" />
     </html>
   );
 }


### PR DESCRIPTION
## Description
Previously, the `<GoogleAnalytics>` component was placed directly inside `<html>` but outside `<body>` in the Next.js App Router root layout. This caused React hydration errors and could result in the tracking script being dropped during render.

This PR moves the `<GoogleAnalytics>` component correctly inside the `<body>` tag to ensure stable GA4 tracking and prevent hydration mismatches.