### PR TITLE
feat(docker): make CDP startup conditional via ENABLE_CDP

### DIFF
--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -106,7 +106,7 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'bunny-agent-daemon &' \
-    'start-cdp' \
+    '[ "$ENABLE_CDP" != "false" ] && start-cdp' \
     'exec "$@"' > /usr/local/bin/bunny-entrypoint && \
     chmod +x /usr/local/bin/bunny-entrypoint && \
     mkdir -p /etc/bunny-agent-init.d

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -93,7 +93,7 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'sandagent-daemon &' \
-    'start-cdp' \
+    '[ "$ENABLE_CDP" != "false" ] && start-cdp' \
     'exec "$@"' > /usr/local/bin/sandagent-entrypoint && \
     chmod +x /usr/local/bin/sandagent-entrypoint
 

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -91,7 +91,7 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'sandagent-daemon &' \
-    'start-cdp' \
+    '[ "$ENABLE_CDP" != "false" ] && start-cdp' \
     'exec "$@"' > /usr/local/bin/sandagent-entrypoint && \
     chmod +x /usr/local/bin/sandagent-entrypoint
 ENV NODE_PATH=/opt/sandagent/node_modules


### PR DESCRIPTION
## Changes

Make CDP (Chrome DevTools Protocol) startup conditional in all Docker images.

- CDP starts by default (backward compatible)
- Set `ENABLE_CDP=false` to skip CDP startup
- Applied to: `Dockerfile`, `Dockerfile.template`, `Dockerfile.local`

## Usage

```bash
# CDP disabled
docker run -e ENABLE_CDP=false vikadata/bunny-agent

# CDP enabled (default, no change needed)
docker run vikadata/bunny-agent
```