### PR TITLE
fix(runner-pi): preserve native system prompt in Pi runner when no CLI prompt is provided

### DIFF
--- a/docs/changelog/2026-03-10-pi-runner-preserve-native-system-prompt.md
+++ b/docs/changelog/2026-03-10-pi-runner-preserve-native-system-prompt.md
@@ -1,0 +1,43 @@
+# Pi runner: Preserve native system prompt instead of overriding
+
+Date: 2026-03-10
+Author: AI Assistant
+AI Agent: Kiro
+
+## Prompts & Instructions
+
+**Original Request:**
+> apps/buda/src/domains/agent/logic/chat-service.ts, when chatting with the agent, the server log shows it executes the runner-cli with `--runner pi`. According to Pi agent docs, it supports appending system prompt via CLI. How should I modify apps/buda code to support appending system prompt?
+
+**Refined Instructions:**
+- Investigate why `.pi/SYSTEM.md` and `.pi/APPEND_SYSTEM.md` placed in the sandbox workdir are not being read by the Pi runner
+- Trace the full call chain from chat-service through to Pi's createAgentSession
+- Identify root cause: createPiRunner() unconditionally overwrites Pi's native system prompt
+- Fix the Pi runner to preserve Pi's native system prompt
+
+## What Changed
+
+The Pi runner previously unconditionally overwrote the system prompt that Pi's `createAgentSession()` builds from context files.
+
+Before (broken): `setSystemPrompt(options.systemPrompt)` or `setSystemPrompt("You are a helpful coding assistant.")` was always called, discarding everything Pi loaded from `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md`, `AGENTS.md`, and skills.
+
+After (fixed): When no `--system-prompt` is passed, Pi's native system prompt is preserved. When `--system-prompt` is passed, the CLI value is appended to Pi's native system prompt instead of replacing it.
+
+## Why
+
+Pi's `createAgentSession()` internally calls `DefaultResourceLoader.reload()` which discovers and loads `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md`, `AGENTS.md`/`CLAUDE.md` context files, and skills. The unconditional `setSystemPrompt()` call threw all of this away. Users placing context files in the sandbox workdir had no effect, breaking Pi's documented context file mechanism when running through SandAgent.
+
+## Files Affected
+
+- `packages/runner-pi/src/pi-runner.ts` - Removed unconditional system prompt override; now preserves Pi's native system prompt and only appends when `--system-prompt` CLI flag is explicitly provided
+
+## Breaking Changes
+
+- The hardcoded `"You are a helpful coding assistant."` fallback is removed. Pi's native system prompt (from context files) is used instead. This is the correct behavior per Pi's documentation.
+
+## Testing
+
+1. Place a `.pi/APPEND_SYSTEM.md` file in the sandbox workdir with custom instructions
+2. Run the Pi runner via SandAgent without `--system-prompt`
+3. Verify the agent behavior reflects the content of `.pi/APPEND_SYSTEM.md`
+4. Run with `--system-prompt "extra"` and verify both Pi's native prompt and the CLI prompt are present

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -246,11 +246,17 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         modelRegistry,
       });
 
+      // Only override Pi's native system prompt when --system-prompt is explicitly passed.
+      // Pi's createAgentSession already builds a full system prompt from:
+      //   .pi/SYSTEM.md, .pi/APPEND_SYSTEM.md, AGENTS.md, skills, etc.
+      // We append the CLI system prompt to preserve Pi's native context files.
       if (options.systemPrompt != null && options.systemPrompt !== "") {
-        session.agent.setSystemPrompt(options.systemPrompt);
-      } else {
-        session.agent.setSystemPrompt("You are a helpful coding assistant.");
+        const existing = session.agent.state.systemPrompt || "";
+        session.agent.setSystemPrompt(
+          existing ? existing + "\n\n" + options.systemPrompt : options.systemPrompt,
+        );
       }
+      // When no --system-prompt is passed, keep Pi's built system prompt as-is.
 
       const eventQueue: AgentSessionEvent[] = [];
       let isComplete = false;


### PR DESCRIPTION
本次更新修复了 runner-pi 对 Pi 原生 system prompt 的错误覆盖问题。此前 createPiRunner() 会无条件调用 `setSystemPrompt()`，导致 Pi 通过 `.pi/SYSTEM.md`、`.pi/APPEND_SYSTEM.md`、`AGENTS.md` 以及 skills 自动加载的上下文全部失效；修复后，当未传入 --system-prompt 时会保留 Pi 原生 prompt，当显式传入时则改为在原有 prompt 基础上追加，而不是替换。需要说明的是，这些上下文文件本身不是必需项，缺失不会导致 Pi 报错，只是不会提供对应的额外上下文。

<img width="1493" height="861" alt="企业微信截图_17731445819377" src="https://github.com/user-attachments/assets/f13d6d77-8b51-439b-bffe-577524db9147" />
