### PR TITLE
fix(docker): apply pi-coding-agent patch in published image

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Stage pi-coding-agent patch into docker context
+        run: cp patches/@earendil-works__pi-coding-agent@0.78.0.patch docker/bunny-agent-claude/pi-coding-agent.patch
+
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v6

--- a/docker/bunny-agent-claude/.gitignore
+++ b/docker/bunny-agent-claude/.gitignore
@@ -6,3 +6,6 @@
 
 # Environment variables
 .env
+
+# Patch file staged by CI from ../../patches/ before docker build
+pi-coding-agent.patch

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -31,6 +31,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     python3 \
     python3-pip \
     nginx \
+    patch \
     && rm -rf /var/lib/apt/lists/* \
     && break || sleep 5; \
     done
@@ -56,6 +57,15 @@ RUN mkdir -p /opt/bunny-agent && \
     rm package.json package-lock.json && \
     npm cache clean --force && \
     chown -R agent:agent /opt/bunny-agent
+
+# Apply pi-coding-agent patch so the harness uses the caller-provided system
+# prompt (appendSystemPrompt) as the opening identity instead of the default
+# "operating inside pi" wording. Mirrors patches/@earendil-works__pi-coding-agent@0.78.0.patch.
+COPY pi-coding-agent.patch /tmp/pi-coding-agent.patch
+RUN cd /opt/bunny-agent/node_modules/@earendil-works/pi-coding-agent && \
+    patch -p1 < /tmp/pi-coding-agent.patch && \
+    rm /tmp/pi-coding-agent.patch && \
+    chown -R agent:agent /opt/bunny-agent/node_modules/@earendil-works/pi-coding-agent
 
 # Install Playwright Chromium browser and system dependencies.
 # Refresh apt signing keys before Playwright runs apt-get again: under buildx+QEMU

--- a/patches/@earendil-works__pi-coding-agent@0.78.0.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.78.0.patch
@@ -1,5 +1,27 @@
+diff --git a/dist/core/system-prompt.js b/dist/core/system-prompt.js
+index 4fa08b2a2665ee733849ba27ad144289a9c943e1..b59cbb23ca27bc1508161ef37b85df989b24357a 100644
+--- a/dist/core/system-prompt.js
++++ b/dist/core/system-prompt.js
+@@ -78,7 +78,7 @@ export function buildSystemPrompt(options) {
+     addGuideline("Be concise in your responses");
+     addGuideline("Show file paths clearly when working with files");
+     const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
+-    let prompt = `You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
++    let prompt = `${appendSystemPrompt || "You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files."}
+ 
+ Available tools:
+ ${toolsList}
+@@ -96,7 +96,7 @@ Pi documentation (read only when the user asks about pi itself, its SDK, extensi
+ - When asked about: extensions (docs/extensions.md, examples/extensions/), themes (docs/themes.md), skills (docs/skills.md), prompt templates (docs/prompt-templates.md), TUI components (docs/tui.md), keybindings (docs/keybindings.md), SDK integrations (docs/sdk.md), custom providers (docs/custom-provider.md), adding models (docs/models.md), pi packages (docs/packages.md)
+ - When working on pi topics, read the docs and examples, and follow .md cross-references before implementing
+ - Always read pi .md files completely and follow links to related docs (e.g., tui.md for TUI API details)`;
+-    if (appendSection) {
++    if (!appendSystemPrompt && appendSection) {
+         prompt += appendSection;
+     }
+     // Append project context files
 diff --git a/package.json b/package.json
-index 60e3a139e6ee936f79c5061672c5e76948f96be2..7bba6db47ecf5f675fa8a32932713d2065f2ff8f 100644
+index b9fdb2891cd3a270322616933e83710dac6f809d..f228025f57668644ae4309ac7ec8f4f591b8ccb3 100644
 --- a/package.json
 +++ b/package.json
 @@ -4,7 +4,8 @@

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,8 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent@0.78.0':
-    hash: 2cf65fcc8d0948bf8ff9c0123a54dfd0cea061c6e50f71e56c22d3bbcd52865b
+    hash: cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23
     path: patches/@earendil-works__pi-coding-agent@0.78.0.patch
-  openai@6.26.0:
-    hash: f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01
-    path: patches/openai@6.26.0.patch
 
 importers:
 
@@ -145,7 +142,7 @@ importers:
         version: 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.78.0
-        version: 0.78.0(patch_hash=2cf65fcc8d0948bf8ff9c0123a54dfd0cea061c6e50f71e56c22d3bbcd52865b)(ws@8.19.0)(zod@4.3.6)
+        version: 0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)
       '@openai/codex-sdk':
         specifier: ^0.110.0
         version: 0.110.0
@@ -595,7 +592,7 @@ importers:
         version: 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.78.0
-        version: 0.78.0(patch_hash=2cf65fcc8d0948bf8ff9c0123a54dfd0cea061c6e50f71e56c22d3bbcd52865b)(ws@8.19.0)(zod@4.3.6)
+        version: 0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.48
@@ -8672,7 +8669,7 @@ snapshots:
       '@google/genai': 1.44.0
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6)
+      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.38
@@ -8696,7 +8693,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6)
+      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -8741,7 +8738,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=2cf65fcc8d0948bf8ff9c0123a54dfd0cea061c6e50f71e56c22d3bbcd52865b)(ws@8.19.0)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.78.0(ws@8.19.0)(zod@4.3.6)
@@ -13881,7 +13878,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6):
+  openai@6.26.0(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   '@earendil-works/pi-coding-agent@0.78.0':
     hash: cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23
     path: patches/@earendil-works__pi-coding-agent@0.78.0.patch
+  openai@6.26.0:
+    hash: f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01
+    path: patches/openai@6.26.0.patch
 
 importers:
 
@@ -8669,7 +8672,7 @@ snapshots:
       '@google/genai': 1.44.0
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.38
@@ -8693,7 +8696,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.19.0)(zod@4.3.6)
+      openai: 6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6)
       partial-json: 0.1.7
       typebox: 1.1.38
     transitivePeerDependencies:
@@ -13878,7 +13881,7 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  openai@6.26.0(ws@8.19.0)(zod@4.3.6):
+  openai@6.26.0(patch_hash=f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01)(ws@8.19.0)(zod@4.3.6):
     optionalDependencies:
       ws: 8.19.0
       zod: 4.3.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,4 +7,5 @@ ignoredBuiltDependencies:
   - esbuild
   - sharp
 patchedDependencies:
-  '@earendil-works/pi-coding-agent@0.74.0': patches/@earendil-works__pi-coding-agent@0.74.0.patch
+  '@earendil-works/pi-coding-agent@0.78.0': patches/@earendil-works__pi-coding-agent@0.78.0.patch
+  'openai@6.26.0': patches/openai@6.26.0.patch


### PR DESCRIPTION
## Summary

- pnpm patches only apply inside the monorepo, so the published `vikadata/bunny-agent` image was still running the unpatched `@earendil-works/pi-coding-agent` from npm. The intended system-prompt override never took effect in production.
- Dockerfile now installs `patch`, copies the patch into the image, and applies it against the npm-installed `pi-coding-agent` under `/opt/bunny-agent/node_modules` after `npm install`.
- `publish-docker.yml` stages `patches/@earendil-works__pi-coding-agent@0.78.0.patch` into the docker build context as `pi-coding-agent.patch` before the buildx step, so the same patch the repo tracks is the one applied to the image (single source of truth).
- `docker/bunny-agent-claude/.gitignore` ignores the staged patch file so the CI-copied artifact doesn't get committed by accident.
- `pnpm-workspace.yaml` had a stale `0.74.0` entry pointing at a file that no longer existed — replaced with the real `0.78.0` patch so `pnpm install` doesn't silently fall back.

## What the patch does (refresher)

In `pi-coding-agent`'s `buildSystemPrompt`, when the caller passes `appendSystemPrompt`, use it as the opening identity instead of the default "operating inside pi, a coding agent harness" wording (and skip the duplicate append). When `appendSystemPrompt` is empty, behavior is unchanged.

## Test plan

- [ ] `pnpm install --frozen-lockfile` succeeds (no stale patch reference)
- [ ] Local `docker build` from `docker/bunny-agent-claude/` after `cp patches/@earendil-works__pi-coding-agent@0.78.0.patch docker/bunny-agent-claude/pi-coding-agent.patch` succeeds
- [ ] Inside the built image: `grep "appendSystemPrompt ||" /opt/bunny-agent/node_modules/@earendil-works/pi-coding-agent/dist/core/system-prompt.js` returns a match
- [ ] CI `Publish Docker Image` workflow stages the patch and the build step still passes on both `linux/amd64` and `linux/arm64`
- [ ] Buda chat against the new image shows the caller-supplied `staticSystemPrompt` as the first line of the model's system prompt (no "operating inside pi" preamble)

## Maintenance note

When bumping `@earendil-works/pi-coding-agent` to a new version, both the `patches/*.patch` filename and the `cp ...@0.78.0.patch` line in `publish-docker.yml` need to be updated to match. Patch failure during docker build is fail-loud — the workflow will go red rather than silently shipping the unpatched binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)