### PR TITLE
feat(daemon): add created_at and modified_at to fsStat response

### DIFF
--- a/apps/daemon/src/__tests__/daemon.test.ts
+++ b/apps/daemon/src/__tests__/daemon.test.ts
@@ -69,6 +69,12 @@ describe("fs", () => {
     expect(r.ok).toBe(true);
     expect(r.data.is_dir).toBe(false);
     expect(r.data.size).toBe(5);
+    expect(
+      typeof r.data.created_at === "string" || r.data.created_at === null,
+    ).toBe(true);
+    expect(
+      typeof r.data.modified_at === "string" || r.data.modified_at === null,
+    ).toBe(true);
   });
 
   it("exists true/false", async () => {

--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -120,10 +120,17 @@ export async function fsStat(state: AppState, q: PathQuery) {
   const root = resolveVolumeRoot(state, q.volume);
   const target = resolveUnderRoot(root, q.path);
   const stat = await fs.stat(target);
+  const created_at =
+    msToIsoOrNull((stat as unknown as { birthtimeMs?: number }).birthtimeMs) ??
+    msToIsoOrNull((stat as unknown as { ctimeMs?: number }).ctimeMs);
   return ok({
     path: target,
     is_dir: stat.isDirectory(),
     size: stat.isFile() ? stat.size : 0,
+    created_at,
+    modified_at: msToIsoOrNull(
+      (stat as unknown as { mtimeMs?: number }).mtimeMs,
+    ),
   });
 }
 


### PR DESCRIPTION
## Summary
- Includes `created_at` and `modified_at` timestamps in the filesystem stat route response for the daemon.
- Adds corresponding assertions to the daemon tests to ensure correct output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)