### PR TITLE
fix(image-tools): drop full provider response from details to shrink session logs

### DIFF
--- a/packages/runner-harness/src/tools/image-generate.ts
+++ b/packages/runner-harness/src/tools/image-generate.ts
@@ -2,17 +2,23 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, extname, join } from "node:path";
 import type { ToolDefinition } from "./types.js";
 
+export interface ImageGenerationUsage {
+  total_tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  input_tokens_details?: { image_tokens?: number; text_tokens?: number };
+}
+
+/**
+ * Image tool result `details`. The full provider response is intentionally NOT
+ * included: it can carry a multi-MB base64 image payload that, once persisted
+ * by the agent runtime into its session log, bloats the file (the same image
+ * is already saved to disk via `filePath`). Keep only the file path and a
+ * compact usage record.
+ */
 export interface ImageToolDetails {
   filePath: string | undefined;
-  response: {
-    data: Array<{ b64_json?: string; url?: string; revised_prompt?: string }>;
-    usage?: {
-      total_tokens?: number;
-      input_tokens?: number;
-      output_tokens?: number;
-      input_tokens_details?: { image_tokens?: number; text_tokens?: number };
-    };
-  };
+  usage?: ImageGenerationUsage;
 }
 
 async function resolveB64(item: {
@@ -117,6 +123,7 @@ export function buildImageGenerateTool(
           );
         const json = (await res.json()) as {
           data: Array<{ b64_json?: string; url?: string }>;
+          usage?: ImageGenerationUsage;
         };
         const saved = await saveImageItem(json.data?.[0] ?? {}, filePath);
         return {
@@ -126,7 +133,10 @@ export function buildImageGenerateTool(
               text: saved ?? "Generated but could not be saved.",
             },
           ],
-          details: { filePath: saved, response: json },
+          details: {
+            filePath: saved,
+            ...(json.usage != null ? { usage: json.usage } : {}),
+          } satisfies ImageToolDetails,
         };
       } catch (e: unknown) {
         return {

--- a/packages/runner-harness/src/tools/index.ts
+++ b/packages/runner-harness/src/tools/index.ts
@@ -1,6 +1,9 @@
 export { buildBashTool } from "./bash-execute.js";
 export { buildReadFileTool, buildWriteFileTool } from "./file-ops.js";
-export type { ImageToolDetails } from "./image-generate.js";
+export type {
+  ImageGenerationUsage,
+  ImageToolDetails,
+} from "./image-generate.js";
 export { buildImageGenerateTool, saveImageItem } from "./image-generate.js";
 export type { SearchResult, ToolDefinition } from "./types.js";
 export { buildWebFetchTool } from "./web-fetch.js";

--- a/packages/runner-pi/src/__tests__/image-tools.test.ts
+++ b/packages/runner-pi/src/__tests__/image-tools.test.ts
@@ -113,37 +113,7 @@ describe("buildImageGenerateTool", () => {
     vi.clearAllMocks();
   });
 
-  it("returns details.response with full API response including usage", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => baseApiResponse,
-    });
-
-    const tool = buildImageGenerateTool(
-      "/tmp",
-      "gpt-image-1",
-      "https://api.openai.com",
-      "sk-test",
-    );
-
-    const result = await tool.execute(
-      "call_1",
-      { prompt: "a cute cat" },
-      new AbortController().signal,
-      vi.fn(),
-      mockCtx,
-    );
-
-    expect(result.details).toBeDefined();
-    const details = result.details as ImageToolDetails;
-    expect(details.response).toEqual(baseApiResponse);
-    expect(details.response.usage?.input_tokens).toBe(22);
-    expect(details.response.usage?.output_tokens).toBe(1120);
-    expect(details.response.usage?.total_tokens).toBe(1404);
-    expect(details.usage?.raw["gpt-image-1"]).toEqual(baseApiResponse.usage);
-  });
-
-  it("details.response keeps full image response payload", async () => {
+  it("extracts provider usage into details.usage.raw without echoing the full response", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => baseApiResponse,
@@ -164,10 +134,12 @@ describe("buildImageGenerateTool", () => {
       mockCtx,
     );
 
-    expect((result.details as ImageToolDetails).response).toEqual(
-      baseApiResponse,
-    );
-    expect((result.details as ImageToolDetails).filePath).toContain("cat.png");
+    const details = result.details as ImageToolDetails;
+    expect(details.usage?.raw["gpt-image-1"]).toEqual(baseApiResponse.usage);
+    expect(details.filePath).toContain("cat.png");
+    // The full provider response (with multi-MB b64_json) must NOT be echoed
+    // back into details — it would bloat the persisted session JSONL.
+    expect(details).not.toHaveProperty("response");
   });
 
   it("returns error content and undefined details on API failure", async () => {

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -623,14 +623,6 @@ describe("createPiRunner", () => {
                   },
                 },
               },
-              response: {
-                data: [{ b64_json: "" }],
-                usage: {
-                  total_tokens: 1404,
-                  input_tokens: 22,
-                  output_tokens: 1120,
-                },
-              },
             },
           },
           isError: false,
@@ -779,14 +771,6 @@ describe("createPiRunner", () => {
                     input_tokens: 20,
                     output_tokens: 110,
                   },
-                },
-              },
-              response: {
-                data: [{ b64_json: "" }],
-                usage: {
-                  total_tokens: 130,
-                  input_tokens: 20,
-                  output_tokens: 110,
                 },
               },
             },

--- a/packages/runner-pi/src/image-tools.ts
+++ b/packages/runner-pi/src/image-tools.ts
@@ -2,7 +2,10 @@
  * Image generation tool for bunny-agent pi runner.
  *
  * Reuses the chat model's provider config (baseUrl + apiKey) — only the model ID differs.
- * Returns filePath and the raw API response as details.
+ * Returns filePath and a compact usage payload as details. The full provider response
+ * is intentionally NOT returned: it can contain a multi-MB base64 image payload that
+ * pi-coding-agent persists into the session JSONL, bloating session files and risking
+ * the resume-skip threshold (see SANDAGENT_MAX_SESSION_BYTES).
  */
 
 import { mkdirSync, writeFileSync } from "node:fs";
@@ -39,8 +42,6 @@ export type ImageToolDetails = ToolDetailsWithUsage<
   ImageGenerationUsage,
   {
     filePath: string | undefined;
-    /** Full provider JSON (may include `usage` from the vendor). */
-    response: ImageGenerationResponse;
   }
 >;
 
@@ -379,7 +380,6 @@ export function buildImageGenerateTool(
             ...(json.usage != null
               ? { usage: { raw: { [imageModelId]: json.usage } } }
               : {}),
-            response: json,
           } satisfies ImageToolDetails,
         };
       } catch (e: unknown) {
@@ -649,7 +649,6 @@ export function buildImageEditTool(
             ...(json.usage != null
               ? { usage: { raw: { [imageModelId]: json.usage } } }
               : {}),
-            response: json,
           } satisfies ImageToolDetails,
         };
       } catch (e: unknown) {


### PR DESCRIPTION
## Summary

- The `generate_image` / `edit_image` tools in both `runner-pi` and `runner-harness` were returning the full provider JSON (including the multi-MB base64 image payload) as `details.response`. The agent runtime serializes tool results into the session JSONL, so a single image generation inflated the session file by ~2.3MB — quickly tripping the 10MB `SANDAGENT_MAX_SESSION_BYTES` resume-skip threshold.
- The image is already saved to disk via `filePath`, and no consumer (`stream-converter`, `usage-metadata`, `apps/*`) ever read `details.response`. Drop it; keep `filePath` and a compact `usage` payload (the same one we were already extracting into `details.usage.raw[modelId]` for pi-runner).
- `runner-harness` got the same trim, plus a small consistency improvement: it now extracts provider `usage` into `details.usage` instead of discarding it.

## Test plan

- [x] `pnpm --filter @bunny-agent/runner-pi typecheck`
- [x] `pnpm --filter @bunny-agent/runner-pi test` — 97/97 pass
- [x] `pnpm --filter @bunny-agent/runner-harness typecheck` + build
- [x] `pnpm -r typecheck` across the whole monorepo
- [x] `pnpm -r test` across the whole monorepo
- [ ] Generate an image end-to-end and confirm the resulting `.jsonl` line is small (KB, not MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)