### PR TITLE
feat(pi-runner): pass custom system prompt to DefaultResourceLoader

### DIFF
--- a/apps/runner-cli/src/cli.ts
+++ b/apps/runner-cli/src/cli.ts
@@ -93,6 +93,7 @@ function parseRunArgs(): ParsedRunArgs {
         default: process.env.SANDAGENT_WORKSPACE ?? process.cwd(),
       },
       "system-prompt": { type: "string", short: "s" },
+      "append-system-prompt": { type: "string" },
       "max-turns": { type: "string", short: "t" },
       "allowed-tools": { type: "string", short: "a" },
       "skill": { type: "string", multiple: true },
@@ -137,6 +138,7 @@ function parseRunArgs(): ParsedRunArgs {
     model: values.model!,
     cwd: values.cwd!,
     systemPrompt: values["system-prompt"],
+    appendSystemPrompt: values["append-system-prompt"],
     maxTurns: values["max-turns"]
       ? Number.parseInt(values["max-turns"], 10)
       : undefined,
@@ -209,6 +211,7 @@ Options:
   -m, --model <model>          Model (default: claude-sonnet-4-20250514)
   -c, --cwd <path>             Working directory (default: cwd)
   -s, --system-prompt <prompt> Custom system prompt
+      --append-system-prompt <prompt> Append text to system prompt
   -t, --max-turns <n>          Max conversation turns
   -a, --allowed-tools <tools>  Comma-separated allowed tools
       --skill <path>      Additional skill path (can be repeated, for pi runner)

--- a/apps/runner-cli/src/cli.ts
+++ b/apps/runner-cli/src/cli.ts
@@ -95,7 +95,7 @@ function parseRunArgs(): ParsedRunArgs {
       "system-prompt": { type: "string", short: "s" },
       "max-turns": { type: "string", short: "t" },
       "allowed-tools": { type: "string", short: "a" },
-      "skill-path": { type: "string", multiple: true },
+      "skill": { type: "string", multiple: true },
       resume: { type: "string" },
       help: { type: "boolean", short: "h" },
     },
@@ -141,7 +141,7 @@ function parseRunArgs(): ParsedRunArgs {
       ? Number.parseInt(values["max-turns"], 10)
       : undefined,
     allowedTools: values["allowed-tools"]?.split(",").map((t) => t.trim()),
-    skillPaths: values["skill-path"] as string[] | undefined,
+    skillPaths: values["skill"] as string[] | undefined,
     resume: values.resume,
     userInput,
   };
@@ -211,7 +211,7 @@ Options:
   -s, --system-prompt <prompt> Custom system prompt
   -t, --max-turns <n>          Max conversation turns
   -a, --allowed-tools <tools>  Comma-separated allowed tools
-      --skill-path <path>      Additional skill path (can be repeated, for pi runner)
+      --skill <path>      Additional skill path (can be repeated, for pi runner)
       --resume <session-id>    Resume a previous session
   -h, --help                   Show this help
 

--- a/packages/manager/src/sand-agent.ts
+++ b/packages/manager/src/sand-agent.ts
@@ -62,6 +62,9 @@ export class SandAgent {
     if (this.runner.systemPrompt) {
       cmd.push("--system-prompt", this.runner.systemPrompt);
     }
+    if (this.runner.appendSystemPrompt) {
+      cmd.push("--append-system-prompt", this.runner.appendSystemPrompt);
+    }
 
     // Add optional skill paths (for pi runner)
     if (this.runner.skillPaths && this.runner.skillPaths.length > 0) {

--- a/packages/manager/src/sand-agent.ts
+++ b/packages/manager/src/sand-agent.ts
@@ -66,7 +66,7 @@ export class SandAgent {
     // Add optional skill paths (for pi runner)
     if (this.runner.skillPaths && this.runner.skillPaths.length > 0) {
       for (const skillPath of this.runner.skillPaths) {
-        cmd.push("--skill-path", skillPath);
+        cmd.push("--skill", skillPath);
       }
     }
 

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -145,6 +145,8 @@ export interface RunnerSpec {
   runnerType?: "claude" | "pi" | "codex" | "gemini" | "opencode";
   /** Optional system prompt override (overrides template's CLAUDE.md) */
   systemPrompt?: string;
+  /** Text to append to the system prompt */
+  appendSystemPrompt?: string;
   /** Maximum number of conversation turns */
   maxTurns?: number;
   /** Allowed tools (undefined means all tools, or use template's settings) */

--- a/packages/runner-core/src/index.ts
+++ b/packages/runner-core/src/index.ts
@@ -28,6 +28,7 @@ export function createRunner(
   const base = {
     model: options.model,
     systemPrompt: options.systemPrompt,
+    appendSystemPrompt: options.appendSystemPrompt,
     maxTurns: options.maxTurns,
     allowedTools: options.allowedTools,
     resume: options.resume,

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -285,11 +285,12 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         return SessionManager.create(cwd);
       })();
 
-      const resourceLoader = options.skillPaths || options.systemPrompt
+      const resourceLoader = options.skillPaths || options.systemPrompt || options.appendSystemPrompt
         ? new SandagentResourceLoader({
             cwd,
             skillPaths: options.skillPaths,
             systemPrompt: options.systemPrompt,
+            appendSystemPrompt: options.appendSystemPrompt,
           })
         : undefined;
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -285,8 +285,12 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         return SessionManager.create(cwd);
       })();
 
-      const resourceLoader = options.skillPaths
-        ? new SandagentResourceLoader({ cwd, skillPaths: options.skillPaths })
+      const resourceLoader = options.skillPaths || options.systemPrompt
+        ? new SandagentResourceLoader({
+            cwd,
+            skillPaths: options.skillPaths,
+            systemPrompt: options.systemPrompt,
+          })
         : undefined;
 
       // createAgentSession only calls reload() when it creates its own
@@ -305,11 +309,14 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         resourceLoader,
       });
 
-      if (options.systemPrompt != null && options.systemPrompt !== "") {
-        session.agent.setSystemPrompt(options.systemPrompt);
-      } else {
-        session.agent.setSystemPrompt("You are a helpful coding assistant.");
-      }
+      // The systemPrompt is natively handled by pi-mono's AgentSession which uses
+      // the SandagentResourceLoader to build a comprehensive prompt including:
+      // - The base system prompt (from options.systemPrompt or defaults)
+      // - Tool descriptions and guidelines
+      // - Context files (AGENTS.md, etc.)
+      // - Skill descriptions (<available_skills>)
+      // We do NOT manually call session.agent.setSystemPrompt here, as it would
+      // overwrite the beautifully constructed prompt.
 
       const eventQueue: AgentSessionEvent[] = [];
       let isComplete = false;

--- a/packages/runner-pi/src/sandagent-resource-loader.ts
+++ b/packages/runner-pi/src/sandagent-resource-loader.ts
@@ -23,6 +23,8 @@ export interface SandagentResourceLoaderOptions {
   skillPaths?: string[];
   /** Custom system prompt */
   systemPrompt?: string;
+  /** Text to append to the system prompt */
+  appendSystemPrompt?: string;
 }
 
 /**
@@ -47,6 +49,7 @@ export class SandagentResourceLoader implements ResourceLoader {
       agentDir: this.agentDir,
       settingsManager: options.settingsManager,
       systemPrompt: options.systemPrompt,
+      appendSystemPrompt: options.appendSystemPrompt,
     });
   }
 

--- a/packages/runner-pi/src/sandagent-resource-loader.ts
+++ b/packages/runner-pi/src/sandagent-resource-loader.ts
@@ -21,6 +21,8 @@ export interface SandagentResourceLoaderOptions {
   settingsManager?: SettingsManager;
   /** Additional skill paths (files or directories) */
   skillPaths?: string[];
+  /** Custom system prompt */
+  systemPrompt?: string;
 }
 
 /**
@@ -44,6 +46,7 @@ export class SandagentResourceLoader implements ResourceLoader {
       cwd: this.cwd,
       agentDir: this.agentDir,
       settingsManager: options.settingsManager,
+      systemPrompt: options.systemPrompt,
     });
   }
 

--- a/packages/sdk/src/provider/sandagent-daemon-provider.ts
+++ b/packages/sdk/src/provider/sandagent-daemon-provider.ts
@@ -18,6 +18,7 @@ export interface DaemonProviderSettings {
   resume?: string;
   /** Override system prompt */
   systemPrompt?: string;
+  appendSystemPrompt?: string;
   /** Max agent turns */
   maxTurns?: number;
   /** Allowed tools */
@@ -101,6 +102,7 @@ class DaemonLanguageModel implements LanguageModelV3 {
       cwd: this.settings.cwd,
       resume: this.settings.resume,
       systemPrompt: this.settings.systemPrompt,
+      appendSystemPrompt: this.settings.appendSystemPrompt,
       maxTurns: this.settings.maxTurns,
       allowedTools: this.settings.allowedTools,
       skillPaths: this.settings.skillPaths,

--- a/packages/sdk/src/provider/sandagent-provider.ts
+++ b/packages/sdk/src/provider/sandagent-provider.ts
@@ -108,6 +108,9 @@ export function createSandAgent(
       ...((options.systemPrompt ?? defaultOptions.systemPrompt)
         ? { systemPrompt: options.systemPrompt ?? defaultOptions.systemPrompt }
         : {}),
+      ...((options.appendSystemPrompt ?? defaultOptions.appendSystemPrompt)
+        ? { appendSystemPrompt: options.appendSystemPrompt ?? defaultOptions.appendSystemPrompt }
+        : {}),
       ...(options.skillPaths ? { skillPaths: options.skillPaths } : {}),
     };
 

--- a/packages/sdk/src/provider/types.ts
+++ b/packages/sdk/src/provider/types.ts
@@ -100,6 +100,8 @@ export interface SandAgentProviderSettings
   maxTurns?: number;
   /** Optional system prompt override (overrides template's default) */
   systemPrompt?: string;
+  /** Text to append to the system prompt */
+  appendSystemPrompt?: string;
   /** Additional skill paths (files or directories) for pi runner */
   skillPaths?: string[];
 }


### PR DESCRIPTION
Allows the pi runner to build a comprehensive system prompt combining the user's custom system prompt with context files and skill descriptions natively using pi-mono's DefaultResourceLoader and AgentSession.