### PR TITLE
fix(runner-pi,sdk): surface tool-ref errors as AI SDK tool errors

### DIFF
--- a/.changeset/runner-pi-tool-ref-errors.md
+++ b/.changeset/runner-pi-tool-ref-errors.md
@@ -1,0 +1,17 @@
+---
+"@bunny-agent/runner-pi": patch
+---
+
+fix(runner-pi): throw on tool-ref runtime errors instead of returning them as
+text content.
+
+`buildToolDefinitionsFromRefs` previously returned non-2xx HTTP responses and
+transport failures as a normal `{ content: [{ type: "text", text }] }` result,
+which violates the pi-agent-core `AgentTool.execute` contract ("throw on
+failure instead of encoding errors in content"). The pi-runner could not mark
+the call as an error, and downstream SSE consumers (e.g. Buda) saw the tool as
+successful with the error text as its output.
+
+Both error paths now throw a `PiToolRefError` carrying the tool name, HTTP
+status, and body, so the runner emits a proper tool-error event and the UI can
+render a failure state.

--- a/.changeset/sdk-tool-output-error.md
+++ b/.changeset/sdk-tool-output-error.md
@@ -1,0 +1,16 @@
+---
+"@bunny-agent/sdk": patch
+---
+
+fix(sdk): translate `tool-output-error` SSE events into `tool-result` V3 stream
+parts with `isError: true`.
+
+When a tool-ref runtime fails, runner-pi now emits a `tool-output-error` chunk
+(AI SDK v6 UI message protocol). The language-model provider previously only
+handled `tool-output-available`, so the error was silently dropped and AI SDK
+downstream saw the tool as successful with no output.
+
+Map `tool-output-error` to a `LanguageModelV3Content` tool-result with
+`isError: true`, carrying the `errorText` as the result payload. AI SDK
+`streamText` upgrades that into a `tool-error` stream part, which the UI
+message transform then re-emits as `tool-output-error` for the client.

--- a/apps/web/lib/example/create-sandbox.ts
+++ b/apps/web/lib/example/create-sandbox.ts
@@ -32,10 +32,11 @@ const SANDBOX_IMAGE =
  * container `env` so bunny-agent-daemon sees the same variables as shell `exec`
  * (not only the curl child process).
  *
- * Sandock + bunny-agent image: the entrypoint command is always applied when the
- * image name matches {@link sandockImageNeedsSandagentEntrypoint}. `useBunnyAgentDaemon`
- * only affects sandbox cache key and (in the web app) whether `/api/ai` probes
- * `/healthz` and passes `daemonUrl` for HTTP transport, or omits it for CLI.
+ * Sandock + bundled Bunny images: the entrypoint command is always applied when
+ * the image name matches {@link sandockImageNeedsBundledEntrypoint}.
+ * `useBunnyAgentDaemon` only affects sandbox cache key and (in the web app)
+ * whether `/api/ai` probes `/healthz` and passes `daemonUrl` for HTTP transport,
+ * or omits it for CLI.
  */
 const SANDOCK_SLEEP_ARG = process.env.SANDOCK_CONTAINER_SLEEP_SEC ?? "infinity";
 
@@ -58,12 +59,11 @@ function resolveSandockEntrypoint(image: string): string {
   return "/usr/local/bin/bunny-agent-entrypoint";
 }
 
-function sandockImageNeedsSandagentEntrypoint(image: string): boolean {
+function sandockImageNeedsBundledEntrypoint(image: string): boolean {
   const i = image.toLowerCase();
   return (
-    i.includes("vikadata/bunny-agent") ||
+    i.includes("vikadata/bunny-") ||
     i.includes("vikadata/sandagent") ||
-    i.includes("/bunny-agent:") ||
     i.includes("/sandagent:") ||
     i.endsWith("/bunny-agent") ||
     i.endsWith("/sandagent") ||
@@ -120,6 +120,7 @@ function sandboxCacheKey(params: CreateSandboxParams): string {
   const fingerprintSource = {
     sandboxProvider: params.SANDBOX_PROVIDER ?? "",
     runnerType: params.runnerType ?? "",
+    sandboxImage: params.SANDBOX_IMAGE ?? SANDBOX_IMAGE,
     // Only include variables that can influence skill execution.
     AGENT_KEY: env.AGENT_KEY ?? "",
     BUDA_API_URL: env.BUDA_API_URL ?? "",
@@ -240,7 +241,7 @@ async function buildSandbox(
       workdir: "/agent",
       name: sandboxName,
       sandboxId: cachedId,
-      ...(sandockImageNeedsSandagentEntrypoint(image)
+      ...(sandockImageNeedsBundledEntrypoint(image)
         ? {
             command: [
               resolveSandockEntrypoint(image),

--- a/docs/changelog/2026-05-12-sandock-bunny-buda-entrypoint.md
+++ b/docs/changelog/2026-05-12-sandock-bunny-buda-entrypoint.md
@@ -1,0 +1,23 @@
+# 2026-05-12 - Sandock bunny-buda entrypoint detection
+
+## Problem
+
+The web example accepted `SANDBOX_IMAGE=vikadata/bunny-buda:0.9.37`, but the
+Sandock adapter only passed the bundled Bunny entrypoint for image names matching
+`bunny-agent` or `sandagent`. Sandock replaces the Docker image entrypoint unless
+the command is provided explicitly, so `bunny-agent-daemon` did not start and the
+`/healthz` probe failed.
+
+The sandbox cache key also ignored the image tag, so changing `SANDBOX_IMAGE`
+could still attach to a previously created sandbox.
+
+## Changes
+
+- Treat `vikadata/bunny-*` Sandock images as bundled Bunny images that need the
+  explicit image entrypoint command.
+- Include the resolved sandbox image in the sandbox cache fingerprint so image
+  changes create or attach to the correct runtime.
+
+## Files Changed
+
+- `apps/web/lib/example/create-sandbox.ts`

--- a/docs/changelog/2026-05-13-fix-pr-284-ci-lint.md
+++ b/docs/changelog/2026-05-13-fix-pr-284-ci-lint.md
@@ -1,0 +1,21 @@
+# 2026-05-13 - Fix PR 284 CI lint failures
+
+## Problem
+
+PR 284 failed in the CI lint step after build and typecheck passed. Biome
+reported one formatting issue in the pi runner test and one export ordering
+issue in the pi runner package entrypoint.
+
+## Changes
+
+- Formatted the `tool-output-error` assertion in the pi runner test.
+- Reordered the `PiToolRefError` export to satisfy Biome import/export sorting.
+
+## Verification
+
+- `pnpm run -w lint`
+
+## Files Changed
+
+- `packages/runner-pi/src/__tests__/pi-runner.test.ts`
+- `packages/runner-pi/src/index.ts`

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -918,7 +918,7 @@ describe("createPiRunner", () => {
   });
 });
 
-it("emits isError flag when a tool execution fails", async () => {
+it("emits tool-output-error when a tool execution fails", async () => {
   nextSessionBehavior = "tool_error";
   const runner = createPiRunner({ model: "openai:gpt-4o" });
 
@@ -927,18 +927,27 @@ it("emits isError flag when a tool execution fails", async () => {
     chunks.push(chunk);
   }
 
-  // We should see a tool-output-available chunk that includes isError:true
-  const outputChunk = chunks.find(
+  // We should see a tool-output-error chunk (AI SDK v6) instead of tool-output-available
+  const errorChunk = chunks.find(
+    (c) =>
+      c.includes('"type":"tool-output-error"') && c.includes("tool_fail"),
+  );
+  expect(errorChunk).toBeDefined();
+
+  const data = JSON.parse(errorChunk!.replace(/^data: /, "").trim());
+  // errorText must be a plain string derived from the tool's output
+  expect(typeof data.errorText).toBe("string");
+  expect(data.errorText).toBe("command failed");
+  expect(data.toolCallId).toContain("tool_fail");
+  expect(data.dynamic).toBe(true);
+  expect(data.providerExecuted).toBe(true);
+
+  // There must be no successful tool-output-available chunk for this call
+  const okChunk = chunks.find(
     (c) =>
       c.includes('"type":"tool-output-available"') && c.includes("tool_fail"),
   );
-  expect(outputChunk).toBeDefined();
-  expect(outputChunk).toContain('"isError":true');
-
-  // The output must be a plain string, not the raw pi ToolResult object
-  const data = JSON.parse(outputChunk!.replace(/^data: /, "").trim());
-  expect(typeof data.output).toBe("string");
-  expect(data.output).toBe("command failed");
+  expect(okChunk).toBeUndefined();
 });
 
 // ── redactSecrets unit tests ─────────────────────────────────────────────────

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -929,8 +929,7 @@ it("emits tool-output-error when a tool execution fails", async () => {
 
   // We should see a tool-output-error chunk (AI SDK v6) instead of tool-output-available
   const errorChunk = chunks.find(
-    (c) =>
-      c.includes('"type":"tool-output-error"') && c.includes("tool_fail"),
+    (c) => c.includes('"type":"tool-output-error"') && c.includes("tool_fail"),
   );
   expect(errorChunk).toBeDefined();
 

--- a/packages/runner-pi/src/__tests__/tool-refs.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-refs.test.ts
@@ -142,9 +142,8 @@ describe("buildToolDefinitionsFromRefs", () => {
     ).rejects.toMatchObject({
       name: "PiToolRefError",
       status: 403,
-      message: expect.stringMatching(
-        /status 403.*tool not enabled for this agent/,
-      ),
+      body: "tool not enabled for this agent",
+      message: "tool not enabled for this agent",
     });
   });
 

--- a/packages/runner-pi/src/__tests__/tool-refs.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-refs.test.ts
@@ -127,7 +127,7 @@ describe("buildToolDefinitionsFromRefs", () => {
     });
   });
 
-  it("surfaces non-2xx responses as a tool error message", async () => {
+  it("surfaces non-2xx responses as a thrown tool error", async () => {
     await server.close();
     server = await startFakeBridge(() => ({
       status: 403,
@@ -137,30 +137,23 @@ describe("buildToolDefinitionsFromRefs", () => {
     const [tool] = buildToolDefinitionsFromRefs([
       { ...sampleSpec, runtime: { type: "http", url: server.url } },
     ]);
-    const result = await tool.execute(
-      "tc_2",
-      {},
-      undefined,
-      undefined,
-      undefined as never,
-    );
-
-    expect(result.content[0]).toMatchObject({ type: "text" });
-    const text = (result.content[0] as { text: string }).text;
-    expect(text).toMatch(/status 403/);
-    expect(text).toMatch(/tool not enabled/);
+    await expect(
+      tool.execute("tc_2", {}, undefined, undefined, undefined as never),
+    ).rejects.toMatchObject({
+      name: "PiToolRefError",
+      status: 403,
+      message: expect.stringMatching(
+        /status 403.*tool not enabled for this agent/,
+      ),
+    });
   });
 
   it("propagates AbortSignal so a cancelled run terminates the fetch", async () => {
     // Replace the server with one that never responds so we can assert the
     // abort path. The bridge fetch should reject with an AbortError-like
-    // condition that the wrapper converts into a tool-error result.
+    // condition that the wrapper converts into a thrown tool error.
     await server.close();
     server = await startFakeBridge(() => ({
-      // Hold the response by returning very late — but http.createServer
-      // resolves synchronously here. To keep the test deterministic, we
-      // instead abort BEFORE calling execute and rely on the fetch failing
-      // immediately on the pre-aborted signal.
       body: { ok: true },
     }));
 
@@ -170,19 +163,18 @@ describe("buildToolDefinitionsFromRefs", () => {
     const [tool] = buildToolDefinitionsFromRefs([
       { ...sampleSpec, runtime: { type: "http", url: server.url } },
     ]);
-    const result = await tool.execute(
-      "tc_3",
-      {},
-      controller.signal,
-      undefined,
-      undefined as never,
-    );
-
-    const text = (result.content[0] as { text: string }).text;
-    // Either fetch failed (aborted) or never reached the server. Both surface
-    // as a transport error from the wrapper, which is what we want.
-    expect(text).toMatch(/transport error/i);
-    expect(text).toMatch(/abort/i);
+    await expect(
+      tool.execute(
+        "tc_3",
+        {},
+        controller.signal,
+        undefined,
+        undefined as never,
+      ),
+    ).rejects.toMatchObject({
+      name: "PiToolRefError",
+      message: expect.stringMatching(/transport error.*abort/i),
+    });
   });
 
   it("executes sandbox module runtime tools", async () => {

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -6,6 +6,12 @@ export {
   type PiRunnerOptions,
 } from "./pi-runner.js";
 export type { ToolDetailsWithUsage, ToolUsageDetails } from "./tool-details.js";
+export {
+  buildToolDefinitionsFromRefs,
+  PiToolRefError,
+  type PiToolRef,
+  type PiToolRuntime,
+} from "./tool-refs.js";
 export type {
   WebSearchBillingDetails,
   WebSearchProviderUsage,

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -8,8 +8,8 @@ export {
 export type { ToolDetailsWithUsage, ToolUsageDetails } from "./tool-details.js";
 export {
   buildToolDefinitionsFromRefs,
-  PiToolRefError,
   type PiToolRef,
+  PiToolRefError,
   type PiToolRuntime,
 } from "./tool-refs.js";
 export type {

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -128,16 +128,27 @@ export class PiAISDKStreamConverter {
       const raw = (event.result as { details?: ToolDetailsWithUsage })?.details
         ?.usage?.raw;
       if (raw != null) accumulateToolUsage(this.toolUsageTally, raw);
-      chunks.push(
-        sseData({
-          type: "tool-output-available",
-          toolCallId: event.toolCallId,
-          output,
-          isError: event.isError,
-          dynamic: true,
-          providerExecuted: true,
-        }),
-      );
+      if (event.isError) {
+        chunks.push(
+          sseData({
+            type: "tool-output-error",
+            toolCallId: event.toolCallId,
+            errorText: output,
+            dynamic: true,
+            providerExecuted: true,
+          }),
+        );
+      } else {
+        chunks.push(
+          sseData({
+            type: "tool-output-available",
+            toolCallId: event.toolCallId,
+            output,
+            dynamic: true,
+            providerExecuted: true,
+          }),
+        );
+      }
       return chunks;
     }
 

--- a/packages/runner-pi/src/tool-refs.ts
+++ b/packages/runner-pi/src/tool-refs.ts
@@ -77,10 +77,11 @@ function buildOne(spec: PiToolRef): ToolDefinition {
         );
       }
       if (response.status < 200 || response.status >= 300) {
-        throw new PiToolRefError(
-          formatToolRuntimeErrorMessage(response),
-          { toolName: spec.name, status: response.status, body: response.body },
-        );
+        throw new PiToolRefError(formatToolRuntimeErrorMessage(response), {
+          toolName: spec.name,
+          status: response.status,
+          body: response.body,
+        });
       }
       return okResult(response.body);
     },

--- a/packages/runner-pi/src/tool-refs.ts
+++ b/packages/runner-pi/src/tool-refs.ts
@@ -1,8 +1,6 @@
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
-const LOG_PREFIX = "[bunny-agent:pi-tool-ref]";
-
 type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
   details: undefined;
@@ -74,19 +72,25 @@ function buildOne(spec: PiToolRef): ToolDefinition {
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         throw new PiToolRefError(
-          `${LOG_PREFIX} tool "${spec.name}" transport error: ${message}`,
+          `Tool "${spec.name}" transport error: ${message}`,
           { toolName: spec.name },
         );
       }
       if (response.status < 200 || response.status >= 300) {
         throw new PiToolRefError(
-          `${LOG_PREFIX} tool "${spec.name}" failed (status ${response.status}): ${response.body}`,
+          formatToolRuntimeErrorMessage(response),
           { toolName: spec.name, status: response.status, body: response.body },
         );
       }
       return okResult(response.body);
     },
   };
+}
+
+function formatToolRuntimeErrorMessage(response: RuntimeResponse): string {
+  const body = response.body.trim();
+  if (body.length > 0) return body;
+  return `Tool execution failed with status ${response.status}`;
 }
 
 async function executeToolRef(

--- a/packages/runner-pi/src/tool-refs.ts
+++ b/packages/runner-pi/src/tool-refs.ts
@@ -10,6 +10,22 @@ type ToolResult = {
 
 type RuntimeResponse = { status: number; body: string };
 
+export class PiToolRefError extends Error {
+  readonly toolName: string;
+  readonly status?: number;
+  readonly body?: string;
+  constructor(
+    message: string,
+    opts: { toolName: string; status?: number; body?: string },
+  ) {
+    super(message);
+    this.name = "PiToolRefError";
+    this.toolName = opts.toolName;
+    this.status = opts.status;
+    this.body = opts.body;
+  }
+}
+
 export type PiToolRuntime =
   | {
       type: "http";
@@ -57,10 +73,16 @@ function buildOne(spec: PiToolRef): ToolDefinition {
         response = await executeToolRef(spec, params, signal);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return transportErrorResult(spec.name, message);
+        throw new PiToolRefError(
+          `${LOG_PREFIX} tool "${spec.name}" transport error: ${message}`,
+          { toolName: spec.name },
+        );
       }
       if (response.status < 200 || response.status >= 300) {
-        return statusErrorResult(spec.name, response.status, response.body);
+        throw new PiToolRefError(
+          `${LOG_PREFIX} tool "${spec.name}" failed (status ${response.status}): ${response.body}`,
+          { toolName: spec.name, status: response.status, body: response.body },
+        );
       }
       return okResult(response.body);
     },
@@ -119,34 +141,6 @@ async function executeModuleTool(
 function okResult(text: string): ToolResult {
   return {
     content: [{ type: "text", text }],
-    details: undefined,
-  };
-}
-
-function statusErrorResult(
-  toolName: string,
-  status: number,
-  body: string,
-): ToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text: `${LOG_PREFIX} tool "${toolName}" failed (status ${status}): ${body}`,
-      },
-    ],
-    details: undefined,
-  };
-}
-
-function transportErrorResult(toolName: string, message: string): ToolResult {
-  return {
-    content: [
-      {
-        type: "text",
-        text: `${LOG_PREFIX} tool "${toolName}" transport error: ${message}`,
-      },
-    ],
     details: undefined,
   };
 }

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -654,6 +654,18 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
         });
         break;
       }
+      case "tool-output-error": {
+        const toolName = this.toolNameMap.get(parsed.toolCallId as string);
+        parts.push({
+          type: "tool-result",
+          toolCallId: parsed.toolCallId as string,
+          toolName: toolName ?? "",
+          result: (parsed.errorText as string) ?? "Tool execution failed",
+          isError: true,
+          dynamic: readToolDynamicFlag(parsed),
+        });
+        break;
+      }
       case "error": {
         parts.push({
           type: "error",


### PR DESCRIPTION
## Summary

runner-pi's tool-ref wrapper silently swallowed tool execution failures, so downstream apps (Buda) rendered HTTP 4xx/5xx from a provider-executed tool (e.g. `generate_video` hitting a 429 quota limit) as if the tool had succeeded. The AI then tried to explain the "success text" to the user instead of retrying or surfacing the quota error.

Root cause: `buildToolDefinitionsFromRefs` returned non-2xx HTTP responses and transport failures as plain `{ content: [{ type: "text", text: "[bunny-agent:pi-tool-ref] tool ... failed (status 429): ..." }] }`, violating the `pi-agent-core` `AgentTool.execute` contract ("throw on failure instead of encoding errors in content"). pi-coding-agent therefore could not flag `tool_execution_end.isError = true`, the stream-converter emitted a normal `tool-output-available` SSE chunk, and the `bunny-agent` language-model provider mapped it as a successful `tool-result`.

## Changes

**`@bunny-agent/runner-pi`**
- `tool-refs.ts`: introduce `PiToolRefError` (carries `toolName`, HTTP `status`, response `body`) and throw it on non-2xx and transport errors. The error propagates through pi-coding-agent, which correctly marks `tool_execution_end.isError = true`.
- `stream-converter.ts`: emit AI SDK v6 `tool-output-error` (with `errorText`) when `event.isError`; keep `tool-output-available` for success. Previously we sent `tool-output-available` + `isError: true`, which does not exist in the AI SDK v6 UI protocol.
- `index.ts`: re-export `buildToolDefinitionsFromRefs`, `PiToolRefError`, `PiToolRef`, `PiToolRuntime`.
- Tests updated to assert the new throw / `tool-output-error` paths.

**`@bunny-agent/sdk`**
- `provider/bunny-agent-language-model.ts`: map the new `tool-output-error` SSE chunk into a V3 `LanguageModelV3ToolResult` with `isError: true` and `result: errorText`. AI SDK's `streamText` upgrades that into a `tool-error` stream part, and the UI message transform re-emits `tool-output-error` for the client. V3 provider spec has no independent `tool-error` part, so `tool-result + isError` is the correct bridge.

Pipeline end-to-end:
```
runner tool throw -> pi-coding-agent isError -> SSE tool-output-error
  -> SDK provider: tool-result + isError:true
  -> AI SDK streamText: tool-error
  -> UI stream: tool-output-error
```

## Test plan

- [x] `pnpm --filter @bunny-agent/runner-pi vitest run` (113 tests, all pass; updated `pi-runner.test.ts` and `tool-refs.test.ts` to cover throw + `tool-output-error` paths)
- [x] `pnpm --filter @bunny-agent/runner-pi typecheck` + `build`
- [x] `pnpm --filter @bunny-agent/sdk vitest run` (13 tests pass)
- [x] `pnpm --filter @bunny-agent/sdk typecheck` + `build`
- [ ] Manual: hit a 429 in Buda with `generate_video` and confirm the chat shows a tool failure state (requires downstream release of runner-pi + sdk)

## Follow-up

`packages/runner-claude/src/ai-sdk-stream.ts` has an analogous gap: it never inspects `tool_result.is_error` on Claude Agent SDK content blocks. Single-tool failures surface as `tool-output-available` regardless. Out of scope for this PR; will file a separate change if needed.