### PR TITLE
feat(daemon): add multipart file upload endpoint

### DIFF
--- a/apps/daemon/README.md
+++ b/apps/daemon/README.md
@@ -325,6 +325,55 @@ Response: `application/x-ndjson` chunked stream — each line is an AI SDK UI me
 | POST | `/api/fs/remove` | `{"path":"tmp","recursive":true}` |
 | POST | `/api/fs/move` | `{"from":"a.txt","to":"b.txt"}` |
 | POST | `/api/fs/copy` | `{"from":"a.txt","to":"b.txt"}` |
+| POST | `/api/fs/upload` | `multipart/form-data` — see below |
+
+#### `POST /api/fs/upload`
+
+Upload one or more files via `multipart/form-data`.
+
+Form fields:
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | No | Target directory (default: `.`) |
+| `volume` | string | No | Volume name for multi-tenant isolation |
+| `create_dirs` | string | No | Create parent dirs (default: `"true"`) |
+| `file` | file | Yes | One or more files to upload |
+
+Example:
+
+```bash
+# Upload a single file
+curl -X POST http://localhost:3080/api/fs/upload \
+  -F "path=uploads" \
+  -F "file=@local-file.txt"
+
+# Upload multiple files
+curl -X POST http://localhost:3080/api/fs/upload \
+  -F "path=data" \
+  -F "file=@report.csv" \
+  -F "file=@image.png"
+
+# Upload to a specific volume
+curl -X POST http://localhost:3080/api/fs/upload \
+  -F "path=docs" \
+  -F "volume=vol-001" \
+  -F "file=@readme.md"
+```
+
+Response:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "files": [
+      { "fieldname": "file", "filename": "report.csv", "path": "/workspace/data/report.csv", "size": 1234 }
+    ]
+  },
+  "error": null
+}
+```
 
 All fs endpoints accept optional `volume` for multi-tenant isolation.
 

--- a/apps/daemon/src/multipart.ts
+++ b/apps/daemon/src/multipart.ts
@@ -1,0 +1,63 @@
+/**
+ * Minimal multipart/form-data parser — zero external dependencies.
+ * Parses raw body buffer using the boundary from Content-Type header.
+ */
+
+export interface ParsedMultipart {
+  fields: Record<string, string>;
+  files: Array<{ filename: string; data: Buffer }>;
+}
+
+export function parseMultipart(
+  contentType: string,
+  body: Buffer,
+): ParsedMultipart {
+  const match = contentType.match(/boundary=(?:"([^"]+)"|([^\s;]+))/);
+  if (!match) throw new Error("missing multipart boundary");
+  const boundary = match[1] ?? match[2];
+  const delimiter = Buffer.from(`--${boundary}`);
+
+  const fields: Record<string, string> = {};
+  const files: Array<{ filename: string; data: Buffer }> = [];
+
+  // Split body by boundary
+  let start = body.indexOf(delimiter) + delimiter.length;
+  while (start < body.length) {
+    const end = body.indexOf(delimiter, start);
+    if (end === -1) break;
+
+    const part = body.subarray(start, end);
+    // Skip leading \r\n
+    const partStart = part[0] === 0x0d && part[1] === 0x0a ? 2 : 0;
+    const headerEnd = part.indexOf("\r\n\r\n", partStart);
+    if (headerEnd === -1) {
+      start = end + delimiter.length;
+      continue;
+    }
+
+    const headerStr = part.subarray(partStart, headerEnd).toString("utf-8");
+    // Data is between header end and trailing \r\n before next boundary
+    let data = part.subarray(headerEnd + 4);
+    // Strip trailing \r\n
+    if (
+      data.length >= 2 &&
+      data[data.length - 2] === 0x0d &&
+      data[data.length - 1] === 0x0a
+    ) {
+      data = data.subarray(0, data.length - 2);
+    }
+
+    const nameMatch = headerStr.match(/name="([^"]+)"/);
+    const filenameMatch = headerStr.match(/filename="([^"]+)"/);
+
+    if (filenameMatch && nameMatch) {
+      files.push({ filename: filenameMatch[1], data: Buffer.from(data) });
+    } else if (nameMatch) {
+      fields[nameMatch[1]] = data.toString("utf-8");
+    }
+
+    start = end + delimiter.length;
+  }
+
+  return { fields, files };
+}

--- a/apps/daemon/src/nextjs.ts
+++ b/apps/daemon/src/nextjs.ts
@@ -14,13 +14,20 @@
  * Requests to /api/daemon/api/coding/run → daemon /api/coding/run (NDJSON stream)
  */
 
+import { parseMultipart } from "./multipart.js";
 import { DaemonRouter } from "./router.js";
 import { codingRunStream, type RunRequest } from "./routes/coding.js";
+import { fsUpload } from "./routes/fs.js";
+import { AppError, type AppState, fail } from "./utils.js";
 
 export function createNextHandler(opts: { root: string; prefix?: string }) {
   const router = new DaemonRouter({ root: opts.root });
   const env = process.env as Record<string, string>;
   const prefix = opts.prefix ?? "/api/daemon";
+  const state: AppState = {
+    root: opts.root,
+    volumesRoot: `${opts.root}/volumes`,
+  };
 
   return async (req: Request): Promise<Response> => {
     const url = new URL(req.url);
@@ -34,6 +41,27 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
     if (method === "POST" && pathname === "/api/coding/run") {
       const body = (await req.json().catch(() => ({}))) as RunRequest;
       return codingRunStream(body, env);
+    }
+
+    // Multipart upload: /api/fs/upload
+    if (method === "POST" && pathname === "/api/fs/upload") {
+      try {
+        const ct = req.headers.get("content-type") ?? "";
+        if (!ct.includes("multipart/form-data")) {
+          return Response.json(
+            fail("content-type must be multipart/form-data"),
+            { status: 400 },
+          );
+        }
+        const raw = Buffer.from(await req.arrayBuffer());
+        const parts = parseMultipart(ct, raw);
+        const result = await fsUpload(state, parts);
+        return Response.json(result);
+      } catch (err) {
+        const status = err instanceof AppError ? err.status : 500;
+        const msg = err instanceof Error ? err.message : String(err);
+        return Response.json(fail(msg), { status });
+      }
     }
 
     // Standard JSON routes

--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -204,3 +204,50 @@ export async function fsCopy(state: AppState, body: MoveCopyBody) {
   await fs.copyFile(from, to);
   return ok({ path: to });
 }
+
+// --- Upload types ---
+
+export interface UploadedFile {
+  fieldname: string;
+  filename: string;
+  path: string;
+  size: number;
+}
+
+export interface UploadResult {
+  files: UploadedFile[];
+}
+
+/**
+ * Handle multipart/form-data file upload.
+ * Expects form field "path" for target directory and one or more "file" parts.
+ */
+export async function fsUpload(
+  state: AppState,
+  parts: {
+    fields: Record<string, string>;
+    files: Array<{ filename: string; data: Buffer }>;
+  },
+) {
+  const volume = parts.fields.volume;
+  const targetDir = parts.fields.path ?? ".";
+  const createDirs = parts.fields.create_dirs !== "false";
+
+  const root = resolveVolumeRoot(state, volume);
+  const dir = resolveUnderRoot(root, targetDir);
+
+  if (createDirs) await ensureDir(dir);
+
+  const results: UploadedFile[] = [];
+  for (const file of parts.files) {
+    const target = resolveUnderRoot(root, path.join(targetDir, file.filename));
+    await fs.writeFile(target, file.data);
+    results.push({
+      fieldname: "file",
+      filename: file.filename,
+      path: target,
+      size: file.data.length,
+    });
+  }
+  return ok({ files: results });
+}

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,8 +1,10 @@
 import * as http from "node:http";
 import { URL } from "node:url";
+import { parseMultipart } from "./multipart.js";
 import { DaemonRouter } from "./router.js";
 import { sandagentRun } from "./routes/coding.js";
-import { fail } from "./utils.js";
+import { fsUpload } from "./routes/fs.js";
+import { AppError, type AppState, fail } from "./utils.js";
 
 export interface DaemonConfig {
   host: string;
@@ -13,6 +15,10 @@ export interface DaemonConfig {
 export function createDaemon(config: DaemonConfig): http.Server {
   const router = new DaemonRouter({ root: config.root });
   const env = process.env as Record<string, string>;
+  const state: AppState = {
+    root: config.root,
+    volumesRoot: `${config.root}/volumes`,
+  };
 
   return http.createServer(async (req, res) => {
     const method = req.method ?? "GET";
@@ -26,6 +32,31 @@ export function createDaemon(config: DaemonConfig): http.Server {
     if (method === "POST" && pathname === "/api/coding/run") {
       const body = JSON.parse((await readBody(req)) || "{}");
       return sandagentRun(body, res, env);
+    }
+
+    // Multipart upload: /api/fs/upload
+    if (method === "POST" && pathname === "/api/fs/upload") {
+      try {
+        const ct = req.headers["content-type"] ?? "";
+        if (!ct.includes("multipart/form-data")) {
+          res.writeHead(400, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify(fail("content-type must be multipart/form-data")),
+          );
+          return;
+        }
+        const raw = await readBodyRaw(req);
+        const parts = parseMultipart(ct, raw);
+        const result = await fsUpload(state, parts);
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        const status = err instanceof AppError ? err.status : 500;
+        const msg = err instanceof Error ? err.message : String(err);
+        res.writeHead(status, { "Content-Type": "application/json" });
+        res.end(JSON.stringify(fail(msg)));
+      }
+      return;
     }
 
     // Standard JSON routes
@@ -47,6 +78,15 @@ function readBody(req: http.IncomingMessage): Promise<string> {
     const chunks: Buffer[] = [];
     req.on("data", (c) => chunks.push(c));
     req.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    req.on("error", reject);
+  });
+}
+
+function readBodyRaw(req: http.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
     req.on("error", reject);
   });
 }


### PR DESCRIPTION
## Summary

Add `POST /api/fs/upload` endpoint for multipart/form-data file uploads to the daemon.

## Changes

- **`apps/daemon/src/multipart.ts`** — Zero-dependency multipart/form-data parser
- **`apps/daemon/src/routes/fs.ts`** — `fsUpload` handler with volume isolation support
- **`apps/daemon/src/server.ts`** — Wire upload route into Node.js HTTP server
- **`apps/daemon/src/nextjs.ts`** — Wire upload route into Next.js handler
- **`apps/daemon/README.md`** — API documentation for the upload endpoint

## Usage

```bash
# Single file
curl -X POST http://localhost:3080/api/fs/upload -F "path=uploads" -F "file=@local-file.txt"

# Multiple files
curl -X POST http://localhost:3080/api/fs/upload -F "path=data" -F "file=@a.csv" -F "file=@b.png"

# With volume isolation
curl -X POST http://localhost:3080/api/fs/upload -F "volume=vol-001" -F "file=@readme.md"
```