### PR TITLE
fix: align image generation params and release CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - "release/**"
 
 jobs:
   ci:

--- a/docs/changelog/2026-05-06-generate-image-aspect-ratio.md
+++ b/docs/changelog/2026-05-06-generate-image-aspect-ratio.md
@@ -52,3 +52,19 @@ This sends `aspect_ratio: "3:4"` to the proxy, which forwards it to the Gemini I
 ## Follow-up: aspectRatio precedence
 
 After review, the tool now omits the default `size: "1024x1024"` whenever `aspectRatio` is provided. This prevents OpenAI-compatible proxies from prioritizing the square `size` value over Gemini's native `aspect_ratio` parameter. Requests for `aspectRatio: "3:4"` are sent unchanged as `aspect_ratio: "3:4"`.
+
+## Follow-up: supported size values
+
+The `size` schema was corrected to only expose supported values: `auto`, `1024x1024`, `1536x1024`, `1024x1536`, `256x256`, `512x512`, `1792x1024`, and `1024x1792`. Explicit supported `size` values are now preserved even when `aspectRatio` is also provided.
+
+## Follow-up: Gemini-supported aspect ratios
+
+The `aspectRatio` schema was expanded to include the full supported set for Gemini 2.5 Flash Image and Gemini 3 Pro Image: `1:1`, `3:2`, `2:3`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, and `21:9`.
+
+## Follow-up: K-resolution imageSize
+
+Added `imageSize` with `1K`, `2K`, and `4K` values for models that support K-resolution output. The request body now sends top-level `image_size` when provided and no longer adds the default `size: "1024x1024"` when `aspectRatio` or `imageSize` is present.
+
+## Follow-up: release branch CI
+
+Enabled CI for pull requests targeting `release/**` branches so release backports run the same build, typecheck, lint, and test workflow as `main` and `develop` pull requests.

--- a/packages/runner-harness/src/tools/image-generate.ts
+++ b/packages/runner-harness/src/tools/image-generate.ts
@@ -56,10 +56,11 @@ export function buildImageGenerateTool(
     description:
       "Generate an image from a text prompt. Saves to disk and returns the file path.",
     promptSnippet:
-      "generate_image(prompt, filename?, size?, aspectRatio?, quality?)",
+      "generate_image(prompt, filename?, size?, aspectRatio?, imageSize?, quality?)",
     promptGuidelines: [
       "Use when the user asks to create, draw, or visualize something.",
-      "For models like gemini-3-pro-image, use aspectRatio (e.g. '3:4') instead of size.",
+      "Use aspectRatio (e.g. '3:4') when the requested output needs specific proportions.",
+      "Use imageSize (e.g. '2K') when the user requests 1K, 2K, or 4K resolution.",
     ],
     parameters: {
       type: "object",
@@ -70,30 +71,43 @@ export function buildImageGenerateTool(
         size: {
           type: "string",
           enum: [
+            "auto",
+            "1024x1024",
+            "1536x1024",
+            "1024x1536",
             "256x256",
             "512x512",
-            "768x1024",
-            "1024x768",
-            "960x1280",
-            "1280x960",
-            "1024x1024",
             "1792x1024",
             "1024x1792",
-            "1280x1280",
-            "1568x1056",
-            "1056x1568",
-            "1472x1088",
-            "1088x1472",
-            "1728x960",
-            "960x1728",
           ],
+          description:
+            "Image dimensions. Supported values: auto, 1024x1024, 1536x1024, 1024x1536, " +
+            "256x256, 512x512, 1792x1024, 1024x1792.",
         },
         aspectRatio: {
           type: "string",
-          enum: ["1:1", "3:4", "4:3", "9:16", "16:9"],
+          enum: [
+            "1:1",
+            "3:2",
+            "2:3",
+            "3:4",
+            "4:3",
+            "4:5",
+            "5:4",
+            "9:16",
+            "16:9",
+            "21:9",
+          ],
           description:
-            "Image aspect ratio for models that support it (e.g. gemini-3-pro-image). " +
-            "Use instead of size: '3:4' (portrait), '4:3' (landscape), '9:16' (tall), '16:9' (wide).",
+            "Image aspect ratio. Use this instead of size for models that support it " +
+            "when exact proportions matter. Supported values: 1:1, 3:2, 2:3, 3:4, 4:3, " +
+            "4:5, 5:4, 9:16, 16:9, 21:9.",
+        },
+        imageSize: {
+          type: "string",
+          enum: ["1K", "2K", "4K"],
+          description:
+            "Image resolution for models that support K-resolution output. Use this for requests like 2K or 4K.",
         },
         quality: { type: "string", enum: ["standard", "hd"] },
       },
@@ -105,6 +119,7 @@ export function buildImageGenerateTool(
       const size = p.size as string | undefined;
       const quality = (p.quality as string) ?? "standard";
       const aspectRatio = p.aspectRatio as string | undefined;
+      const imageSize = p.imageSize as string | undefined;
       const rawFilename = p.filename as string | undefined;
       const filename = rawFilename
         ? extname(rawFilename)
@@ -128,7 +143,12 @@ export function buildImageGenerateTool(
               n: 1,
               quality,
               ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
-              ...(!aspectRatio ? { size: size ?? "1024x1024" } : {}),
+              ...(imageSize ? { image_size: imageSize } : {}),
+              ...(size
+                ? { size }
+                : !aspectRatio && !imageSize
+                  ? { size: "1024x1024" }
+                  : {}),
             }),
           },
         );

--- a/packages/runner-pi/src/__tests__/image-tools.test.ts
+++ b/packages/runner-pi/src/__tests__/image-tools.test.ts
@@ -24,6 +24,11 @@ const mockCtx = {} as Parameters<
   ReturnType<typeof buildImageGenerateTool>["execute"]
 >[4];
 
+function parseLastRequestBody(): Record<string, unknown> {
+  const callArgs = mockFetch.mock.calls[0]?.[1] as { body?: string };
+  return JSON.parse(callArgs.body ?? "{}") as Record<string, unknown>;
+}
+
 // ── saveImageItem ────────────────────────────────────────────────────
 
 describe("saveImageItem", () => {
@@ -168,14 +173,13 @@ describe("buildImageGenerateTool", () => {
     );
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const callArgs = mockFetch.mock.calls[0]?.[1] as { body?: string };
-    const body = JSON.parse(callArgs.body ?? "{}") as Record<string, unknown>;
+    const body = parseLastRequestBody();
     expect(body.aspect_ratio).toBe("3:4");
     expect(body).not.toHaveProperty("size");
     expect(body.model).toBe("gemini-3-pro-image");
   });
 
-  it("prioritizes aspect_ratio over an explicit size when aspectRatio is provided", async () => {
+  it("keeps explicit size alongside aspect_ratio when aspectRatio is provided", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => baseApiResponse,
@@ -193,7 +197,7 @@ describe("buildImageGenerateTool", () => {
       {
         prompt: "a mountain landscape",
         filename: "landscape.png",
-        size: "1024x1024",
+        size: "1024x1536",
         aspectRatio: "3:4",
       },
       new AbortController().signal,
@@ -202,9 +206,71 @@ describe("buildImageGenerateTool", () => {
     );
 
     expect(mockFetch).toHaveBeenCalledOnce();
-    const callArgs = mockFetch.mock.calls[0]?.[1] as { body?: string };
-    const body = JSON.parse(callArgs.body ?? "{}") as Record<string, unknown>;
+    const body = parseLastRequestBody();
     expect(body.aspect_ratio).toBe("3:4");
+    expect(body.size).toBe("1024x1536");
+  });
+
+  it("supports the extended portrait aspect ratios", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseApiResponse,
+    });
+
+    const tool = buildImageGenerateTool(
+      "/tmp",
+      "gemini-3-pro-image",
+      "https://api.example.com",
+      "sk-test",
+    );
+
+    await tool.execute(
+      "call_ar_45",
+      {
+        prompt: "a product poster",
+        filename: "poster.png",
+        aspectRatio: "4:5",
+      },
+      new AbortController().signal,
+      vi.fn(),
+      mockCtx,
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = parseLastRequestBody();
+    expect(body.aspect_ratio).toBe("4:5");
+  });
+
+  it("sends image_size with aspect_ratio for K-resolution requests", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => baseApiResponse,
+    });
+
+    const tool = buildImageGenerateTool(
+      "/tmp",
+      "gemini-3-pro-image",
+      "https://api.example.com",
+      "sk-test",
+    );
+
+    await tool.execute(
+      "call_ar_2k",
+      {
+        prompt: "a product poster",
+        filename: "poster.png",
+        aspectRatio: "3:4",
+        imageSize: "2K",
+      },
+      new AbortController().signal,
+      vi.fn(),
+      mockCtx,
+    );
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const body = parseLastRequestBody();
+    expect(body.aspect_ratio).toBe("3:4");
+    expect(body.image_size).toBe("2K");
     expect(body).not.toHaveProperty("size");
   });
 

--- a/packages/runner-pi/src/image-tools.ts
+++ b/packages/runner-pi/src/image-tools.ts
@@ -60,35 +60,43 @@ const generateImageSchema = {
     size: {
       type: "string",
       enum: [
+        "auto",
+        "1024x1024",
+        "1536x1024",
+        "1024x1536",
         "256x256",
         "512x512",
-        "768x1024",
-        "1024x768",
-        "960x1280",
-        "1280x960",
-        "1024x1024",
         "1792x1024",
         "1024x1792",
-        "1280x1280",
-        "1568x1056",
-        "1056x1568",
-        "1472x1088",
-        "1088x1472",
-        "1728x960",
-        "960x1728",
       ],
       description:
-        "Image dimensions. Common: 1024x1024 (square), 960x1280 / 768x1024 (portrait 3:4), " +
-        "1280x960 / 1024x768 (landscape 4:3), 1056x1568 (portrait), 1728x960 (wide), 960x1728 (tall). " +
-        "Use aspectRatio instead for models like gemini-3-pro-image.",
+        "Image dimensions. Supported values: auto, 1024x1024, 1536x1024, 1024x1536, " +
+        "256x256, 512x512, 1792x1024, 1024x1792.",
     },
     aspectRatio: {
       type: "string",
-      enum: ["1:1", "3:4", "4:3", "9:16", "16:9"],
+      enum: [
+        "1:1",
+        "3:2",
+        "2:3",
+        "3:4",
+        "4:3",
+        "4:5",
+        "5:4",
+        "9:16",
+        "16:9",
+        "21:9",
+      ],
       description:
         "Image aspect ratio. Use this instead of size for models that support it " +
-        "(e.g. gemini-3-pro-image). Common values: '3:4' (portrait), '4:3' (landscape), " +
-        "'9:16' (tall), '16:9' (wide), '1:1' (square).",
+        "when exact proportions matter. Supported values: 1:1, 3:2, 2:3, 3:4, 4:3, " +
+        "4:5, 5:4, 9:16, 16:9, 21:9.",
+    },
+    imageSize: {
+      type: "string",
+      enum: ["1K", "2K", "4K"],
+      description:
+        "Image resolution for models that support K-resolution output. Use this for requests like 2K or 4K.",
     },
     quality: {
       type: "string",
@@ -325,12 +333,13 @@ export function buildImageGenerateTool(
     description:
       "Generate an image from a text prompt. Saves the image to disk and returns the file path.",
     promptSnippet:
-      "generate_image(prompt, filename?, size?, aspectRatio?, quality?) - generate an image from text",
+      "generate_image(prompt, filename?, size?, aspectRatio?, imageSize?, quality?) - generate an image from text",
     promptGuidelines: [
       "Use generate_image when the user asks to create, draw, or visualize something.",
       "Be descriptive in the prompt — more detail produces better results.",
       "Provide a filename with extension, e.g. 'cat.png'.",
-      "For models like gemini-3-pro-image, use aspectRatio (e.g. '3:4') instead of size to control proportions.",
+      "Use aspectRatio (e.g. '3:4') when the requested output needs specific proportions.",
+      "Use imageSize (e.g. '2K') when the user requests 1K, 2K, or 4K resolution.",
     ],
     // biome-ignore lint/suspicious/noExplicitAny: plain JSON Schema compatible with TypeBox TSchema
     parameters: generateImageSchema as any,
@@ -340,6 +349,7 @@ export function buildImageGenerateTool(
       const size = p.size as string | undefined;
       const quality = (p.quality as string) ?? "auto";
       const aspectRatio = p.aspectRatio as string | undefined;
+      const imageSize = p.imageSize as string | undefined;
       const rawFilename = p.filename as string | undefined;
 
       // Ensure filename has an extension
@@ -366,7 +376,12 @@ export function buildImageGenerateTool(
             response_format: "b64_json",
             output_format: "png",
             ...(aspectRatio ? { aspect_ratio: aspectRatio } : {}),
-            ...(!aspectRatio ? { size: size ?? "1024x1024" } : {}),
+            ...(imageSize ? { image_size: imageSize } : {}),
+            ...(size
+              ? { size }
+              : !aspectRatio && !imageSize
+                ? { size: "1024x1024" }
+                : {}),
           }),
           signal,
         });


### PR DESCRIPTION
## Summary
- align generate_image size values with supported OpenAI-compatible image size options
- add full Gemini-supported aspectRatio values and top-level image_size support for 1K/2K/4K requests
- send top-level aspect_ratio/image_size without falling back to default 1024x1024 when ratio or K-resolution is requested
- enable CI for pull requests targeting release/** branches

## Validation
- pnpm lint
- pnpm --filter @bunny-agent/runner-pi test -- image-tools.test.ts
- pnpm --filter @bunny-agent/runner-pi typecheck
- git diff --check