### PR TITLE
fix(daemon): handle fsList error on broken symlink

### DIFF
--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -71,12 +71,10 @@ export async function fsList(state: AppState, q: ListQuery) {
       const fullPath = path.join(target, e.name);
       const stat = await fs.stat(fullPath).catch(() => null);
       const created_at =
-        stat === null
-          ? null
-          : (msToIsoOrNull(
-              (stat as unknown as { birthtimeMs?: number }).birthtimeMs,
-            ) ??
-            msToIsoOrNull((stat as unknown as { ctimeMs?: number }).ctimeMs));
+        msToIsoOrNull(
+          (stat as unknown as { birthtimeMs?: number })?.birthtimeMs,
+        ) ??
+        msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
       return {
         name: e.name,
         path: fullPath,
@@ -121,15 +119,15 @@ export async function fsStat(state: AppState, q: PathQuery) {
   const target = resolveUnderRoot(root, q.path);
   const stat = await fs.stat(target);
   const created_at =
-    msToIsoOrNull((stat as unknown as { birthtimeMs?: number }).birthtimeMs) ??
-    msToIsoOrNull((stat as unknown as { ctimeMs?: number }).ctimeMs);
+    msToIsoOrNull((stat as unknown as { birthtimeMs?: number })?.birthtimeMs) ??
+    msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
   return ok({
     path: target,
     is_dir: stat.isDirectory(),
     size: stat.isFile() ? stat.size : 0,
     created_at,
     modified_at: msToIsoOrNull(
-      (stat as unknown as { mtimeMs?: number }).mtimeMs,
+      (stat as unknown as { mtimeMs?: number })?.mtimeMs,
     ),
   });
 }

--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -85,7 +85,7 @@ export async function fsList(state: AppState, q: ListQuery) {
         size: stat?.isFile() ? stat.size : 0,
         created_at,
         modified_at: msToIsoOrNull(
-          (stat as unknown as { mtimeMs?: number }).mtimeMs,
+          (stat as unknown as { mtimeMs?: number })?.mtimeMs,
         ),
       };
     }),

--- a/docs/changelog/2026-04-29-fix-fs-list.md
+++ b/docs/changelog/2026-04-29-fix-fs-list.md
@@ -1,0 +1,3 @@
+# 2026-04-29 - Fix fs/list symlink error
+
+- Fixed an issue in `fsList` where encountering a broken symlink would cause a "Cannot read properties of null (reading 'mtimeMs')" error, because `fs.stat` returns `null` but the code attempted to access `.mtimeMs` on it unconditionally.


### PR DESCRIPTION
## Summary
* Fixes `fsList` error encountered when encountering broken symlinks.

## Test plan
* Verified `fsList` works correctly when a broken symlink is present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)