### PR TITLE
fix(daemon): volume root compatibility and path resolution

### DIFF
--- a/apps/daemon/src/utils.ts
+++ b/apps/daemon/src/utils.ts
@@ -1,5 +1,6 @@
 // Shared types and utilities
 
+import { existsSync } from "node:fs";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
@@ -26,9 +27,41 @@ export interface AppState {
  * Resolve volume root: if volume given, use volumesRoot/volume; otherwise use root.
  */
 export function resolveVolumeRoot(state: AppState, volume?: string): string {
-  if (!volume) return state.root;
-  validateVolumeName(volume);
-  return path.join(state.volumesRoot, volume);
+  const normalizedRoot = path.resolve(state.root);
+  if (!volume) return state.root;  
+  //if (!volume) return normalizedRoot;
+  const normalizedVolume = normalizeVolumeName(volume);
+  validateVolumeName(normalizedVolume);
+  const scopedVolumeRoot = path.resolve(state.volumesRoot, normalizedVolume);
+
+  const mountVolumeRoot = path.resolve(path.sep, normalizedVolume);
+  if (
+    isWellKnownMountVolume(normalizedVolume) &&
+    existsSync(mountVolumeRoot) &&
+    (volume.startsWith("/") || !existsSync(scopedVolumeRoot))
+  ) {
+    return mountVolumeRoot;
+  }
+
+  // Backward compatibility:
+  // if SANDAGENT_ROOT already points to the requested volume root
+  // (e.g. root=/agent and volume=agent), prefer root over root/volumes/agent.
+  if (
+    path.basename(normalizedRoot) === normalizedVolume &&
+    !existsSync(scopedVolumeRoot)
+  ) {
+    return normalizedRoot;
+  }
+
+  return scopedVolumeRoot;
+}
+
+function normalizeVolumeName(name: string): string {
+  return name.replace(/^\/+/, "");
+}
+
+function isWellKnownMountVolume(name: string): boolean {
+  return name === "agent" || name === "space";
 }
 
 /**

--- a/apps/daemon/src/utils.ts
+++ b/apps/daemon/src/utils.ts
@@ -28,8 +28,7 @@ export interface AppState {
  */
 export function resolveVolumeRoot(state: AppState, volume?: string): string {
   const normalizedRoot = path.resolve(state.root);
-  if (!volume) return state.root;  
-  //if (!volume) return normalizedRoot;
+  if (!volume) return state.root;
   const normalizedVolume = normalizeVolumeName(volume);
   validateVolumeName(normalizedVolume);
   const scopedVolumeRoot = path.resolve(state.volumesRoot, normalizedVolume);

--- a/docs/changelog/2026-04-05-daemon-volume-root-compat.md
+++ b/docs/changelog/2026-04-05-daemon-volume-root-compat.md
@@ -1,0 +1,9 @@
+## Daemon volume root compatibility fix
+
+- Fixed `resolveVolumeRoot()` in `apps/daemon/src/utils.ts` to avoid double-nesting volume paths when `SANDAGENT_ROOT` already points to a specific volume directory (for example `root=/agent` with `volume=agent`).
+- Added a compatibility fallback that returns `root` instead of `root/volumes/<volume>` when the requested volume name matches the root directory name and the nested volume path does not exist.
+- Added an integration regression test in `apps/daemon/src/__tests__/daemon.test.ts` to verify fs read/write APIs succeed in this configuration.
+- Added support for leading-slash volume input (for example `/agent` and `/space`) by normalizing to a volume name before validation and resolution.
+- Added mount-aware resolution for well-known sandbox mounts: when `/agent` or `/space` exists, daemon routes these volumes to those absolute directories (with existing scoped-volume behavior still used as fallback).
+- Added a regression test to verify leading-slash volume values resolve correctly.
+- Cleaned formatting in `apps/daemon/src/utils.ts` for `resolveVolumeRoot()` to satisfy formatter checks.


### PR DESCRIPTION
## Summary
- Update `resolveVolumeRoot` to handle backward compatibility correctly when `SANDAGENT_ROOT` points to the requested volume.
- Accept leading slashes in volume names.
- Improve test coverage for volume name resolutions.
- Comment out unused coding run endpoints.

## Test plan
- Run tests in `apps/daemon/src/__tests__/daemon.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)