### PR TITLE
feat(runner-pi): add AskUserQuestion tool for mid-run user prompts

### DIFF
--- a/apps/web/app/(example)/example/page.tsx
+++ b/apps/web/app/(example)/example/page.tsx
@@ -141,7 +141,13 @@ function ChatMessage({
             }
             if (part.type === "dynamic-tool") {
               const toolPart = part as DynamicToolUIPart;
-              if (toolPart.toolName === "AskUserQuestion") {
+              // Both runner-claude (Claude Code) and runner-pi expose this tool
+              // for mid-run user prompts; the names differ by ecosystem
+              // convention (PascalCase vs snake_case).
+              if (
+                toolPart.toolName === "AskUserQuestion" ||
+                toolPart.toolName === "ask_user_question"
+              ) {
                 return (
                   <AskUserQuestionUI
                     key={toolPart.toolCallId ?? key}

--- a/apps/web/app/api/ai/route.ts
+++ b/apps/web/app/api/ai/route.ts
@@ -358,15 +358,22 @@ export async function POST(request: Request) {
         ...(daemonUrl ? { daemonUrl } : {}),
         cwd: sandbox.getWorkdir?.() || "/bunny-agent",
         runnerType,
-        allowedTools: ["read", "bash", "edit", "write", "get_current_time"],
+        allowedTools: [
+          "read",
+          "bash",
+          "edit",
+          "write",
+          "get_current_time",
+          "AskUserQuestion",
+        ],
         verbose: true,
         artifactProcessors: [artifactProcessor],
         resume,
         systemPrompt: "============test============",
         // Passed to RunnerSpec via createBunnyAgent merge (not only bunnyAgent(model, { skillPaths }))
         skillPaths: [
-          "/Users/zhengxu/vika/kapps/apps/buda/agent-templates/system-skills",
-          "/Users/zhengxu/vika/kapps/apps/buda/agent-templates/company-templates/entire-company/finance-agent/.agents/skills",
+          // "/Users/zhengxu/vika/kapps/apps/buda/agent-templates/system-skills",
+          // "/Users/zhengxu/vika/kapps/apps/buda/agent-templates/company-templates/entire-company/finance-agent/.agents/skills",
         ],
       };
       const bunnyAgent = createBunnyAgent(bunnyAgentOptions);

--- a/apps/web/app/api/ai/route.ts
+++ b/apps/web/app/api/ai/route.ts
@@ -365,6 +365,7 @@ export async function POST(request: Request) {
           "write",
           "get_current_time",
           "AskUserQuestion",
+          "ask_user_question",
         ],
         verbose: true,
         artifactProcessors: [artifactProcessor],

--- a/apps/web/content/docs/tools/ask-user-question.mdx
+++ b/apps/web/content/docs/tools/ask-user-question.mdx
@@ -129,5 +129,5 @@ Location: `{workdir}/.sandagent/approvals/{toolCallId}.json`
 ## Troubleshooting
 
 - No progress → verify both APIs use the same `workdir`
-- UI not rendering → ensure you handle `dynamic-tool` parts with `toolName === "AskUserQuestion"`
+- UI not rendering → ensure you handle `dynamic-tool` parts with `toolName === "AskUserQuestion"` (runner-claude) or `toolName === "ask_user_question"` (runner-pi)
 - Answers not applied → confirm `answerEndpoint` matches your API route

--- a/docs/changelog/2026-05-21-runner-pi-ask-user-question.md
+++ b/docs/changelog/2026-05-21-runner-pi-ask-user-question.md
@@ -19,11 +19,14 @@ when they needed disambiguation.
   `questions`, `answers`, `reason`) matches what runner-claude's
   `canUseTool` writes, so existing approval UIs serve both runners with no
   changes.
-- Wired the tool into `createPiRunner` so it is always registered, regardless
-  of `allowedTools`. The pi runner is otherwise allowed-tool-driven, but
-  AskUserQuestion is the model's only hook back into the user — gating it
-  behind an allowlist would let callers silently disable interaction without
-  realizing it.
+- Wired the tool into `createPiRunner`'s `customTools`. Like every other pi
+  tool, callers opt in by including `"AskUserQuestion"` in their
+  `allowedTools` list — that keeps the runner's allowlist semantics
+  consistent across all tools, and avoids silently exposing user-prompt
+  capability to callers that did not ask for it.
+- Updated `apps/web/app/api/ai/route.ts` to add `"AskUserQuestion"` to its
+  `allowedTools` so the bundled web example surfaces the tool to the
+  model.
 - Borrowed openclaw's display-text sanitization
   (`extensions/codex/src/app-server/elicitation-bridge.ts`) to strip ANSI
   escapes and other control characters from question/header/option text before
@@ -52,3 +55,4 @@ when they needed disambiguation.
 - `packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts` (new)
 - `packages/runner-pi/src/pi-runner.ts`
 - `packages/runner-pi/src/index.ts`
+- `apps/web/app/api/ai/route.ts`

--- a/docs/changelog/2026-05-21-runner-pi-ask-user-question.md
+++ b/docs/changelog/2026-05-21-runner-pi-ask-user-question.md
@@ -1,0 +1,54 @@
+# 2026-05-21 - runner-pi: AskUserQuestion tool
+
+## Problem
+
+The pi runner had no way for the model to surface a structured choice to the
+user mid-run. runner-claude already supports this via Claude Code's
+`AskUserQuestion` tool plus a file-based approval roundtrip
+(`.bunny-agent/approvals/<toolUseID>.json`), but pi-coding-agent has no
+equivalent hook, so pi-driven sessions could only fall back to free-form prose
+when they needed disambiguation.
+
+## Changes
+
+- Added `buildAskUserQuestionTool` in `packages/runner-pi/src/`. The tool
+  registers as a custom pi `ToolDefinition` named `AskUserQuestion`, accepts
+  the same questions/options/multiSelect schema Claude Code uses (1-4
+  questions, 2-4 options each), and writes a pending approval file for the
+  frontend to answer. The file shape (`status`, `toolName`, `input`,
+  `questions`, `answers`, `reason`) matches what runner-claude's
+  `canUseTool` writes, so existing approval UIs serve both runners with no
+  changes.
+- Wired the tool into `createPiRunner` so it is always registered, regardless
+  of `allowedTools`. The pi runner is otherwise allowed-tool-driven, but
+  AskUserQuestion is the model's only hook back into the user — gating it
+  behind an allowlist would let callers silently disable interaction without
+  realizing it.
+- Borrowed openclaw's display-text sanitization
+  (`extensions/codex/src/app-server/elicitation-bridge.ts`) to strip ANSI
+  escapes and other control characters from question/header/option text before
+  the approval file is written. Length caps mirror the same module.
+- Default timeout is 120 s (matching openclaw's
+  `DEFAULT_CODEX_APPROVAL_TIMEOUT_MS`), longer than runner-claude's 60 s
+  because users often need real time to read multi-option prompts. The poll
+  loop is also wired to the pi `AbortSignal`, so an aborted run terminates the
+  prompt immediately instead of running out the clock.
+- Added the `ASK_USER_QUESTION_TOOL_TIMEOUT` environment variable (in
+  seconds) to override the default. Resolved via the runner's standard order:
+  `options.env` first, then `process.env`, then the built-in default. Invalid
+  or non-positive values fall back to the default.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/runner-pi typecheck`
+- `pnpm --filter @bunny-agent/runner-pi test` (121 tests, including 8 new
+  tests covering happy path, multi-select, decline, timeout, abort, sanitize,
+  and approval-file cleanup)
+- `pnpm lint`
+
+## Files Changed
+
+- `packages/runner-pi/src/ask-user-question-tool.ts` (new)
+- `packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts` (new)
+- `packages/runner-pi/src/pi-runner.ts`
+- `packages/runner-pi/src/index.ts`

--- a/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
+++ b/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
@@ -60,9 +60,9 @@ describe("buildAskUserQuestionTool", () => {
     rmSync(cwd, { recursive: true, force: true });
   });
 
-  it("declares the AskUserQuestion contract", () => {
+  it("declares the ask_user_question contract", () => {
     const tool = makeTool(cwd);
-    expect(tool.name).toBe("AskUserQuestion");
+    expect(tool.name).toBe("ask_user_question");
     expect(tool.executionMode).toBe("sequential");
     expect(tool.description).toMatch(/multiple-choice/i);
   });
@@ -93,7 +93,7 @@ describe("buildAskUserQuestionTool", () => {
       file,
       JSON.stringify({
         status: "completed",
-        toolName: "AskUserQuestion",
+        toolName: "ask_user_question",
         questions: [sampleQuestion],
         answers: { [sampleQuestion.question]: "Postgres" },
       }),
@@ -131,7 +131,7 @@ describe("buildAskUserQuestionTool", () => {
       file,
       JSON.stringify({
         status: "completed",
-        toolName: "AskUserQuestion",
+        toolName: "ask_user_question",
         questions: [q],
         answers: { [q.question]: ["Postgres", "MySQL"] },
       }),
@@ -167,7 +167,7 @@ describe("buildAskUserQuestionTool", () => {
       file,
       JSON.stringify({
         status: "declined",
-        toolName: "AskUserQuestion",
+        toolName: "ask_user_question",
         questions: [sampleQuestion],
         answers: {},
         reason: "user_dismissed",

--- a/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
+++ b/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
@@ -1,0 +1,266 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildAskUserQuestionTool } from "../ask-user-question-tool.js";
+
+// ---------------------------------------------------------------------------
+// AskUserQuestion tool — drives the approval file from a sibling task to
+// simulate the frontend writing the user's answer.
+// ---------------------------------------------------------------------------
+
+const APPROVAL_REL = join(".bunny-agent", "approvals");
+const ESC = String.fromCharCode(0x1b);
+
+const sampleQuestion = {
+  question: "Which database should we use?",
+  header: "Database",
+  multiSelect: false,
+  options: [
+    { label: "Postgres", description: "Relational, mature, default choice." },
+    { label: "MySQL", description: "Relational, common in legacy stacks." },
+  ],
+};
+
+function makeTool(
+  cwd: string,
+  overrides: { timeoutMs?: number; pollMs?: number } = {},
+) {
+  return buildAskUserQuestionTool({
+    cwd,
+    timeoutMs: overrides.timeoutMs ?? 1_000,
+    pollMs: overrides.pollMs ?? 10,
+  });
+}
+
+function approvalPath(cwd: string, toolCallId: string): string {
+  return join(cwd, APPROVAL_REL, `${toolCallId}.json`);
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error("waitFor timed out");
+}
+
+describe("buildAskUserQuestionTool", () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "ask-user-question-"));
+  });
+
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("declares the AskUserQuestion contract", () => {
+    const tool = makeTool(cwd);
+    expect(tool.name).toBe("AskUserQuestion");
+    expect(tool.executionMode).toBe("sequential");
+    expect(tool.description).toMatch(/multiple-choice/i);
+  });
+
+  it("returns the user's answer once the frontend completes the approval", async () => {
+    const tool = makeTool(cwd);
+    const toolCallId = "call-happy";
+    const file = approvalPath(cwd, toolCallId);
+
+    const exec = tool.execute(
+      toolCallId,
+      { questions: [sampleQuestion] },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+
+    await waitFor(() => {
+      try {
+        const pending = JSON.parse(readFileSync(file, "utf-8"));
+        return pending.status === "pending";
+      } catch {
+        return false;
+      }
+    });
+
+    writeFileSync(
+      file,
+      JSON.stringify({
+        status: "completed",
+        toolName: "AskUserQuestion",
+        questions: [sampleQuestion],
+        answers: { [sampleQuestion.question]: "Postgres" },
+      }),
+    );
+
+    const result = await exec;
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("User answered:");
+    expect(text).toContain("Postgres");
+  });
+
+  it("returns multi-select answers joined", async () => {
+    const tool = makeTool(cwd);
+    const toolCallId = "call-multi";
+    const file = approvalPath(cwd, toolCallId);
+    const q = { ...sampleQuestion, multiSelect: true };
+
+    const exec = tool.execute(
+      toolCallId,
+      { questions: [q] },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+    await waitFor(() => {
+      try {
+        return JSON.parse(readFileSync(file, "utf-8")).status === "pending";
+      } catch {
+        return false;
+      }
+    });
+
+    writeFileSync(
+      file,
+      JSON.stringify({
+        status: "completed",
+        toolName: "AskUserQuestion",
+        questions: [q],
+        answers: { [q.question]: ["Postgres", "MySQL"] },
+      }),
+    );
+
+    const result = await exec;
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("Postgres, MySQL");
+  });
+
+  it("reports a decline reason when the frontend declines", async () => {
+    const tool = makeTool(cwd);
+    const toolCallId = "call-decline";
+    const file = approvalPath(cwd, toolCallId);
+
+    const exec = tool.execute(
+      toolCallId,
+      { questions: [sampleQuestion] },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+    await waitFor(() => {
+      try {
+        return JSON.parse(readFileSync(file, "utf-8")).status === "pending";
+      } catch {
+        return false;
+      }
+    });
+
+    writeFileSync(
+      file,
+      JSON.stringify({
+        status: "declined",
+        toolName: "AskUserQuestion",
+        questions: [sampleQuestion],
+        answers: {},
+        reason: "user_dismissed",
+      }),
+    );
+
+    const result = await exec;
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("user_dismissed");
+    expect(text).toMatch(/did not answer/i);
+  });
+
+  it("returns timeout when the frontend never responds", async () => {
+    const tool = makeTool(cwd, { timeoutMs: 50, pollMs: 10 });
+    const result = await tool.execute(
+      "call-timeout",
+      { questions: [sampleQuestion] },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("timeout");
+  });
+
+  it("respects an aborted signal", async () => {
+    const tool = makeTool(cwd, { timeoutMs: 5_000, pollMs: 10 });
+    const ctrl = new AbortController();
+    const exec = tool.execute(
+      "call-abort",
+      { questions: [sampleQuestion] },
+      ctrl.signal,
+      undefined,
+      undefined as never,
+    );
+    setTimeout(() => ctrl.abort(), 25);
+    const result = await exec;
+    const text =
+      result.content[0]?.type === "text" ? result.content[0].text : "";
+    expect(text).toContain("run_aborted");
+  });
+
+  it("sanitizes ANSI escapes from question text before writing the approval file", async () => {
+    const tool = makeTool(cwd, { timeoutMs: 50, pollMs: 10 });
+    const toolCallId = "call-sanitize";
+    const file = approvalPath(cwd, toolCallId);
+    const dirty = {
+      // \x1b[31m is the red ANSI escape; should be stripped.
+      question: `${ESC}[31mWhich DB?${ESC}[0m`,
+      header: "DB",
+      multiSelect: false,
+      options: [
+        { label: "Postgres", description: "ok" },
+        { label: "MySQL", description: "ok" },
+      ],
+    };
+    let captured: { question?: string } = {};
+    void tool
+      .execute(
+        toolCallId,
+        { questions: [dirty] },
+        undefined,
+        undefined,
+        undefined as never,
+      )
+      .catch(() => undefined);
+
+    await waitFor(() => {
+      try {
+        const pending = JSON.parse(readFileSync(file, "utf-8"));
+        captured = pending.questions?.[0] ?? {};
+        return Boolean(captured.question);
+      } catch {
+        return false;
+      }
+    });
+
+    expect(captured.question).toBe("Which DB?");
+    expect(captured.question ?? "").not.toContain(ESC);
+  });
+
+  it("cleans up the approval file after each call", async () => {
+    const tool = makeTool(cwd, { timeoutMs: 50, pollMs: 10 });
+    await tool.execute(
+      "call-cleanup",
+      { questions: [sampleQuestion] },
+      undefined,
+      undefined,
+      undefined as never,
+    );
+    const file = approvalPath(cwd, "call-cleanup");
+    expect(() => readFileSync(file)).toThrow();
+  });
+});

--- a/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
+++ b/packages/runner-pi/src/__tests__/ask-user-question-tool.test.ts
@@ -2,7 +2,10 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { buildAskUserQuestionTool } from "../ask-user-question-tool.js";
+import {
+  buildAskUserQuestionTool,
+  sanitizeToolCallId,
+} from "../ask-user-question-tool.js";
 
 // ---------------------------------------------------------------------------
 // AskUserQuestion tool — drives the approval file from a sibling task to
@@ -34,7 +37,7 @@ function makeTool(
 }
 
 function approvalPath(cwd: string, toolCallId: string): string {
-  return join(cwd, APPROVAL_REL, `${toolCallId}.json`);
+  return join(cwd, APPROVAL_REL, `${sanitizeToolCallId(toolCallId)}.json`);
 }
 
 async function waitFor(

--- a/packages/runner-pi/src/ask-user-question-tool.ts
+++ b/packages/runner-pi/src/ask-user-question-tool.ts
@@ -12,6 +12,7 @@
  * UI — same defensive cleanup openclaw applies to its MCP elicitation bridge.
  */
 
+import { createHash } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
@@ -185,6 +186,27 @@ function readApproval(file: string): ApprovalFile | undefined {
   }
 }
 
+// pi-ai's Gemini provider embeds "thought signatures" inside toolCallId
+// (`call_xxx__thought__<base64>`). Those are needed by the provider when
+// echoing tool results back to Gemini, but they leak into our SSE stream and
+// approval filenames where they are noisy at best (long random strings) and
+// broken at worst (base64 contains "/", "+", and can exceed NAME_MAX). Reduce
+// every toolCallId to a stable, filename-safe stem so the runner output, the
+// approval file, and the SDK's submitAnswer all line up on the same id.
+const TOOL_CALL_ID_PREFIX_LEN = 32;
+const TOOL_CALL_ID_HASH_LEN = 16;
+
+export function sanitizeToolCallId(toolCallId: string): string {
+  const safePrefix = toolCallId
+    .replace(/[^A-Za-z0-9_-]/g, "_")
+    .slice(0, TOOL_CALL_ID_PREFIX_LEN);
+  const hash = createHash("sha1")
+    .update(toolCallId)
+    .digest("hex")
+    .slice(0, TOOL_CALL_ID_HASH_LEN);
+  return `${safePrefix}-${hash}`;
+}
+
 function safeUnlink(file: string): void {
   try {
     if (existsSync(file)) unlinkSync(file);
@@ -351,7 +373,10 @@ export function buildAskUserQuestionTool(opts: BuildOptions): ToolDefinition {
       const sanitizedInput: AskUserQuestionParams = { questions: sanitized };
 
       const approvalDir = join(cwd, APPROVAL_DIR);
-      const approvalFile = join(approvalDir, `${toolCallId}.json`);
+      const approvalFile = join(
+        approvalDir,
+        `${sanitizeToolCallId(toolCallId)}.json`,
+      );
 
       try {
         mkdirSync(approvalDir, { recursive: true });

--- a/packages/runner-pi/src/ask-user-question-tool.ts
+++ b/packages/runner-pi/src/ask-user-question-tool.ts
@@ -22,7 +22,7 @@ import {
 import { join } from "node:path";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 
-const TOOL_NAME = "AskUserQuestion";
+const TOOL_NAME = "ask_user_question";
 const APPROVAL_DIR = join(".bunny-agent", "approvals");
 
 export const ASK_USER_QUESTION_TIMEOUT_MS = 120_000;
@@ -332,12 +332,12 @@ export function buildAskUserQuestionTool(opts: BuildOptions): ToolDefinition {
   const { cwd, timeoutMs, pollMs } = opts;
   return {
     name: TOOL_NAME,
-    label: "AskUserQuestion",
+    label: "ask_user_question",
     description: TOOL_DESCRIPTION,
     promptSnippet:
-      "AskUserQuestion: ask the user 1-4 multiple-choice questions when the task is genuinely ambiguous.",
+      "ask_user_question: ask the user 1-4 multiple-choice questions when the task is genuinely ambiguous.",
     promptGuidelines: [
-      "Use AskUserQuestion only when the task is genuinely ambiguous and a user choice is required to proceed; otherwise pick a sensible default.",
+      "Use ask_user_question only when the task is genuinely ambiguous and a user choice is required to proceed; otherwise pick a sensible default.",
       "Each question must carry 2-4 mutually exclusive options. Do not add an 'Other' option — the host adds one automatically.",
     ],
     // Pause other tool calls while a user prompt is open; otherwise pi may
@@ -370,7 +370,7 @@ export function buildAskUserQuestionTool(opts: BuildOptions): ToolDefinition {
           content: [
             {
               type: "text" as const,
-              text: `AskUserQuestion failed to create approval file: ${message}`,
+              text: `ask_user_question failed to create approval file: ${message}`,
             },
           ],
           details: undefined,

--- a/packages/runner-pi/src/ask-user-question-tool.ts
+++ b/packages/runner-pi/src/ask-user-question-tool.ts
@@ -1,0 +1,419 @@
+/**
+ * AskUserQuestion tool for the pi runner.
+ *
+ * Lets the model surface a structured choice to the user mid-run, mirroring
+ * Claude Code's `AskUserQuestion`. The tool writes an approval file under
+ * `<cwd>/.bunny-agent/approvals/<toolCallId>.json` that uses the same shape as
+ * `runner-claude`'s `canUseTool` flow, so any frontend already wired for
+ * Claude Code approvals can answer pi questions without changes.
+ *
+ * Display text (question / header / option labels) is sanitized before being
+ * written to disk to keep ANSI escapes and other control characters out of the
+ * UI — same defensive cleanup openclaw applies to its MCP elicitation bridge.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+const TOOL_NAME = "AskUserQuestion";
+const APPROVAL_DIR = join(".bunny-agent", "approvals");
+
+export const ASK_USER_QUESTION_TIMEOUT_MS = 120_000;
+export const ASK_USER_QUESTION_POLL_MS = 500;
+
+const MAX_QUESTIONS = 4;
+const MIN_OPTIONS = 2;
+const MAX_OPTIONS = 4;
+const MAX_HEADER_LEN = 12;
+const MAX_QUESTION_LEN = 500;
+const MAX_OPTION_LABEL_LEN = 80;
+const MAX_OPTION_DESCRIPTION_LEN = 240;
+
+// ANSI/control-character scrubbers, mirrored from openclaw's elicitation
+// bridge (extensions/codex/src/app-server/elicitation-bridge.ts). Built from
+// String.fromCharCode so the source itself stays free of control bytes and
+// Biome accepts the patterns; passing a non-literal string also keeps
+// useRegexLiterals from rewriting them back into raw control characters.
+const ESC = String.fromCharCode(0x1b);
+const CSI = String.fromCharCode(0x9b);
+const ST = String.fromCharCode(0x9c);
+const OSC = String.fromCharCode(0x9d);
+const BEL = String.fromCharCode(0x07);
+const ANSI_OSC_RE = new RegExp(
+  `(?:${ESC}\\]|${OSC})[^${ESC}${ST}${BEL}]*(?:${BEL}|${ESC}\\\\|${ST})`,
+  "g",
+);
+const ANSI_CTL_RE = new RegExp(
+  `(?:${ESC}\\[[0-?]*[ -/]*[@-~]|${CSI}[0-?]*[ -/]*[@-~]|${ESC}[@-Z\\\\\\-_])`,
+  "g",
+);
+const CTL_CHAR_RE = new RegExp(
+  `[${String.fromCharCode(0x00)}-${String.fromCharCode(0x1f)}${String.fromCharCode(0x7f)}-${String.fromCharCode(0x9f)}]+`,
+  "g",
+);
+
+interface AskUserQuestionOption {
+  label: string;
+  description: string;
+}
+
+interface AskUserQuestionItem {
+  question: string;
+  header: string;
+  multiSelect: boolean;
+  options: AskUserQuestionOption[];
+}
+
+export interface AskUserQuestionParams {
+  questions: AskUserQuestionItem[];
+}
+
+type ApprovalStatus = "pending" | "completed" | "declined" | "cancelled";
+
+interface ApprovalFile {
+  status: ApprovalStatus;
+  toolName: string;
+  input: AskUserQuestionParams;
+  questions: AskUserQuestionItem[];
+  answers: Record<string, string | string[]>;
+  reason?: string;
+}
+
+const askUserQuestionSchema = {
+  type: "object",
+  required: ["questions"],
+  properties: {
+    questions: {
+      type: "array",
+      minItems: 1,
+      maxItems: MAX_QUESTIONS,
+      description: `Between 1 and ${MAX_QUESTIONS} questions to ask the user.`,
+      items: {
+        type: "object",
+        required: ["question", "header", "multiSelect", "options"],
+        properties: {
+          question: {
+            type: "string",
+            description:
+              "The full question to ask the user. Should be specific, end with a question mark, and avoid jargon the user has not used.",
+          },
+          header: {
+            type: "string",
+            description: `Short label (max ${MAX_HEADER_LEN} chars) shown as a chip/tag in the UI. Examples: "Library", "Auth method", "Approach".`,
+          },
+          multiSelect: {
+            type: "boolean",
+            description:
+              "Set true when the choices are not mutually exclusive and the user may select more than one.",
+          },
+          options: {
+            type: "array",
+            minItems: MIN_OPTIONS,
+            maxItems: MAX_OPTIONS,
+            description: `Between ${MIN_OPTIONS} and ${MAX_OPTIONS} mutually exclusive options. Do not add an "Other" option — the host adds one automatically.`,
+            items: {
+              type: "object",
+              required: ["label", "description"],
+              properties: {
+                label: {
+                  type: "string",
+                  description:
+                    "Display text for the option (1-5 words). Should clearly describe the choice.",
+                },
+                description: {
+                  type: "string",
+                  description:
+                    "What this option means or what happens if chosen — call out trade-offs.",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+const TOOL_DESCRIPTION = `Ask the user one or more multiple-choice questions when the task is genuinely ambiguous and you need user input to proceed (choosing between libraries, design approaches, trade-offs, etc.). Each question carries 2-${MAX_OPTIONS} options; up to ${MAX_QUESTIONS} questions per call. The user can also select an automatically-provided "Other" option to give free-form input. Use sparingly — prefer making a sensible default choice when the task is clear.`;
+
+function sanitizeText(value: unknown): string {
+  if (typeof value !== "string") return "";
+  return value
+    .replace(ANSI_OSC_RE, "")
+    .replace(ANSI_CTL_RE, "")
+    .replace(CTL_CHAR_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max
+    ? value
+    : `${value.slice(0, Math.max(0, max - 3))}...`;
+}
+
+function sanitizeQuestions(
+  questions: AskUserQuestionItem[],
+): AskUserQuestionItem[] {
+  return questions.map((q) => ({
+    question: truncate(sanitizeText(q.question), MAX_QUESTION_LEN),
+    header: truncate(sanitizeText(q.header), MAX_HEADER_LEN),
+    multiSelect: !!q.multiSelect,
+    options: q.options.map((o) => ({
+      label: truncate(sanitizeText(o.label), MAX_OPTION_LABEL_LEN),
+      description: truncate(
+        sanitizeText(o.description),
+        MAX_OPTION_DESCRIPTION_LEN,
+      ),
+    })),
+  }));
+}
+
+function readApproval(file: string): ApprovalFile | undefined {
+  try {
+    const raw = readFileSync(file, "utf-8");
+    return JSON.parse(raw) as ApprovalFile;
+  } catch {
+    return undefined;
+  }
+}
+
+function safeUnlink(file: string): void {
+  try {
+    if (existsSync(file)) unlinkSync(file);
+  } catch {
+    // Best-effort cleanup; the approval directory is recreated each call.
+  }
+}
+
+interface PollOutcome {
+  kind: "answered" | "declined" | "cancelled" | "timeout" | "aborted";
+  answers: Record<string, string | string[]>;
+  reason?: string;
+}
+
+/**
+ * Wait for the frontend to update the approval file. Resolves as soon as the
+ * status flips away from "pending", the deadline elapses, or the abort signal
+ * fires. Internal polling cadence is fixed at {@link ASK_USER_QUESTION_POLL_MS}.
+ */
+export async function pollApprovalFile(
+  approvalFile: string,
+  signal: AbortSignal | undefined,
+  options: { timeoutMs?: number; pollMs?: number } = {},
+): Promise<PollOutcome> {
+  const timeoutMs = options.timeoutMs ?? ASK_USER_QUESTION_TIMEOUT_MS;
+  const pollMs = options.pollMs ?? ASK_USER_QUESTION_POLL_MS;
+  const deadline = Date.now() + timeoutMs;
+  let lastApproval: ApprovalFile | undefined;
+
+  while (true) {
+    if (signal?.aborted) {
+      return { kind: "aborted", answers: lastApproval?.answers ?? {} };
+    }
+
+    const approval = readApproval(approvalFile);
+    if (approval) lastApproval = approval;
+
+    if (approval && approval.status !== "pending") {
+      const answers = approval.answers ?? {};
+      if (approval.status === "completed" && Object.keys(answers).length > 0) {
+        return { kind: "answered", answers };
+      }
+      if (approval.status === "declined") {
+        return { kind: "declined", answers, reason: approval.reason };
+      }
+      if (approval.status === "cancelled") {
+        return { kind: "cancelled", answers, reason: approval.reason };
+      }
+      // status === "completed" with empty answers means the user dismissed
+      // without choosing. Treat as decline.
+      return {
+        kind: "declined",
+        answers,
+        reason: approval.reason ?? "no_answer_provided",
+      };
+    }
+
+    if (Date.now() >= deadline) {
+      // Salvage partial answers if the frontend wrote some before timing out.
+      const partial = lastApproval?.answers ?? {};
+      return {
+        kind: Object.keys(partial).length > 0 ? "answered" : "timeout",
+        answers: partial,
+      };
+    }
+
+    await sleepWithAbort(
+      Math.min(pollMs, Math.max(0, deadline - Date.now())),
+      signal,
+    );
+  }
+}
+
+function sleepWithAbort(
+  ms: number,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+function formatAcceptedText(
+  questions: AskUserQuestionItem[],
+  answers: Record<string, string | string[]>,
+): string {
+  const lines: string[] = ["User answered:"];
+  for (const q of questions) {
+    const raw = answers[q.question];
+    const formatted = Array.isArray(raw)
+      ? raw.join(", ")
+      : typeof raw === "string" && raw.length > 0
+        ? raw
+        : "(no answer)";
+    lines.push(`Q: ${q.question}`);
+    lines.push(`A: ${formatted}`);
+  }
+  return lines.join("\n");
+}
+
+function formatDeclinedText(
+  reason: string,
+  partial: Record<string, string | string[]>,
+): string {
+  const partialNote =
+    Object.keys(partial).length > 0
+      ? ` Partial answers received: ${JSON.stringify(partial)}.`
+      : "";
+  return `User did not answer the questions (reason: ${reason}). Make a sensible default choice and continue, or ask again if the choice is genuinely required.${partialNote}`;
+}
+
+interface BuildOptions {
+  cwd: string;
+  /** Override timeout — primarily for tests. */
+  timeoutMs?: number;
+  /** Override poll interval — primarily for tests. */
+  pollMs?: number;
+}
+
+/**
+ * Build the AskUserQuestion ToolDefinition.
+ *
+ * The returned tool writes one approval file per call to
+ * `<cwd>/.bunny-agent/approvals/<toolCallId>.json`, then waits up to
+ * {@link ASK_USER_QUESTION_TIMEOUT_MS} for the host to update it. The tool
+ * always cleans up its own approval file on exit.
+ */
+export function buildAskUserQuestionTool(opts: BuildOptions): ToolDefinition {
+  const { cwd, timeoutMs, pollMs } = opts;
+  return {
+    name: TOOL_NAME,
+    label: "AskUserQuestion",
+    description: TOOL_DESCRIPTION,
+    promptSnippet:
+      "AskUserQuestion: ask the user 1-4 multiple-choice questions when the task is genuinely ambiguous.",
+    promptGuidelines: [
+      "Use AskUserQuestion only when the task is genuinely ambiguous and a user choice is required to proceed; otherwise pick a sensible default.",
+      "Each question must carry 2-4 mutually exclusive options. Do not add an 'Other' option — the host adds one automatically.",
+    ],
+    // Pause other tool calls while a user prompt is open; otherwise pi may
+    // surface output the user has not yet had a chance to react to.
+    executionMode: "sequential",
+    // biome-ignore lint/suspicious/noExplicitAny: TypeBox accepts plain JSON Schema literals here, see image-tools.ts.
+    parameters: askUserQuestionSchema as any,
+    async execute(toolCallId, params, signal) {
+      const raw = (params as AskUserQuestionParams).questions ?? [];
+      const sanitized = sanitizeQuestions(raw);
+      const sanitizedInput: AskUserQuestionParams = { questions: sanitized };
+
+      const approvalDir = join(cwd, APPROVAL_DIR);
+      const approvalFile = join(approvalDir, `${toolCallId}.json`);
+
+      try {
+        mkdirSync(approvalDir, { recursive: true });
+        const pending: ApprovalFile = {
+          status: "pending",
+          toolName: TOOL_NAME,
+          input: sanitizedInput,
+          questions: sanitized,
+          answers: {},
+        };
+        writeFileSync(approvalFile, JSON.stringify(pending));
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unknown error";
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `AskUserQuestion failed to create approval file: ${message}`,
+            },
+          ],
+          details: undefined,
+        };
+      }
+
+      let outcome: PollOutcome;
+      try {
+        outcome = await pollApprovalFile(approvalFile, signal, {
+          timeoutMs,
+          pollMs,
+        });
+      } finally {
+        safeUnlink(approvalFile);
+      }
+
+      if (outcome.kind === "answered") {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatAcceptedText(sanitized, outcome.answers),
+            },
+          ],
+          details: undefined,
+        };
+      }
+
+      const reason =
+        outcome.kind === "timeout"
+          ? "timeout"
+          : outcome.kind === "aborted"
+            ? "run_aborted"
+            : (outcome.reason ?? outcome.kind);
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: formatDeclinedText(reason, outcome.answers),
+          },
+        ],
+        details: undefined,
+      };
+    },
+  };
+}

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -1,4 +1,10 @@
 export type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+export {
+  ASK_USER_QUESTION_POLL_MS,
+  ASK_USER_QUESTION_TIMEOUT_MS,
+  type AskUserQuestionParams,
+  buildAskUserQuestionTool,
+} from "./ask-user-question-tool.js";
 export type { ImageToolDetails, ImageToolUsageDetails } from "./image-tools.js";
 export {
   createPiRunner,

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -356,9 +356,8 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
             ? buildToolDefinitionsFromRefs(options.toolRefs)
             : [];
 
-        // AskUserQuestion is always available — it is the model's only way to
-        // surface a structured choice to the user, so allowedTools must not
-        // gate it. Mirrors how runner-claude force-includes Skill/WebSearch.
+        // AskUserQuestion is registered as a normal custom tool — callers opt
+        // in by including "AskUserQuestion" in their allowedTools list.
         // Timeout override: ASK_USER_QUESTION_TOOL_TIMEOUT (seconds).
         // Resolution order: options.env -> process.env -> built-in default.
         const askTimeoutSeconds = parsePositiveInt(
@@ -371,6 +370,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
               ? askTimeoutSeconds * 1000
               : undefined,
         });
+        customTools.push(askUserQuestionTool);
 
         const { session } = await createAgentSession({
           cwd,
@@ -382,7 +382,6 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           customTools: [
             ...applyAllowedTools(customTools, options.allowedTools),
             ...toolRefDefinitions,
-            askUserQuestionTool,
           ],
         });
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -9,6 +9,7 @@ import {
   SessionManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import { buildAskUserQuestionTool } from "./ask-user-question-tool.js";
 import { BunnyAgentResourceLoader } from "./bunny-agent-resource-loader.js";
 import { buildImageEditTool, buildImageGenerateTool } from "./image-tools.js";
 import {
@@ -117,6 +118,13 @@ function getEnvValue(
   name: string,
 ): string | undefined {
   return optionsEnv?.[name] ?? process.env[name];
+}
+
+/** Parse a string into a positive integer, returning undefined on any non-positive or invalid value. */
+function parsePositiveInt(value: string | undefined): number | undefined {
+  if (value === undefined || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : undefined;
 }
 
 function applyModelOverrides(
@@ -348,6 +356,22 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
             ? buildToolDefinitionsFromRefs(options.toolRefs)
             : [];
 
+        // AskUserQuestion is always available — it is the model's only way to
+        // surface a structured choice to the user, so allowedTools must not
+        // gate it. Mirrors how runner-claude force-includes Skill/WebSearch.
+        // Timeout override: ASK_USER_QUESTION_TOOL_TIMEOUT (seconds).
+        // Resolution order: options.env -> process.env -> built-in default.
+        const askTimeoutSeconds = parsePositiveInt(
+          getEnvValue(options.env, "ASK_USER_QUESTION_TOOL_TIMEOUT"),
+        );
+        const askUserQuestionTool = buildAskUserQuestionTool({
+          cwd,
+          timeoutMs:
+            askTimeoutSeconds !== undefined
+              ? askTimeoutSeconds * 1000
+              : undefined,
+        });
+
         const { session } = await createAgentSession({
           cwd,
           model,
@@ -358,6 +382,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           customTools: [
             ...applyAllowedTools(customTools, options.allowedTools),
             ...toolRefDefinitions,
+            askUserQuestionTool,
           ],
         });
 

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -1,5 +1,6 @@
 import type { Usage } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
+import { sanitizeToolCallId } from "./ask-user-question-tool.js";
 import type { ToolDetailsWithUsage } from "./tool-details.js";
 import {
   accumulateToolUsage,
@@ -103,17 +104,18 @@ export class PiAISDKStreamConverter {
 
     if (event.type === "tool_execution_start") {
       chunks.push(...this.endTextStreamIfOpen());
+      const toolCallId = sanitizeToolCallId(event.toolCallId);
       chunks.push(
         sseData({
           type: "tool-input-start",
-          toolCallId: event.toolCallId,
+          toolCallId,
           toolName: event.toolName,
           dynamic: true,
           providerExecuted: true,
         }),
         sseData({
           type: "tool-input-available",
-          toolCallId: event.toolCallId,
+          toolCallId,
           toolName: event.toolName,
           input: event.args,
           dynamic: true,
@@ -128,11 +130,12 @@ export class PiAISDKStreamConverter {
       const raw = (event.result as { details?: ToolDetailsWithUsage })?.details
         ?.usage?.raw;
       if (raw != null) accumulateToolUsage(this.toolUsageTally, raw);
+      const toolCallId = sanitizeToolCallId(event.toolCallId);
       if (event.isError) {
         chunks.push(
           sseData({
             type: "tool-output-error",
-            toolCallId: event.toolCallId,
+            toolCallId,
             errorText: output,
             dynamic: true,
             providerExecuted: true,
@@ -142,7 +145,7 @@ export class PiAISDKStreamConverter {
         chunks.push(
           sseData({
             type: "tool-output-available",
-            toolCallId: event.toolCallId,
+            toolCallId,
             output,
             dynamic: true,
             providerExecuted: true,


### PR DESCRIPTION
## Summary

- Adds an always-on `AskUserQuestion` custom tool to the pi runner so the model can surface a structured choice (1-4 questions × 2-4 options, with `multiSelect`) to the user mid-run, the same way Claude Code does in `runner-claude`.
- Reuses runner-claude's `.bunny-agent/approvals/<toolCallId>.json` file shape, so any frontend already wired for Claude Code approvals serves pi without changes.
- Display text (question / header / option labels) is sanitized via the same ANSI / control-character scrubber openclaw uses in its MCP elicitation bridge (`extensions/codex/src/app-server/elicitation-bridge.ts`), with matching length caps.
- Default 120s timeout, matching openclaw's `DEFAULT_CODEX_APPROVAL_TIMEOUT_MS`. Overridable via `ASK_USER_QUESTION_TOOL_TIMEOUT` (seconds), resolved as `options.env` → `process.env` → default. Wired to the run's `AbortSignal` so an aborted run terminates the prompt immediately.
- The tool is intentionally exempt from `allowedTools` filtering — it is the model's only hook back into the user, so callers should not be able to silently disable it.

See `docs/changelog/2026-05-21-runner-pi-ask-user-question.md` for the full rationale.

## Test plan

- [x] `pnpm --filter @bunny-agent/runner-pi typecheck`
- [x] `pnpm --filter @bunny-agent/runner-pi test` — 121 tests, including 8 new tests covering happy path / multi-select / decline / timeout / abort / sanitize / approval-file cleanup
- [x] `pnpm lint`
- [ ] Manual smoke through the runner-cli once the frontend wires up an `AskUserQuestion`-style approval UI for pi

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1554" height="1376" alt="image" src="https://github.com/user-attachments/assets/30378d4a-e411-4fd7-9132-e249a4c4e6ef" />
