### PR TITLE
feat(ci): add workflow_dispatch trigger to publish-docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,12 @@ on:
       - "Release on Tag"
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g., v1.0.0)'
+        required: true
+        type: string
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -17,8 +23,8 @@ jobs:
       contents: read
     # Only run when the Release workflow succeeded AND was triggered by a semver tag (v*.*.*)
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'v')
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v'))
 
     steps:
       - name: Checkout Repo
@@ -26,7 +32,7 @@ jobs:
         with:
           # Check out the exact version tag. The job-level 'if' already
           # ensures head_branch is a v*.*.* tag (trusted maintainer ref).
-          ref: refs/tags/${{ github.event.workflow_run.head_branch }}
+          ref: refs/tags/${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
       - name: Extract version from tag
@@ -34,7 +40,7 @@ jobs:
         run: |
           # Use the head_branch from the triggering workflow_run event as the primary
           # source of truth (it is the git tag that triggered "Release on Tag").
-          TAG="${{ github.event.workflow_run.head_branch }}"
+          TAG="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}"
 
           # Cross-check: if a semver tag points at HEAD, prefer that (handles edge
           # cases where head_branch contains unexpected values).

--- a/docs/changelog/2026-03-26-publish-docker-workflow-dispatch.md
+++ b/docs/changelog/2026-03-26-publish-docker-workflow-dispatch.md
@@ -1,0 +1,14 @@
+# Add `workflow_dispatch` to Docker Publish Workflow
+
+Date: 2026-03-26
+
+## Overview
+
+Added the ability to manually trigger the `.github/workflows/publish-docker.yml` workflow via GitHub's `workflow_dispatch` event.
+
+## Changes
+
+- Added `workflow_dispatch` to the `on:` triggers for `.github/workflows/publish-docker.yml`.
+- Defined a `tag` input for `workflow_dispatch` so users can specify the semver tag to build.
+- Updated the job-level `if` condition to allow the job to run when manually dispatched, in addition to the existing tag-based trigger from the Release workflow.
+- Updated the "Checkout Repo" and "Extract version from tag" steps to use `inputs.tag` when manually dispatched, falling back to `github.event.workflow_run.head_branch` for the automated trigger.


### PR DESCRIPTION
## Summary

Add `workflow_dispatch` trigger to the Docker publish workflow, allowing manual builds with a specified tag.

## Changes

- Added `workflow_dispatch` to `.github/workflows/publish-docker.yml` with a required `tag` input
- Updated job `if` condition to run on both manual dispatch and automated release triggers
- Updated checkout and version extraction steps to use `inputs.tag` when manually dispatched, falling back to `github.event.workflow_run.head_branch` for automated runs

## Why

Enables re-running Docker builds for a specific tag without re-triggering the full release workflow — useful for debugging build failures or rebuilding images.