### PR TITLE
fix(error): stop propagating '[object Object]' in daemon streams

### DIFF
--- a/apps/daemon/src/__tests__/coding.test.ts
+++ b/apps/daemon/src/__tests__/coding.test.ts
@@ -206,7 +206,10 @@ describe("coding/run error handling", () => {
 
     const err = JSON.parse(payloads[0]);
     expect(err.type).toBe("error");
-    expect(err.errorText).toBe("runner exploded");
+    expect(JSON.parse(err.errorText)).toMatchObject({
+      name: "Error",
+      message: "runner exploded",
+    });
 
     const finish = JSON.parse(payloads[1]);
     expect(finish.type).toBe("finish");
@@ -226,7 +229,10 @@ describe("coding/run error handling", () => {
 
     const err = JSON.parse(payloads[0]);
     expect(err.type).toBe("error");
-    expect(err.errorText).toBe("runner exploded");
+    expect(JSON.parse(err.errorText)).toMatchObject({
+      name: "Error",
+      message: "runner exploded",
+    });
   });
 });
 

--- a/apps/daemon/src/nextjs.ts
+++ b/apps/daemon/src/nextjs.ts
@@ -68,8 +68,7 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
         return Response.json(result);
       } catch (err) {
         const status = err instanceof AppError ? err.status : 500;
-        const msg =
-          err instanceof Error ? err.message : formatUnknownError(err);
+        const msg = formatUnknownError(err);
         return Response.json(fail(msg), { status });
       }
     }
@@ -98,8 +97,7 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
         });
       } catch (err) {
         const status = err instanceof AppError ? err.status : 500;
-        const msg =
-          err instanceof Error ? err.message : formatUnknownError(err);
+        const msg = formatUnknownError(err);
         return Response.json(fail(msg), { status });
       }
     }

--- a/apps/daemon/src/router.ts
+++ b/apps/daemon/src/router.ts
@@ -57,9 +57,7 @@ export class DaemonRouter {
           }
           return {
             status: 500,
-            body: fail(
-              err instanceof Error ? err.message : formatUnknownError(err),
-            ),
+            body: fail(formatUnknownError(err)),
           };
         }
       }

--- a/apps/daemon/src/routes/coding.ts
+++ b/apps/daemon/src/routes/coding.ts
@@ -80,7 +80,7 @@ export async function bunnyAgentRun(
       res.write(chunk);
     }
   } catch (err) {
-    const msg = err instanceof Error ? err.message : formatUnknownError(err);
+    const msg = formatUnknownError(err);
     // Keep output format consistent with runner-cli (SSE `data:` events),
     // so the SDK can parse errors uniformly.
     res.write(`data: ${JSON.stringify({ type: "error", errorText: msg })}\n\n`);
@@ -138,8 +138,7 @@ export function codingRunStream(
           controller.enqueue(encoder.encode(chunk));
         }
       } catch (err) {
-        const msg =
-          err instanceof Error ? err.message : formatUnknownError(err);
+        const msg = formatUnknownError(err);
         controller.enqueue(
           encoder.encode(
             `data: ${JSON.stringify({ type: "error", errorText: msg })}\n\n` +

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -68,8 +68,7 @@ export function createDaemon(config: DaemonConfig): http.Server {
           res.end(JSON.stringify(result));
         } catch (err) {
           const status = err instanceof AppError ? err.status : 500;
-          const msg =
-            err instanceof Error ? err.message : formatUnknownError(err);
+          const msg = formatUnknownError(err);
           res.writeHead(status, { "Content-Type": "application/json" });
           res.end(JSON.stringify(fail(msg)));
         }
@@ -98,8 +97,7 @@ export function createDaemon(config: DaemonConfig): http.Server {
           res.end(buffer);
         } catch (err) {
           const status = err instanceof AppError ? err.status : 500;
-          const msg =
-            err instanceof Error ? err.message : formatUnknownError(err);
+          const msg = formatUnknownError(err);
           res.writeHead(status, { "Content-Type": "application/json" });
           res.end(JSON.stringify(fail(msg)));
         }
@@ -139,8 +137,7 @@ export function createDaemon(config: DaemonConfig): http.Server {
           sendJson(res, err.status, fail(err.message));
         } else {
           console.error("Unhandled request error:", err);
-          const msg =
-            err instanceof Error ? err.message : formatUnknownError(err);
+          const msg = formatUnknownError(err);
           sendJson(res, 500, fail(`Internal server error: ${msg}`));
         }
       } else {

--- a/apps/daemon/src/utils.ts
+++ b/apps/daemon/src/utils.ts
@@ -23,10 +23,39 @@ export function fail(error: string): ApiEnvelope<null> {
  * Avoids noisy "[object Object]" in logs and API error payloads.
  */
 export function formatUnknownError(err: unknown): string {
+  const isObjectToStringMessage = (msg: string): boolean =>
+    /^\[object [^\]]+\]$/.test(msg.trim());
+
+  const collectErrorExtras = (e: Error): Record<string, unknown> => {
+    const extra: Record<string, unknown> = {};
+
+    for (const key of Object.getOwnPropertyNames(e)) {
+      if (key === "name" || key === "message" || key === "stack") continue;
+      extra[key] = (e as unknown as Record<string, unknown>)[key];
+    }
+
+    // Some SDKs put diagnostics on inherited properties; keep common keys.
+    for (const key of ["code", "status", "response", "body", "data"]) {
+      if (key in (e as unknown as Record<string, unknown>) && !(key in extra)) {
+        extra[key] = (e as unknown as Record<string, unknown>)[key];
+      }
+    }
+
+    return extra;
+  };
+
   const errorRecord = (e: Error): Record<string, unknown> => ({
     name: e.name,
     message: e.message,
+    ...(isObjectToStringMessage(e.message)
+      ? {
+          note: "Upstream error message was stringified object",
+        }
+      : {}),
     ...(e.cause !== undefined ? { cause: formatUnknownError(e.cause) } : {}),
+    ...(Object.keys(collectErrorExtras(e)).length > 0
+      ? { extra: collectErrorExtras(e) }
+      : {}),
   });
 
   if (err == null) return String(err);

--- a/apps/web/app/(example)/example/page.tsx
+++ b/apps/web/app/(example)/example/page.tsx
@@ -124,7 +124,7 @@ function ChatMessage({
               const filePart = part as import("ai").FileUIPart;
               if (filePart.mediaType?.startsWith("image/")) {
                 return (
-                  // eslint-disable-next-line @next/next/no-img-element
+                  // biome-ignore lint/performance/noImgElement: Attachment URLs can be blob/data/external and bypass Next image optimization.
                   <img
                     key={key}
                     src={filePart.url}

--- a/packages/manager/src/error-serialize.ts
+++ b/packages/manager/src/error-serialize.ts
@@ -3,12 +3,34 @@
  * Avoids "[object Object]" when callers throw plain objects or Errors with empty messages.
  */
 function errorRecord(err: Error): Record<string, unknown> {
+  const isObjectToStringMessage = /^\[object [^\]]+\]$/.test(
+    err.message.trim(),
+  );
+
+  const extra: Record<string, unknown> = {};
+  for (const key of Object.getOwnPropertyNames(err)) {
+    if (key === "name" || key === "message" || key === "stack") continue;
+    extra[key] = (err as unknown as Record<string, unknown>)[key];
+  }
+  // Some SDKs expose diagnostics on inherited properties.
+  for (const key of ["code", "status", "response", "body", "data"]) {
+    if (key in (err as unknown as Record<string, unknown>) && !(key in extra)) {
+      extra[key] = (err as unknown as Record<string, unknown>)[key];
+    }
+  }
+
   return {
     name: err.name,
     message: err.message,
+    ...(isObjectToStringMessage
+      ? {
+          note: "Upstream error message was stringified object",
+        }
+      : {}),
     ...(err.cause !== undefined
       ? { cause: formatUnknownError(err.cause) }
       : {}),
+    ...(Object.keys(extra).length > 0 ? { extra } : {}),
   };
 }
 

--- a/packages/runner-harness/src/stream.ts
+++ b/packages/runner-harness/src/stream.ts
@@ -44,6 +44,39 @@ export type RunnerChunk =
   // passthrough for anything else
   | { type: string; [key: string]: unknown };
 
+function formatUnknownError(err: unknown): string {
+  if (err == null) return String(err);
+  if (typeof err === "string") return err;
+  if (typeof err === "number" || typeof err === "boolean") return String(err);
+  if (err instanceof Error) {
+    const extra: Record<string, unknown> = {};
+    for (const key of Object.getOwnPropertyNames(err)) {
+      if (key === "name" || key === "message" || key === "stack") continue;
+      extra[key] = (err as unknown as Record<string, unknown>)[key];
+    }
+    try {
+      return JSON.stringify({
+        name: err.name,
+        message: err.message,
+        ...(Object.keys(extra).length > 0 ? { extra } : {}),
+        ...(err.cause !== undefined
+          ? { cause: formatUnknownError(err.cause) }
+          : {}),
+      });
+    } catch {
+      return err.message || err.name || "Error";
+    }
+  }
+  if (typeof err === "object") {
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return "Unserializable object error";
+    }
+  }
+  return String(err);
+}
+
 // ---------------------------------------------------------------------------
 // SSE line parser
 // ---------------------------------------------------------------------------
@@ -99,7 +132,7 @@ export async function* parseRunnerStream(
   } catch (e: unknown) {
     yield {
       type: "error",
-      errorText: e instanceof Error ? e.message : String(e),
+      errorText: formatUnknownError(e),
     };
   }
 }

--- a/packages/sdk/src/__tests__/bunny-agent-language-model-errors.test.ts
+++ b/packages/sdk/src/__tests__/bunny-agent-language-model-errors.test.ts
@@ -54,8 +54,9 @@ describe("stringifyStreamErrorField", () => {
 });
 
 describe("formatErrorForLog", () => {
-  it("returns Error.message for a simple Error", () => {
-    expect(formatErrorForLog(new Error("simple"))).toBe("simple");
+  it("returns a structured string for a simple Error", () => {
+    const parsed = JSON.parse(formatErrorForLog(new Error("simple")));
+    expect(parsed).toMatchObject({ name: "Error", message: "simple" });
   });
 
   it("flattens nested Error causes with ' | cause: ' separator", () => {
@@ -64,12 +65,19 @@ describe("formatErrorForLog", () => {
     const outer = new Error("outer", { cause: middle });
 
     const out = formatErrorForLog(outer);
-    expect(out).toBe("outer | cause: middle layer | cause: root cause");
+    const [outerPart, middlePart, innerPart] = out.split(" | cause: ");
+    expect(JSON.parse(outerPart)).toMatchObject({ message: "outer" });
+    expect(JSON.parse(middlePart)).toMatchObject({ message: "middle layer" });
+    expect(JSON.parse(innerPart)).toMatchObject({ message: "root cause" });
   });
 
-  it("stops walking causes once it hits a non-Error cause", () => {
+  it("includes non-Error cause details from the formatted outer Error", () => {
     const outer = new Error("outer", { cause: { reason: "x" } });
-    expect(formatErrorForLog(outer)).toBe("outer");
+    const out = formatErrorForLog(outer);
+    const parsed = JSON.parse(out);
+    expect(parsed.message).toBe("outer");
+    expect(typeof parsed.cause).toBe("string");
+    expect(JSON.parse(parsed.cause)).toEqual({ reason: "x" });
   });
 
   it("delegates non-Error values to formatUnknownError (no '[object Object]')", () => {

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -43,10 +43,10 @@ export interface BunnyAgentLanguageModelOptions {
  */
 export function formatErrorForLog(error: unknown): string {
   if (error instanceof Error) {
-    const parts = [error.message];
+    const parts = [formatUnknownError(error)];
     let cause: unknown = error.cause;
     while (cause instanceof Error) {
-      parts.push(cause.message);
+      parts.push(formatUnknownError(cause));
       cause = cause.cause;
     }
     return parts.join(" | cause: ");


### PR DESCRIPTION
## Summary
- normalize daemon error responses to always use `formatUnknownError(err)` instead of special-casing `err.message`
- enrich manager/daemon error serialization with attached diagnostic fields (`status`, `code`, `response`, `body`, `data`) so upstream SDK failures remain debuggable
- align SDK/runner-harness stream logging and tests to expect structured error payloads, preventing `[object Object]` from resurfacing in SSE parsing paths

## Test plan
- [x] `pnpm run -w lint`
- [x] `pnpm --filter @bunny-agent/sdk test -- bunny-agent-language-model-errors`
- [x] `pnpm --filter @bunny-agent/manager test -- error-serialize`
- [x] `pnpm --filter @bunny-agent/daemon test`


Made with [Cursor](https://cursor.com)