### PR TITLE
fix(pi-runner): flag emitted tool execution events as providerExecuted to prevent AI SDK validation errors

### DIFF
--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -443,14 +443,14 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
                 }
               }
             } else if (event.type === "tool_execution_start") {
-              yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true })}\n\n`;
-              yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true, providerExecuted: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true, providerExecuted: true })}\n\n`;
             } else if (event.type === "tool_execution_end") {
               // Pi tools return results in { content: [{type:"text",text:"..."}], details:{} }
               // format.  Extract the plain text so the UI and downstream SDK
               // receive a readable string instead of a raw JSON object.
               const output = extractToolResultText(event.result);
-              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true, providerExecuted: true })}\n\n`;
             } else if (event.type === "agent_end") {
               if (aborted) {
                 yield* finishError("Run aborted by signal.");


### PR DESCRIPTION
The underlying AI SDK v3 stream parser checks whether tools exist in the `tools` dictionary passed down. However, when using the pi-runner, tools are orchestrated within the sandbox/VM natively, so Buda/kapps don't inject the tool definition down. To fix the "Model tried to call unavailable tool" (`NoSuchToolError`) issue in the AI SDK downstream parser, we explicitly emit `providerExecuted: true` for `tool-input-start`, `tool-input-available`, and `tool-output-available` events.