### PR TITLE
feat(runners): propagate tool execution errors via isError flag in SSE stream

### DIFF
--- a/docs/changelog/2026-03-12-tool-error-isError-flag.md
+++ b/docs/changelog/2026-03-12-tool-error-isError-flag.md
@@ -1,0 +1,23 @@
+# Propagate Tool Execution Errors via isError Flag in SSE Stream
+
+## Summary
+
+Fixed an issue where `tool-output-available` events in the SSE stream were not properly communicating when a tool execution failed.
+
+## Changes
+
+### Pi Runner (`packages/runner-pi`)
+
+- Extract `isError` flag from `tool_execution_end` events emitted by `@mariozechner/pi-agent-core`
+- Append `isError` to the Data Stream Protocol JSON payload so the Vercel AI SDK can correctly render tool errors
+
+### Codex Runner (`packages/runner-codex`)
+
+- Added logic to `toToolEndPayload` to calculate `isError` based on:
+  - `exit_code !== 0` for shell commands
+  - `status === 'failed'` or presence of an `error` object for MCP tool calls
+
+### Tests
+
+- Added unit tests for pi-runner verifying `isError: true` is emitted on tool failures
+- Added unit tests for codex-runner verifying `isError` calculation for both shell and MCP tool results

--- a/packages/runner-codex/src/__tests__/codex-runner.test.ts
+++ b/packages/runner-codex/src/__tests__/codex-runner.test.ts
@@ -104,3 +104,80 @@ describe("createCodexRunner", () => {
     );
   });
 });
+
+it("streams tool execution and correctly identifies errors for command_execution", async () => {
+  startThreadMock.mockReturnValue({
+    runStreamed: vi.fn().mockResolvedValue({
+      events: (async function* () {
+        yield {
+          type: "item.completed",
+          item: {
+            type: "command_execution",
+            id: "call-123",
+            status: "failed",
+            exit_code: 1,
+            aggregated_output: "command failed",
+          },
+        };
+        yield {
+          type: "turn.completed",
+          usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+        };
+      })(),
+    }),
+  });
+
+  const runner = createCodexRunner({
+    model: "codex-test",
+    env: { OPENAI_API_KEY: "test" },
+  });
+
+  const chunks: string[] = [];
+  for await (const chunk of runner.run("test tool error")) {
+    chunks.push(chunk);
+  }
+
+  const toolOutputChunk = chunks.find((c) =>
+    c.includes('"type":"tool-output-available"'),
+  );
+  expect(toolOutputChunk).toBeDefined();
+  expect(toolOutputChunk).toContain('"isError":true');
+});
+
+it("streams tool execution and correctly identifies errors for mcp_tool_call", async () => {
+  startThreadMock.mockReturnValue({
+    runStreamed: vi.fn().mockResolvedValue({
+      events: (async function* () {
+        yield {
+          type: "item.completed",
+          item: {
+            type: "mcp_tool_call",
+            id: "mcp-123",
+            status: "failed",
+            error: { message: "Internal server error" },
+          },
+        };
+        yield {
+          type: "turn.completed",
+          usage: { input_tokens: 1, cached_input_tokens: 0, output_tokens: 1 },
+        };
+      })(),
+    }),
+  });
+
+  const runner = createCodexRunner({
+    model: "codex-test",
+    env: { OPENAI_API_KEY: "test" },
+  });
+
+  const chunks: string[] = [];
+  for await (const chunk of runner.run("test mcp error")) {
+    chunks.push(chunk);
+  }
+
+  const toolOutputChunk = chunks.find((c) =>
+    c.includes('"type":"tool-output-available"'),
+  );
+  expect(toolOutputChunk).toBeDefined();
+  expect(toolOutputChunk).toContain('"isError":true');
+});

--- a/packages/runner-codex/src/codex-runner.ts
+++ b/packages/runner-codex/src/codex-runner.ts
@@ -88,7 +88,7 @@ function toToolStartPayload(
 
 function toToolEndPayload(
   event: ThreadEvent,
-): { toolCallId: string; result: unknown } | null {
+): { toolCallId: string; result: unknown; isError?: boolean } | null {
   if (event.type !== "item.completed") {
     return null;
   }
@@ -103,6 +103,7 @@ function toToolEndPayload(
         exitCode: item.exit_code,
         output: item.aggregated_output,
       },
+      isError: item.exit_code !== 0,
     };
   }
 
@@ -110,6 +111,7 @@ function toToolEndPayload(
     return {
       toolCallId: item.id,
       result: item.result ?? item.error ?? { status: item.status },
+      isError: item.error != null || item.status === "failed",
     };
   }
 
@@ -184,7 +186,7 @@ export function createCodexRunner(options: CodexRunnerOptions): CodexRunner {
 
         const toolEnd = toToolEndPayload(event);
         if (toolEnd) {
-          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: toolEnd.toolCallId, output: toolEnd.result })}\n\n`;
+          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: toolEnd.toolCallId, output: toolEnd.result, isError: toolEnd.isError })}\n\n`;
         }
 
         if (event.type === "turn.completed") {

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -8,7 +8,7 @@ class MockSession {
   agent = { state: {}, setSystemPrompt: vi.fn() };
   sessionId = "mock-session-id";
   private listeners: Listener[] = [];
-  private behavior: "normal" | "pending" = "normal";
+  private behavior: "normal" | "pending" | "tool_error" = "normal";
 
   subscribe(fn: Listener): () => void {
     this.listeners.push(fn);
@@ -17,7 +17,7 @@ class MockSession {
     };
   }
 
-  setBehavior(behavior: "normal" | "pending"): void {
+  setBehavior(behavior: "normal" | "pending" | "tool_error"): void {
     this.behavior = behavior;
   }
 
@@ -26,6 +26,24 @@ class MockSession {
       return new Promise(() => {
         // Keep pending forever so the abort test can fire.
       });
+    }
+
+    if (this.behavior === "tool_error") {
+      this.emit({
+        type: "tool_execution_start",
+        toolCallId: "tool_fail",
+        toolName: "bash",
+        args: { command: "exit 1" },
+      });
+      this.emit({
+        type: "tool_execution_end",
+        toolCallId: "tool_fail",
+        toolName: "bash",
+        result: { stdout: "", stderr: "command failed" },
+        isError: true,
+      });
+      this.emit({ type: "agent_end", messages: [] });
+      return;
     }
 
     this.emit({
@@ -65,7 +83,7 @@ class MockSession {
 }
 
 const createdSessions: MockSession[] = [];
-let nextSessionBehavior: "normal" | "pending" = "normal";
+let nextSessionBehavior: "normal" | "pending" | "tool_error" = "normal";
 
 vi.mock("@mariozechner/pi-coding-agent", () => ({
   AuthStorage: {
@@ -161,4 +179,21 @@ describe("createPiRunner", () => {
     expect(chunks.some((c) => c.includes('"type":"finish"'))).toBe(true);
     expect(chunks.some((c) => c.includes("[DONE]"))).toBe(true);
   });
+});
+
+it("emits isError flag when a tool execution fails", async () => {
+  nextSessionBehavior = "tool_error";
+  const runner = createPiRunner({ model: "openai:gpt-4o" });
+
+  const chunks: string[] = [];
+  for await (const chunk of runner.run("trigger tool error")) {
+    chunks.push(chunk);
+  }
+
+  // We should see a tool-output-available chunk that includes isError:true
+  const outputChunk = chunks.find((c) =>
+    c.includes('"type":"tool-output-available"'),
+  );
+  expect(outputChunk).toBeDefined();
+  expect(outputChunk).toContain('"isError":true');
 });

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -361,7 +361,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
               yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true })}\n\n`;
               yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true })}\n\n`;
             } else if (event.type === "tool_execution_end") {
-              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output: event.result, dynamic: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output: event.result, isError: event.isError, dynamic: true })}\n\n`;
             } else if (event.type === "agent_end") {
               if (aborted) {
                 yield* finishError("Run aborted by signal.");


### PR DESCRIPTION
## Description
Fixes an issue where `tool-output-available` events in the SSE stream were not properly communicating when a tool execution failed (e.g., parameter validation failures in the `pi` coding engine).

### Root Causes & Fixes
- The Vercel AI SDK expects an `isError` flag on tool result chunks to correctly render tool errors. However, both `pi-runner` and `codex-runner` were only passing `output`, ignoring the error status.
- **Pi Runner**: The underlying `@mariozechner/pi-agent-core` emits `isError: boolean` inside its `tool_execution_end` event. We now extract this flag and append it to the Data Stream Protocol JSON payload (`isError: event.isError`).
- **Codex Runner**: Added logic to `toToolEndPayload` to calculate `isError` based on `exit_code !== 0` for shell commands, and `status === 'failed'` (or presence of an `error` object) for MCP tool calls.