### PR TITLE
feat(sdk): support multi-part user messages for image uploads

### DIFF
--- a/docs/changelog/2026-03-17-fix-ci-image-parts.md
+++ b/docs/changelog/2026-03-17-fix-ci-image-parts.md
@@ -1,0 +1,23 @@
+# Fix CI Build Failures for Multi-Part Image Messages
+
+## Date: 2026-03-17
+
+## Summary
+
+Fixed two TypeScript build errors introduced in the `feat(sdk): support multi-part user messages for image uploads` PR.
+
+## Changes
+
+### `packages/runner-codex/src/codex-runner.ts`
+
+- Imported `Input`, `UserInput` types from `@openai/codex-sdk`.
+- Typed `inputToCodex` as `Input` instead of `string | Array<Record<string, unknown>>`.
+- Fixed image-part mapping: instead of constructing OpenAI-format `image_url` objects (incompatible with Codex SDK), base64 data URLs are now decoded and written to a temp file, then passed as `{ type: "local_image", path }` which is the correct `UserInput` format for the Codex SDK.
+- Non-base64 image URLs (HTTP/HTTPS) are skipped as they are unsupported by the Codex SDK.
+- Temp files are cleaned up after the streaming turn completes.
+
+### `packages/sdk/src/provider/sandagent-language-model.ts`
+
+- Fixed `convertPromptToMessages` to use the Vercel AI SDK v3 `LanguageModelV3FilePart` format (`type: 'file'`, `data`, `mediaType`) instead of the old v2 image part format (`type: 'image'`, `part.image`, `part.mimeType`).
+- Property accesses updated: `part.image` → `part.data`, `part.mimeType` → `part.mediaType`.
+- For `Uint8Array` data, the conversion now produces a proper data URL (`data:<mediaType>;base64,...`).

--- a/packages/manager/src/sand-agent.ts
+++ b/packages/manager/src/sand-agent.ts
@@ -96,7 +96,7 @@ export class SandAgent {
       .pop();
 
     if (lastUserMessage) {
-      cmd.push(lastUserMessage.content);
+      cmd.push(typeof lastUserMessage.content === "string" ? lastUserMessage.content : JSON.stringify(lastUserMessage.content));
     }
 
     return cmd;

--- a/packages/manager/src/sand-agent.ts
+++ b/packages/manager/src/sand-agent.ts
@@ -96,7 +96,11 @@ export class SandAgent {
       .pop();
 
     if (lastUserMessage) {
-      cmd.push(typeof lastUserMessage.content === "string" ? lastUserMessage.content : JSON.stringify(lastUserMessage.content));
+      cmd.push(
+        typeof lastUserMessage.content === "string"
+          ? lastUserMessage.content
+          : JSON.stringify(lastUserMessage.content),
+      );
     }
 
     return cmd;

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -174,7 +174,12 @@ export interface Message {
   /** Role of the message sender */
   role: "user" | "assistant" | "system";
   /** Content of the message */
-  content: string | Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
+  content:
+    | string
+    | Array<
+        | { type: "text"; text: string }
+        | { type: "image"; data: string; mimeType: string }
+      >;
 }
 
 /**

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -174,7 +174,7 @@ export interface Message {
   /** Role of the message sender */
   role: "user" | "assistant" | "system";
   /** Content of the message */
-  content: string;
+  content: string | Array<{ type: "text"; text: string } | { type: "image"; data: string; mimeType: string }>;
 }
 
 /**

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -48,11 +48,36 @@ export interface ClaudeRunnerOptions extends BaseRunnerOptions {
  * Build a regular user message (not a tool result)
  */
 export function buildUserMessage(userInput: string): SDKUserMessage {
+  // If userInput is a serialized JSON array (from SandAgent manager for multi-part messages)
+  // Claude Agent SDK allows content to be string or array of blocks.
+  // Let's decode it safely.
+  let parsedContent: string | Array<Record<string, unknown>> = userInput;
+  try {
+    if (userInput.startsWith("[") && userInput.endsWith("]")) {
+      const parsed = JSON.parse(userInput);
+      if (Array.isArray(parsed)) {
+        // Claude SDK UserMessage allows arrays of ContentBlock
+        // Convert to Claude's format if it contains images
+        parsedContent = parsed.map((p) => {
+          if (p.type === "text") return { type: "text", text: p.text };
+          if (p.type === "image")
+            return {
+              type: "image",
+              source: { type: "base64", media_type: p.mimeType, data: p.data },
+            };
+          return { type: "text", text: JSON.stringify(p) };
+        });
+      }
+    }
+  } catch (e) {
+    // Fallback to string
+  }
+
   return {
     type: "user",
     message: {
       role: "user",
-      content: userInput,
+      content: parsedContent,
     },
   } as SDKUserMessage;
 }

--- a/packages/runner-codex/src/codex-runner.ts
+++ b/packages/runner-codex/src/codex-runner.ts
@@ -168,7 +168,28 @@ export function createCodexRunner(options: CodexRunnerOptions): CodexRunner {
         ? codex.resumeThread(options.resume, threadOptions)
         : codex.startThread(threadOptions);
 
-      const streamedTurn = await thread.runStreamed(userInput, {
+      let inputToCodex: string | Array<Record<string, unknown>> = userInput;
+      try {
+        if (userInput.startsWith("[") && userInput.endsWith("]")) {
+          const parsed = JSON.parse(userInput);
+          if (Array.isArray(parsed)) {
+            // Codex expects OpenAI format parts for user message
+            inputToCodex = parsed.map((p) => {
+              if (p.type === "image") {
+                return {
+                  type: "image_url",
+                  image_url: { url: p.data },
+                };
+              }
+              return { type: "text", text: p.text || JSON.stringify(p) };
+            });
+          }
+        }
+      } catch (e) {
+        // Fallback to string
+      }
+
+      const streamedTurn = await thread.runStreamed(inputToCodex, {
         signal: options.abortController?.signal,
       });
 

--- a/packages/runner-codex/src/codex-runner.ts
+++ b/packages/runner-codex/src/codex-runner.ts
@@ -1,9 +1,14 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import {
   type ApprovalMode,
   Codex,
+  type Input,
   type ModelReasoningEffort,
   type SandboxMode,
   type ThreadEvent,
+  type UserInput,
   type WebSearchMode,
 } from "@openai/codex-sdk";
 import type { BaseRunnerOptions } from "./types.js";
@@ -168,21 +173,38 @@ export function createCodexRunner(options: CodexRunnerOptions): CodexRunner {
         ? codex.resumeThread(options.resume, threadOptions)
         : codex.startThread(threadOptions);
 
-      let inputToCodex: string | Array<Record<string, unknown>> = userInput;
+      let inputToCodex: Input = userInput;
+      const tempFiles: string[] = [];
       try {
         if (userInput.startsWith("[") && userInput.endsWith("]")) {
           const parsed = JSON.parse(userInput);
           if (Array.isArray(parsed)) {
-            // Codex expects OpenAI format parts for user message
-            inputToCodex = parsed.map((p) => {
-              if (p.type === "image") {
-                return {
-                  type: "image_url",
-                  image_url: { url: p.data },
-                };
+            // Codex expects its own UserInput format (text or local_image)
+            const parts: UserInput[] = [];
+            for (const p of parsed) {
+              if (p.type === "image" && typeof p.data === "string") {
+                // Write base64 data URL to a temp file for local_image support
+                const match = /^data:([^;]+);base64,(.+)$/.exec(p.data);
+                if (match) {
+                  const ext = match[1].split("/")[1] ?? "png";
+                  const tmpPath = path.join(
+                    os.tmpdir(),
+                    `sandagent-img-${Date.now()}-${Math.random().toString(36).slice(2)}.${ext}`,
+                  );
+                  fs.writeFileSync(tmpPath, Buffer.from(match[2], "base64"));
+                  tempFiles.push(tmpPath);
+                  parts.push({ type: "local_image", path: tmpPath });
+                }
+                // Non-base64 image URLs are not supported by Codex SDK; skip them.
+              } else {
+                const text: string =
+                  typeof p.text === "string" ? p.text : JSON.stringify(p);
+                parts.push({ type: "text", text });
               }
-              return { type: "text", text: p.text || JSON.stringify(p) };
-            });
+            }
+            if (parts.length > 0) {
+              inputToCodex = parts;
+            }
           }
         }
       } catch (e) {
@@ -225,6 +247,15 @@ export function createCodexRunner(options: CodexRunnerOptions): CodexRunner {
           yield `data: ${JSON.stringify({ type: "error", errorText: stringifyUnknown(event.message) })}\n\n`;
           yield `data: ${JSON.stringify({ type: "finish", finishReason: "error" })}\n\n`;
           yield `data: [DONE]\n\n`;
+        }
+      }
+
+      // Clean up any temp image files written for local_image inputs
+      for (const tmpFile of tempFiles) {
+        try {
+          fs.unlinkSync(tmpFile);
+        } catch {
+          // Ignore cleanup errors
         }
       }
     },

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -294,7 +294,39 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
       try {
         traceRawMessage(cwd, null, true);
 
-        const promptPromise = session.prompt(userInput);
+        let promptText = userInput;
+        let images:
+          | Array<{ type: "image"; data: string; mimeType: string }>
+          | undefined = undefined;
+
+        // Try to parse userInput as a JSON array of parts (if passed from sandagent SDK)
+        try {
+          if (userInput.startsWith("[") && userInput.endsWith("]")) {
+            const parsed = JSON.parse(userInput);
+            if (Array.isArray(parsed)) {
+              promptText = parsed
+                .filter((p) => p.type === "text")
+                .map((p) => p.text)
+                .join("\n");
+
+              const imageParts = parsed.filter((p) => p.type === "image");
+              if (imageParts.length > 0) {
+                images = imageParts.map((p) => ({
+                  type: "image",
+                  data: p.data,
+                  mimeType: p.mimeType,
+                }));
+              }
+            }
+          }
+        } catch (e) {
+          // Fallback to raw string if parsing fails
+        }
+
+        const promptPromise = session.prompt(
+          promptText,
+          images ? { images } : undefined,
+        );
 
         const messageId = `msg_${Date.now()}_${Math.random().toString(36).slice(2)}`;
         const textId = `text_${Date.now()}_${Math.random().toString(36).slice(2)}`;

--- a/packages/sdk/src/provider/sandagent-language-model.ts
+++ b/packages/sdk/src/provider/sandagent-language-model.ts
@@ -526,21 +526,20 @@ export class SandAgentLanguageModel implements LanguageModelV3 {
               if (part.type === "text") {
                 return { type: "text" as const, text: part.text };
               }
-              if (part.type === "image") {
-                // Convert Uint8Array to base64 if needed, or if it's a URL, we hope Buda already converted it or we just stringify.
-                // Vercel AI SDK parts can be Uint8Array or URL string
+              if (part.type === "file") {
+                // LanguageModelV3FilePart: data is Uint8Array | string | URL, mediaType is IANA type
                 let dataStr = "";
-                if (part.image instanceof Uint8Array) {
-                  dataStr = Buffer.from(part.image).toString("base64");
-                } else if (part.image instanceof URL) {
-                  dataStr = part.image.toString();
-                } else if (typeof part.image === "string") {
-                  // If it's a base64 string or URL
-                  dataStr = part.image;
+                if (part.data instanceof Uint8Array) {
+                  dataStr = `data:${part.mediaType};base64,${Buffer.from(part.data).toString("base64")}`;
+                } else if (part.data instanceof URL) {
+                  dataStr = part.data.toString();
+                } else if (typeof part.data === "string") {
+                  // Already a data URL or base64 string
+                  dataStr = part.data;
                 }
                 return {
                   type: "image" as const,
-                  mimeType: part.mimeType || "image/png",
+                  mimeType: part.mediaType || "image/png",
                   data: dataStr,
                 };
               }

--- a/packages/sdk/src/provider/sandagent-language-model.ts
+++ b/packages/sdk/src/provider/sandagent-language-model.ts
@@ -521,17 +521,50 @@ export class SandAgentLanguageModel implements LanguageModelV3 {
         }
 
         case "user": {
-          const textParts = message.content
+          const parts = message.content
+            .map((part) => {
+              if (part.type === "text") {
+                return { type: "text" as const, text: part.text };
+              }
+              if (part.type === "image") {
+                // Convert Uint8Array to base64 if needed, or if it's a URL, we hope Buda already converted it or we just stringify.
+                // Vercel AI SDK parts can be Uint8Array or URL string
+                let dataStr = "";
+                if (part.image instanceof Uint8Array) {
+                  dataStr = Buffer.from(part.image).toString("base64");
+                } else if (part.image instanceof URL) {
+                  dataStr = part.image.toString();
+                } else if (typeof part.image === "string") {
+                  // If it's a base64 string or URL
+                  dataStr = part.image;
+                }
+                return {
+                  type: "image" as const,
+                  mimeType: part.mimeType || "image/png",
+                  data: dataStr,
+                };
+              }
+              return null;
+            })
             .filter(
-              (part): part is { type: "text"; text: string } =>
-                part.type === "text",
-            )
-            .map((part) => part.text);
+              (
+                p,
+              ): p is
+                | { type: "text"; text: string }
+                | { type: "image"; mimeType: string; data: string } =>
+                p !== null,
+            );
 
-          if (textParts.length > 0) {
+          if (parts.length > 0) {
+            // If only text parts, combine them into a string for cleaner payload, else pass array
+            const isAllText = parts.every((p) => p.type === "text");
             messages.push({
               role: "user",
-              content: textParts.join("\n"),
+              content: isAllText
+                ? parts
+                    .map((p) => (p as { type: "text"; text: string }).text)
+                    .join("\n")
+                : parts,
             });
           }
           break;


### PR DESCRIPTION
## Description
Modifies the `@sandagent/sdk` mapping layer to stop aggressively dropping file/image attachments from Vercel AI SDK prompts.

### Changes
1. **Types:** Updated `Message.content` in `@sandagent/manager` to allow arrays of `TextContent | ImageContent` instead of just raw strings.
2. **Provider Mapping:** Rewrote `convertPromptToMessages` in `SandAgentLanguageModel` so that when it encounters `part.type === image`, it parses the image payload (handling `Uint8Array`, `URL`, or `string`) and passes it down into the standard `ImageContent` format for the underlying engines.