### PR TITLE
fix(daemon): handle fsList error on broken symlink (#255)

### DIFF
--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -71,12 +71,10 @@ export async function fsList(state: AppState, q: ListQuery) {
       const fullPath = path.join(target, e.name);
       const stat = await fs.stat(fullPath).catch(() => null);
       const created_at =
-        stat === null
-          ? null
-          : (msToIsoOrNull(
-              (stat as unknown as { birthtimeMs?: number }).birthtimeMs,
-            ) ??
-            msToIsoOrNull((stat as unknown as { ctimeMs?: number }).ctimeMs));
+        msToIsoOrNull(
+          (stat as unknown as { birthtimeMs?: number })?.birthtimeMs,
+        ) ??
+        msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
       return {
         name: e.name,
         path: fullPath,
@@ -85,7 +83,7 @@ export async function fsList(state: AppState, q: ListQuery) {
         size: stat?.isFile() ? stat.size : 0,
         created_at,
         modified_at: msToIsoOrNull(
-          (stat as unknown as { mtimeMs?: number }).mtimeMs,
+          (stat as unknown as { mtimeMs?: number })?.mtimeMs,
         ),
       };
     }),
@@ -121,15 +119,15 @@ export async function fsStat(state: AppState, q: PathQuery) {
   const target = resolveUnderRoot(root, q.path);
   const stat = await fs.stat(target);
   const created_at =
-    msToIsoOrNull((stat as unknown as { birthtimeMs?: number }).birthtimeMs) ??
-    msToIsoOrNull((stat as unknown as { ctimeMs?: number }).ctimeMs);
+    msToIsoOrNull((stat as unknown as { birthtimeMs?: number })?.birthtimeMs) ??
+    msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
   return ok({
     path: target,
     is_dir: stat.isDirectory(),
     size: stat.isFile() ? stat.size : 0,
     created_at,
     modified_at: msToIsoOrNull(
-      (stat as unknown as { mtimeMs?: number }).mtimeMs,
+      (stat as unknown as { mtimeMs?: number })?.mtimeMs,
     ),
   });
 }

--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -73,8 +73,7 @@ export async function fsList(state: AppState, q: ListQuery) {
       const created_at =
         msToIsoOrNull(
           (stat as unknown as { birthtimeMs?: number })?.birthtimeMs,
-        ) ??
-        msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
+        ) ?? msToIsoOrNull((stat as unknown as { ctimeMs?: number })?.ctimeMs);
       return {
         name: e.name,
         path: fullPath,

--- a/apps/web/app/(example)/example/page.tsx
+++ b/apps/web/app/(example)/example/page.tsx
@@ -125,6 +125,7 @@ function ChatMessage({
               if (filePart.mediaType?.startsWith("image/")) {
                 return (
                   // eslint-disable-next-line @next/next/no-img-element
+                  // biome-ignore lint/performance/noImgElement: Intended for example
                   <img
                     key={key}
                     src={filePart.url}

--- a/docs/changelog/2026-04-29-fix-fs-list.md
+++ b/docs/changelog/2026-04-29-fix-fs-list.md
@@ -1,0 +1,3 @@
+# 2026-04-29 - Fix fs/list symlink error
+
+- Fixed an issue in `fsList` where encountering a broken symlink would cause a "Cannot read properties of null (reading 'mtimeMs')" error, because `fs.stat` returns `null` but the code attempted to access `.mtimeMs` on it unconditionally.


### PR DESCRIPTION
## Summary
* fix(daemon): fix fsList error on broken symlink

The `fsList` handler throws a "Cannot read properties of null" error when encountering a broken symlink because `fs.stat().catch(() => null)` evaluates to null, but `.mtimeMs` is accessed unconditionally. Added optional chaining (`?.mtimeMs`) to fix this.

* fix(daemon): safely access stat properties with optional chaining

Add optional chaining when accessing `birthtimeMs`, `ctimeMs`, and `mtimeMs` on `stat` objects in `fsList` and `fsStat` to avoid potential runtime errors if `stat` or the properties are undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)