### PR TITLE
Add CDP init startup toggle

### DIFF
--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -91,7 +91,7 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/bunny-agent-daemon && \
     echo 'import("/opt/bunny-agent/node_modules/@bunny-agent/daemon/dist/bundle.mjs")' >> /usr/local/bin/bunny-agent-daemon && \
     chmod +x /usr/local/bin/bunny-agent-daemon
 
-# Entrypoint: run init hooks, copy /skills, start daemon + CDP, then exec CMD
+# Entrypoint: run init hooks, copy /skills, start daemon + optional CDP, then exec CMD
 RUN printf '%s\n' \
     '#!/bin/bash' \
     '# Run all init hooks (drop scripts into /etc/bunny-agent-init.d/)' \
@@ -106,7 +106,10 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'bunny-agent-daemon &' \
-    'start-cdp' \
+    'case "${START_CDP_ON_INIT:-1}" in' \
+    '  0) echo "CDP startup disabled by START_CDP_ON_INIT=0" ;;' \
+    '  *) start-cdp ;;' \
+    'esac' \
     'exec "$@"' > /usr/local/bin/bunny-agent-entrypoint && \
     chmod +x /usr/local/bin/bunny-agent-entrypoint && \
     mkdir -p /etc/bunny-agent-init.d
@@ -117,6 +120,7 @@ ENV PATH=/usr/local/bin:$PATH
 ENV SANDAGENT_ROOT=/agent
 ENV SANDAGENT_DAEMON_HOST=0.0.0.0
 ENV SANDAGENT_DAEMON_PORT=3080
+ENV START_CDP_ON_INIT=1
 
 # Suppress D-Bus errors in headless Chromium (no bus in containers)
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -84,7 +84,7 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/sandagent-daemon && \
 # Install global CLI tools for agent use
 RUN npm install -g brave-search-cli
 
-# Entrypoint: copy /skills, start daemon + CDP, then exec CMD
+# Entrypoint: copy /skills, start daemon + optional CDP, then exec CMD
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'mkdir -p "$HOME/.claude/skills"' \
@@ -93,7 +93,10 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'sandagent-daemon &' \
-    'start-cdp' \
+    'case "${START_CDP_ON_INIT:-1}" in' \
+    '  0) echo "CDP startup disabled by START_CDP_ON_INIT=0" ;;' \
+    '  *) start-cdp ;;' \
+    'esac' \
     'exec "$@"' > /usr/local/bin/sandagent-entrypoint && \
     chmod +x /usr/local/bin/sandagent-entrypoint
 
@@ -102,6 +105,7 @@ ENV PATH=/usr/local/bin:$PATH
 ENV SANDAGENT_ROOT=/agent
 ENV SANDAGENT_DAEMON_HOST=0.0.0.0
 ENV SANDAGENT_DAEMON_PORT=3080
+ENV START_CDP_ON_INIT=1
 
 # Suppress D-Bus errors in headless Chromium (no bus in containers)
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -82,7 +82,7 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/sandagent-daemon && \
 # Install global CLI tools for agent use
 RUN npm install -g brave-search-cli
 
-# Entrypoint: copy /skills, start daemon + CDP, then exec CMD
+# Entrypoint: copy /skills, start daemon + optional CDP, then exec CMD
 RUN printf '%s\n' \
     '#!/bin/bash' \
     'mkdir -p "$HOME/.claude/skills"' \
@@ -91,7 +91,10 @@ RUN printf '%s\n' \
     '  echo "Copied /skills to $HOME/.claude/skills"' \
     'fi' \
     'sandagent-daemon &' \
-    'start-cdp' \
+    'case "${START_CDP_ON_INIT:-1}" in' \
+    '  0) echo "CDP startup disabled by START_CDP_ON_INIT=0" ;;' \
+    '  *) start-cdp ;;' \
+    'esac' \
     'exec "$@"' > /usr/local/bin/sandagent-entrypoint && \
     chmod +x /usr/local/bin/sandagent-entrypoint
 ENV NODE_PATH=/opt/sandagent/node_modules
@@ -99,6 +102,7 @@ ENV PATH=/usr/local/bin:$PATH
 ENV SANDAGENT_ROOT=/agent
 ENV SANDAGENT_DAEMON_HOST=0.0.0.0
 ENV SANDAGENT_DAEMON_PORT=3080
+ENV START_CDP_ON_INIT=1
 
 # Suppress D-Bus errors in headless Chromium (no bus in containers)
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null

--- a/docker/bunny-agent-claude/README.md
+++ b/docker/bunny-agent-claude/README.md
@@ -87,6 +87,10 @@ docker build -f docker/bunny-agent-claude/Dockerfile.local -t vikadata/bunny-age
 1. Copy `.env.example` to `.env`.
 2. Set keys: `DAYTONA_API_KEY`, `E2B_API_KEY`.
 
+## Runtime options
+
+- `START_CDP_ON_INIT`: controls whether the entrypoint starts `start-cdp`. Defaults to `1`; set to `0` to skip CDP startup.
+
 ## Make targets
 
 | Target               | Description                                      |

--- a/docs/changelog/2026-05-08-docker-cdp-start-toggle.md
+++ b/docs/changelog/2026-05-08-docker-cdp-start-toggle.md
@@ -1,0 +1,7 @@
+# Docker CDP Startup Toggle
+
+## Changes
+
+- Added `START_CDP_ON_INIT`, defaulting to `1`, to the Bunny Agent Claude Docker image.
+- Updated Docker entrypoints so `start-cdp` is skipped when `START_CDP_ON_INIT` is set to `0`.
+- Kept CDP startup enabled by default for existing image users.


### PR DESCRIPTION
## Summary
- Add START_CDP_ON_INIT to control whether Docker entrypoints start CDP during init
- Default START_CDP_ON_INIT to 1 to preserve current startup behavior
- Document the runtime option and add a session changelog

## Testing
- Not run; Dockerfile and documentation changes only