### PR TITLE
build: install simple-git globally in sandagent-claude image

### DIFF
--- a/docker/sandagent-claude/Dockerfile
+++ b/docker/sandagent-claude/Dockerfile
@@ -39,6 +39,8 @@ RUN mkdir -p /opt/sandagent && \
 ENV PLAYWRIGHT_BROWSERS_PATH=/opt/sandagent/pw-browsers
 RUN cd /opt/sandagent && npx playwright install --with-deps chromium
 
+RUN npm install simple-git -g
+
 # Create init script to copy deps to workspace on startup
 RUN echo '#!/bin/bash\n\
 if [ ! -d "/workspace/node_modules/@sandagent" ]; then\n\


### PR DESCRIPTION
## Summary
- Installs `simple-git` globally via npm in `docker/sandagent-claude/Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)