### PR TITLE
fix(sdk): extract system messages into runner.systemPrompt for Gemini compatibility

### DIFF
--- a/packages/sdk/src/provider/sandagent-language-model.ts
+++ b/packages/sdk/src/provider/sandagent-language-model.ts
@@ -204,7 +204,29 @@ export class SandAgentLanguageModel implements LanguageModelV3 {
     options: LanguageModelV3CallOptions,
   ): Promise<LanguageModelV3StreamResult> {
     const { prompt, abortSignal } = options;
-    const messages = this.convertPromptToMessages(prompt);
+    const allMessages = this.convertPromptToMessages(prompt);
+
+    // Extract system messages and merge into runner.systemPrompt.
+    // Gemini (Vertex AI) rejects role:"system" in messages — only "user" and
+    // "model" are valid.  By folding system content into the runner's
+    // systemPrompt CLI flag we keep all providers happy.
+    const systemParts: string[] = [];
+    const messages: Message[] = [];
+    for (const m of allMessages) {
+      if (m.role === "system") {
+        systemParts.push(m.content);
+      } else {
+        messages.push(m);
+      }
+    }
+
+    const runner = this.options.runner;
+    if (systemParts.length > 0) {
+      const extra = systemParts.join("\n");
+      runner.systemPrompt = runner.systemPrompt
+        ? `${runner.systemPrompt}\n${extra}`
+        : extra;
+    }
 
     this.logger.debug(
       `[sandagent] Starting stream with ${messages.length} messages`,
@@ -217,7 +239,7 @@ export class SandAgentLanguageModel implements LanguageModelV3 {
 
     const agent = new SandAgent({
       sandbox: this.options.sandbox,
-      runner: this.options.runner,
+      runner,
       env: { ...sandboxEnv, ...this.options.env },
     });
 


### PR DESCRIPTION
## Problem

Gemini (Vertex AI) only accepts `user` and `model` roles in messages. When using Gemini models through LiteLLM proxy (e.g. `openai:gemini-3.1-flash`), any `role: "system"` messages cause a 400 error:

```
litellm.BadRequestError: Vertex_ai_betaException BadRequestError - "Please use a valid role: user, model."
```

## Root Cause

In `SandAgentLanguageModel.doStream()`, `convertPromptToMessages()` converts AI SDK system prompts into `{ role: "system" }` messages and passes them to `SandAgent.stream({ messages })`. While `buildCommand()` ignores these system messages (only taking the last user message), the system content was being lost — it was neither forwarded to the runner nor merged into `runner.systemPrompt`.

## Fix

Extract system messages from the converted messages array and merge their content into `runner.systemPrompt`. This ensures:

1. System prompt content reaches the sandbox runner via `--system-prompt` CLI flag
2. No `role: "system"` messages are passed to `SandAgent.stream()`
3. All model providers (Claude, GPT, Gemini) work correctly

## Files Changed

- `packages/sdk/src/provider/sandagent-language-model.ts` — Extract system messages and merge into `runner.systemPrompt`

## Related

- kapps PR: https://github.com/vikadata/kapps/pull/1792 (buda-side workaround)