### PR TITLE
fix(runner-pi): fix tool streaming state when unavailable tool is called

### DIFF
--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -444,13 +444,23 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
               }
             } else if (event.type === "tool_execution_start") {
               yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true, providerExecuted: true })}\n\n`;
-              yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true, providerExecuted: true })}\n\n`;
+              // We do not yield tool-input-available yet because it might be an invalid tool
+            } else if (event.type === "tool_execution_error") {
+              // Not directly used by Pi currently but handle it if emitted
+              yield `data: ${JSON.stringify({ type: "tool-input-error", toolCallId: event.toolCallId, toolName: event.toolName, errorText: "Tool execution failed" })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-output-error", toolCallId: event.toolCallId, errorText: "Tool execution failed" })}\n\n`;
             } else if (event.type === "tool_execution_end") {
-              // Pi tools return results in { content: [{type:"text",text:"..."}], details:{} }
-              // format.  Extract the plain text so the UI and downstream SDK
-              // receive a readable string instead of a raw JSON object.
               const output = extractToolResultText(event.result);
-              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true, providerExecuted: true })}\n\n`;
+              
+              // If it's a known invalid tool from AI SDK / Pi, handle it as an error
+              if (event.isError && output.includes("Model tried to call unavailable tool")) {
+                yield `data: ${JSON.stringify({ type: "tool-input-error", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true, errorText: output })}\n\n`;
+                yield `data: ${JSON.stringify({ type: "tool-output-error", toolCallId: event.toolCallId, errorText: output, dynamic: true })}\n\n`;
+              } else {
+                // If it successfully executed (or failed due to tool logic), first available input, then output
+                yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true, providerExecuted: true })}\n\n`;
+                yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true, providerExecuted: true })}\n\n`;
+              }
             } else if (event.type === "agent_end") {
               if (aborted) {
                 yield* finishError("Run aborted by signal.");

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -443,14 +443,14 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
                 }
               }
             } else if (event.type === "tool_execution_start") {
-              yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true })}\n\n`;
-              yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: event.toolCallId, toolName: event.toolName, dynamic: true, providerExecuted: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-input-available", toolCallId: event.toolCallId, toolName: event.toolName, input: event.args, dynamic: true, providerExecuted: true })}\n\n`;
             } else if (event.type === "tool_execution_end") {
               // Pi tools return results in { content: [{type:"text",text:"..."}], details:{} }
               // format.  Extract the plain text so the UI and downstream SDK
               // receive a readable string instead of a raw JSON object.
               const output = extractToolResultText(event.result);
-              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true })}\n\n`;
+              yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: event.toolCallId, output, isError: event.isError, dynamic: true, providerExecuted: true })}\n\n`;
             } else if (event.type === "agent_end") {
               if (aborted) {
                 yield* finishError("Run aborted by signal.");


### PR DESCRIPTION
When pi-mono receives a tool call for an unavailable tool (like bash), it correctly returns an immediate error result. However, the stream was emitting `tool-input-available` and then `tool-output-available` (with the error text). This PR catches the known AI SDK / pi-mono error string and correctly emits `tool-input-error` and `tool-output-error` instead, preserving correct UI state for tool cards.