### PR TITLE
refactor(daemon): unify coding-run env preparation

### DIFF
--- a/apps/daemon/src/__tests__/coding-run-env.test.ts
+++ b/apps/daemon/src/__tests__/coding-run-env.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  mergeCodingRunProcessEnv,
+  prepareCodingRunEnv,
   sanitizeCodingRunBodyEnv,
   sanitizeCodingRunBodySystemEnv,
 } from "../coding-run-env.js";
@@ -48,21 +48,31 @@ describe("sanitizeCodingRunBodySystemEnv", () => {
   });
 });
 
-describe("mergeCodingRunProcessEnv", () => {
+describe("prepareCodingRunEnv", () => {
   it("inline env overrides daemon env", () => {
-    const merged = mergeCodingRunProcessEnv(
+    const { env, systemEnv } = prepareCodingRunEnv(
       { PATH: "/usr/bin", FOO: "daemon" },
       { env: { FOO: "inline", BAR: "new" } },
     );
-    expect(merged).toEqual({
+    expect(env).toEqual({
       PATH: "/usr/bin",
       FOO: "inline",
       BAR: "new",
     });
+    expect(systemEnv).toBeUndefined();
   });
 
   it("returns daemon env unchanged when body has no env", () => {
-    const merged = mergeCodingRunProcessEnv({ PATH: "/usr/bin" }, {});
-    expect(merged).toEqual({ PATH: "/usr/bin" });
+    const { env, systemEnv } = prepareCodingRunEnv({ PATH: "/usr/bin" }, {});
+    expect(env).toEqual({ PATH: "/usr/bin" });
+    expect(systemEnv).toBeUndefined();
+  });
+
+  it("sanitizes systemEnv from body", () => {
+    const { systemEnv } = prepareCodingRunEnv(
+      { PATH: "/usr/bin" },
+      { systemEnv: { PATH: "/usr/bin", BAD: 42 } },
+    );
+    expect(systemEnv).toEqual({ PATH: "/usr/bin" });
   });
 });

--- a/apps/daemon/src/coding-run-env.ts
+++ b/apps/daemon/src/coding-run-env.ts
@@ -41,15 +41,24 @@ export interface CodingRunBodyWithEnv {
   systemEnv?: unknown;
 }
 
+export interface PreparedCodingRunEnv {
+  /** Full env passed to the runner (daemon env + inline body.env). */
+  env: Record<string, string>;
+  /** Sanitized subset of env keys safe to expose to the bash tool. */
+  systemEnv: Record<string, string> | undefined;
+}
+
 /**
- * Merge daemon `process.env` with optional inline `env` from the request JSON.
+ * Sanitize and merge env-related fields from a `/api/coding/run` body.
+ * Returns the runner env (daemon env + inline `body.env`) and the
+ * sanitized `systemEnv` subset, with no body mutation.
  */
-export function mergeCodingRunProcessEnv(
+export function prepareCodingRunEnv(
   daemonEnv: Record<string, string>,
   body: CodingRunBodyWithEnv,
-): Record<string, string> {
-  let merged = { ...daemonEnv };
+): PreparedCodingRunEnv {
   const inline = sanitizeCodingRunBodyEnv(body.env);
-  if (inline) merged = { ...merged, ...inline };
-  return merged;
+  const env = inline ? { ...daemonEnv, ...inline } : { ...daemonEnv };
+  const systemEnv = sanitizeCodingRunBodySystemEnv(body.systemEnv);
+  return { env, systemEnv };
 }

--- a/apps/daemon/src/nextjs.ts
+++ b/apps/daemon/src/nextjs.ts
@@ -15,10 +15,7 @@
  * Requests to /api/daemon/api/coding/run    → daemon /api/coding/run (NDJSON stream)
  */
 
-import {
-  mergeCodingRunProcessEnv,
-  sanitizeCodingRunBodySystemEnv,
-} from "./coding-run-env.js";
+import { prepareCodingRunEnv } from "./coding-run-env.js";
 import { parseMultipart } from "./multipart.js";
 import { DaemonRouter } from "./router.js";
 import { codingRunStream, type RunRequest } from "./routes/coding.js";
@@ -45,10 +42,8 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
     // Streaming: /api/coding/run → NDJSON stream
     if (method === "POST" && pathname === "/api/coding/run") {
       const body = (await req.json().catch(() => ({}))) as RunRequest;
-      const mergedEnv = mergeCodingRunProcessEnv(env, body);
-      const sanitizedSystemEnv = sanitizeCodingRunBodySystemEnv(body.systemEnv);
-      if (sanitizedSystemEnv) body.systemEnv = sanitizedSystemEnv;
-      else delete body.systemEnv;
+      const { env: mergedEnv, systemEnv } = prepareCodingRunEnv(env, body);
+      body.systemEnv = systemEnv;
       return codingRunStream(body, mergedEnv);
     }
 

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,8 +1,8 @@
 import * as http from "node:http";
 import { URL } from "node:url";
 import {
-  mergeCodingRunProcessEnv,
-  sanitizeCodingRunBodySystemEnv,
+  type CodingRunBodyWithEnv,
+  prepareCodingRunEnv,
 } from "./coding-run-env.js";
 import { parseMultipart } from "./multipart.js";
 import { DaemonRouter } from "./router.js";
@@ -39,15 +39,11 @@ export function createDaemon(config: DaemonConfig): http.Server {
           string,
           unknown
         >;
-        const mergedEnv = mergeCodingRunProcessEnv(env, body);
-        const sanitizedSystemEnv = sanitizeCodingRunBodySystemEnv(
-          body.systemEnv,
+        const { env: mergedEnv, systemEnv } = prepareCodingRunEnv(
+          env,
+          body as CodingRunBodyWithEnv,
         );
-        if (sanitizedSystemEnv) {
-          body.systemEnv = sanitizedSystemEnv;
-        } else {
-          delete body.systemEnv;
-        }
+        body.systemEnv = systemEnv;
         return bunnyAgentRun(
           body as unknown as Parameters<typeof bunnyAgentRun>[0],
           res,


### PR DESCRIPTION
## Summary
- Replace `mergeCodingRunProcessEnv` + `sanitizeCodingRunBodySystemEnv` two-step dance with a single `prepareCodingRunEnv` that returns `{ env, systemEnv }`
- Drop the awkward `delete body.systemEnv` branch in both `nextjs.ts` and `server.ts`; callers now do a straight assignment
- Update tests to cover the unified entry point

## Test plan
- [x] `pnpm --filter @bunny-agent/daemon test`
- [x] `pnpm -r typecheck`
- [x] `pnpm run -w lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)