### PR TITLE
fix: forward Sandock sandbox env on create

### DIFF
--- a/docs/changelog/2026-05-08-docker-cdp-start-toggle.md
+++ b/docs/changelog/2026-05-08-docker-cdp-start-toggle.md
@@ -4,4 +4,5 @@
 
 - Added `START_CDP_ON_INIT`, defaulting to `1`, to the Bunny Agent Claude Docker image.
 - Updated Docker entrypoints so `start-cdp` is skipped when `START_CDP_ON_INIT` is set to `0`.
+- Forwarded `SandockSandbox` adapter `env` values into the Sandock create API payload so container entrypoints can read runtime environment variables.
 - Kept CDP startup enabled by default for existing image users.

--- a/packages/sandbox-sandock/src/__tests__/sandock-sandbox.test.ts
+++ b/packages/sandbox-sandock/src/__tests__/sandock-sandbox.test.ts
@@ -153,6 +153,25 @@ describe("SandockSandbox", () => {
       );
     });
 
+    it("should pass env option to Sandock API when provided", async () => {
+      const { createSandockClient } = await import("sandock");
+      const mockCreateClient = createSandockClient as ReturnType<typeof vi.fn>;
+      const sandbox = new SandockSandbox({
+        env: { START_CDP_ON_INIT: "0", FOO: "bar" },
+      });
+      await sandbox.attach();
+      const mockClient = mockCreateClient.mock.results[
+        mockCreateClient.mock.results.length - 1
+      ].value as {
+        sandbox: { create: ReturnType<typeof vi.fn> };
+      };
+      expect(mockClient.sandbox.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          env: { START_CDP_ON_INIT: "0", FOO: "bar" },
+        }),
+      );
+    });
+
     it("should not pass command to Sandock API when not provided", async () => {
       const { createSandockClient } = await import("sandock");
       const mockCreateClient = createSandockClient as ReturnType<typeof vi.fn>;

--- a/packages/sandbox-sandock/src/sandock-sandbox.ts
+++ b/packages/sandbox-sandock/src/sandock-sandbox.ts
@@ -352,6 +352,7 @@ export class SandockSandbox implements SandboxAdapter {
       activeDeadlineSeconds?: number;
       autoDeleteInterval?: number;
       command?: string[];
+      env?: Record<string, string>;
     } = {
       image: this.image,
       memory: this.memoryLimitMb,
@@ -366,6 +367,9 @@ export class SandockSandbox implements SandboxAdapter {
         volumeId: v.volumeId,
         mountPath: v.mountPath,
       }));
+    }
+    if (Object.keys(this.env).length > 0) {
+      createOptions.env = this.env;
     }
 
     const createResult = await this.client.sandbox.create(createOptions);


### PR DESCRIPTION
## Summary
- Forward `SandockSandbox` adapter `env` values into the Sandock sandbox create API payload.
- Add a regression test covering create-time env forwarding.
- Update the CDP startup toggle changelog because container entrypoints need runtime env during sandbox creation.

## Root Cause
- `SandockSandbox({ env })` stored env for later exec calls, but `createAndStartSandbox()` did not include `env` in `client.sandbox.create()` options.
- Container entrypoints only see env passed during sandbox creation, so image-level defaults could not be overridden at startup.

## Validation
- `pnpm --filter @bunny-agent/sandbox-sandock test -- --runInBand`
