### PR TITLE
feat(runner-pi): add forkFrom to snapshot-clone a source session

### DIFF
--- a/apps/daemon/src/routes/coding.ts
+++ b/apps/daemon/src/routes/coding.ts
@@ -14,6 +14,15 @@ export interface RunRequest {
   maxTurns?: number;
   allowedTools?: string[];
   resume?: string;
+  /**
+   * Source pi session id to fork from before running the current turn. When
+   * set, the pi runner snapshot-clones the source session into a fresh one
+   * (new id, header.parentSession = source) and continues chat on top of the
+   * copied history. Mutually exclusive with `resume`.
+   *
+   * Currently only the `pi` runner consumes this; other runners ignore it.
+   */
+  forkFrom?: string;
   skillPaths?: string[];
   cwd?: string;
   /** Skip tool approval checks (bypass permissions). */
@@ -81,6 +90,7 @@ export async function bunnyAgentRun(
       maxTurns: req.maxTurns,
       allowedTools: req.allowedTools,
       resume: req.resume,
+      forkFrom: req.forkFrom,
       skillPaths: req.skillPaths,
       cwd: req.cwd ?? process.env.BUNNY_AGENT_ROOT ?? "/workspace",
       yolo: req.yolo,
@@ -144,6 +154,7 @@ export function codingRunStream(
           maxTurns: req.maxTurns,
           allowedTools: req.allowedTools,
           resume: req.resume,
+          forkFrom: req.forkFrom,
           skillPaths: req.skillPaths,
           cwd: req.cwd ?? process.env.BUNNY_AGENT_ROOT ?? "/workspace",
           yolo: req.yolo,

--- a/docs/changelog/2026-07-03-pi-runner-fork-from.md
+++ b/docs/changelog/2026-07-03-pi-runner-fork-from.md
@@ -1,0 +1,101 @@
+# pi-runner: add forkFrom option
+
+Date: 2026-07-03
+
+## Summary
+
+Add a `forkFrom?: string` option to `runner-pi` (and the daemon `/api/coding/run`
+request) that snapshot-clones a source pi session into a fresh session file and
+runs the current turn on top of that copy. Mutually exclusive with `sessionId`.
+
+This is the sandagent-side hook that lets product apps implement
+"save a shared session and continue chatting" without doing pi jsonl surgery
+themselves — they pass the source session id, the daemon calls
+`SessionManager.forkFrom(sourcePath, cwd)`, and the new session id is emitted
+back through the existing message-metadata channel.
+
+## Motivation
+
+Product apps that share agent sessions (e.g. buda "Save & Continue" from a
+public share) need to hand a receiver a working session that:
+
+- has the full source history so the LLM keeps context,
+- has a **new** pi session id so subsequent resumes don't collide with the
+  source, and
+- lives under the receiver's cwd / sandbox rather than the source's.
+
+`SessionManager.forkFrom` from `@earendil-works/pi-coding-agent` already does
+exactly this at the file level, but until now the runner only exposed
+`sessionId` for resume — there was no way to trigger a fork through the
+daemon's HTTP surface. Callers were forced to either (a) reimplement jsonl
+copying outside of pi-mono, or (b) rebuild history by feeding all prior
+messages back in as a fresh session, which loses pi-mono's compaction and
+blows up context on long conversations.
+
+## Changes
+
+- `packages/runner-pi/src/pi-runner.ts`
+  - Add `forkFrom?: string` to `PiRunnerOptions`. Accepts a bare pi session
+    id or a full session file path.
+  - In `run()`, resolve `forkFrom` first (before `sessionId`): call
+    `resolveSessionPathById(cwd, forkFrom)`, then
+    `SessionManager.forkFrom(sourcePath, cwd)`. Throw if the source can't
+    be located so callers get a clear error instead of silently landing in
+    a brand new empty session.
+  - `forkFrom` and `sessionId` are mutually exclusive at the semantic level:
+    if both are set, `forkFrom` wins and `sessionId` is ignored. The new id
+    is emitted through the existing `message-metadata.sessionId` channel so
+    downstream resumes work without extra bookkeeping.
+- `packages/runner-pi/src/session-utils.ts`
+  - `resolveSessionPathById` now also accepts a full path (returns it
+    unchanged when it contains `/`). Eliminates the duplicated
+    "path or id" ternary previously living in `pi-runner.ts`.
+- `packages/runner-harness/src/runner.ts`
+  - Add `forkFrom?: string` to `RunnerCoreOptions` and thread it into
+    `createPiRunner`. Non-pi runners ignore it.
+- `apps/daemon/src/routes/coding.ts`
+  - Add `forkFrom?: string` to `RunRequest` and forward it to
+    `createRunner` in both the `bunnyAgentRun` (Node http) and
+    `codingRunStream` (Web Response) code paths. No new endpoint —
+    reuses `/api/coding/run`.
+
+## Tests
+
+- `packages/runner-pi/src/__tests__/pi-runner.test.ts`
+  - `forkFrom` calls `SessionManager.forkFrom` with `(sourcePath, targetCwd)`.
+  - `forkFrom` wins over `sessionId` when both are set; `SessionManager.open`
+    is not called.
+  - Unresolvable `forkFrom` id throws
+    `Pi runner: forkFrom source session not found: <id>` before touching
+    `SessionManager.forkFrom`.
+- `packages/runner-pi/src/__tests__/session-utils.test.ts`
+  - `resolveSessionPathById` passes through paths containing `/` unchanged.
+  - Returns `undefined` for bare ids that don't exist in the sessions dir.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/runner-pi test` — 128 pass, 0 fail
+- `pnpm --filter @bunny-agent/daemon test` — 103 pass, 0 fail
+- `pnpm -r typecheck` — clean (after rebuild of runner-pi + runner-harness so
+  downstream tsconfigs see the new field via published `dist/*.d.ts`)
+- `pnpm run -w lint` — clean
+
+## Non-goals
+
+- No large-session guard on the fork path. `SessionManager.forkFrom` inherits
+  the same in-memory load characteristics as `loadEntriesFromFile`; the
+  existing `MAX_SESSION_FILE_BYTES = 10MB` resume guard bounds practical
+  session sizes upstream so fork-time OOM is not a realistic risk today.
+  If session sizes grow beyond that, a fork-time size check can be added in
+  a follow-up without changing the API.
+- No cross-sandbox fork. `forkFrom` operates against session files already
+  visible to the calling daemon's fs. Getting a source session into the
+  target sandbox (e.g. object-storage snapshot upload/download) is a caller
+  concern and out of scope here.
+
+## Follow-ups
+
+- On the buda side (kapps repo, separate PR): wire
+  `continueFromSharedSession` to persist the source pi session id, and have
+  `chat-service` set `forkFrom` on the daemon request the first time a
+  cloned session is used.

--- a/packages/runner-harness/src/runner.ts
+++ b/packages/runner-harness/src/runner.ts
@@ -40,6 +40,15 @@ export interface RunnerCoreOptions extends BaseRunnerOptions {
    * Currently only the `pi` runner consumes this; other runners ignore it.
    */
   effort?: string;
+  /**
+   * Source session ID to fork from before running the current turn. When set,
+   * the runner snapshot-clones the source session into a fresh session with a
+   * new id (header.parentSession points at the source) and continues chat on
+   * top of that copied history. Mutually exclusive with `resume`.
+   *
+   * Currently only the `pi` runner consumes this; other runners ignore it.
+   */
+  forkFrom?: string;
 }
 
 export function createRunner(
@@ -103,6 +112,7 @@ function dispatchRunner(
         ...base,
         cwd,
         sessionId: base.resume,
+        forkFrom: options.forkFrom,
         skillPaths: options.skillPaths ?? discoverSkillPaths(cwd),
         toolRefs: options.toolRefs,
         effort: options.effort,

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -196,9 +196,12 @@ vi.mock("@earendil-works/pi-coding-agent", () => {
     lsTool: { name: "ls" },
     SessionManager: {
       continueRecent: vi.fn().mockReturnValue({}),
-      create: vi.fn().mockReturnValue({}),
+      create: vi.fn().mockReturnValue({
+        getSessionDir: () => "/tmp/pi-runner-mock-sessions",
+      }),
       open: vi.fn().mockReturnValue({}),
       list: vi.fn().mockResolvedValue([]),
+      forkFrom: vi.fn().mockReturnValue({}),
     },
     createAgentSession: vi.fn().mockImplementation(async () => {
       const session = new MockSession();
@@ -793,6 +796,72 @@ describe("createPiRunner", () => {
 
     // process.env must not be permanently modified
     expect(process.env[key]).toBeUndefined();
+  });
+
+  it("snapshot-clones via SessionManager.forkFrom when forkFrom is set", async () => {
+    const { SessionManager } = await import("@earendil-works/pi-coding-agent");
+    const forkFromSpy = vi
+      .mocked(SessionManager.forkFrom)
+      .mockClear()
+      .mockReturnValue(
+        {} as unknown as ReturnType<typeof SessionManager.forkFrom>,
+      );
+
+    const runner = createPiRunner({
+      model: "google:gemini-2.5-pro",
+      forkFrom: "/tmp/pi-sessions/2026-07-03_src.jsonl",
+      cwd: "/workspace/target",
+    });
+    for await (const _ of runner.run("continue from shared")) {
+      // consume until done
+    }
+
+    expect(forkFromSpy).toHaveBeenCalledTimes(1);
+    const [sourcePath, targetCwd] = forkFromSpy.mock.calls[0] ?? [];
+    expect(sourcePath).toBe("/tmp/pi-sessions/2026-07-03_src.jsonl");
+    expect(targetCwd).toBe("/workspace/target");
+  });
+
+  it("prefers forkFrom over sessionId when both are provided", async () => {
+    const { SessionManager } = await import("@earendil-works/pi-coding-agent");
+    const forkFromSpy = vi
+      .mocked(SessionManager.forkFrom)
+      .mockClear()
+      .mockReturnValue(
+        {} as unknown as ReturnType<typeof SessionManager.forkFrom>,
+      );
+    const openSpy = vi.mocked(SessionManager.open).mockClear();
+
+    const runner = createPiRunner({
+      model: "google:gemini-2.5-pro",
+      forkFrom: "/tmp/pi-sessions/src.jsonl",
+      sessionId: "/tmp/pi-sessions/should-be-ignored.jsonl",
+    });
+    for await (const _ of runner.run("fork wins")) {
+      // consume
+    }
+
+    expect(forkFromSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("throws when forkFrom source session cannot be resolved by id", async () => {
+    const { SessionManager } = await import("@earendil-works/pi-coding-agent");
+    const forkFromSpy = vi.mocked(SessionManager.forkFrom).mockClear();
+
+    const runner = createPiRunner({
+      model: "google:gemini-2.5-pro",
+      // No slash → treated as bare session id → resolveSessionPathById returns
+      // undefined against a scratch dir → the runner throws before forkFrom.
+      forkFrom: "sess_does_not_exist_zzz",
+    });
+
+    await expect(async () => {
+      for await (const _ of runner.run("missing source")) {
+        // consume until throw
+      }
+    }).rejects.toThrow(/forkFrom source session not found/);
+    expect(forkFromSpy).not.toHaveBeenCalled();
   });
 
   it("accumulates generate_image tool usage into finish messageMetadata", async () => {

--- a/packages/runner-pi/src/__tests__/session-utils.test.ts
+++ b/packages/runner-pi/src/__tests__/session-utils.test.ts
@@ -6,6 +6,7 @@ import {
   extractLastCompactionSummary,
   isSessionFileTooLarge,
   MAX_SESSION_FILE_BYTES,
+  resolveSessionPathById,
 } from "../session-utils.js";
 
 describe("session-utils", () => {
@@ -145,6 +146,19 @@ describe("session-utils", () => {
       const file = join(tmpDir, "empty.jsonl");
       writeFileSync(file, "");
       expect(extractLastCompactionSummary(file)).toBeUndefined();
+    });
+  });
+
+  describe("resolveSessionPathById", () => {
+    it("returns the input unchanged when it already looks like a path", () => {
+      const p = "/tmp/pi-sessions/2026-07-03_abc.jsonl";
+      // No filesystem lookup — the caller owns paths that contain '/'.
+      expect(resolveSessionPathById(tmpDir, p)).toBe(p);
+    });
+
+    it("returns undefined when id cannot be resolved in the sessions dir", () => {
+      // tmpDir is not a real pi sessions dir; readdir throws → undefined.
+      expect(resolveSessionPathById(tmpDir, "sess_missing")).toBeUndefined();
     });
   });
 });

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -54,6 +54,20 @@ export interface PiRunnerOptions {
    * Sessions use Bunny's patched pi config directory (~/.bunny/agent/sessions/...) so workspace is not used.
    */
   sessionId?: string;
+  /**
+   * Source session ID to fork from. When set, the runner locates the source
+   * session file, snapshot-clones it via SessionManager.forkFrom into a brand
+   * new session (with a fresh id and header pointing at the source as
+   * parentSession), and runs the current turn on top of that copied history.
+   *
+   * Mutually exclusive with `sessionId`. If both are set, `forkFrom` wins and
+   * `sessionId` is ignored (the fork produces the new session id, which is
+   * emitted back to the caller via message-metadata for subsequent resumes).
+   *
+   * The source may be either a raw pi session id or a full session file path
+   * (contains '/'), mirroring how `sessionId` accepts both.
+   */
+  forkFrom?: string;
   /** Additional skill paths (files or directories) */
   skillPaths?: string[];
   /**
@@ -288,16 +302,31 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         modelRegistry.authStorage.setRuntimeApiKey(provider, inlineApiKey);
       }
       try {
+        const forkFrom = options.forkFrom?.trim();
         const resume = options.sessionId?.trim();
         const sessionManager = await (async (): Promise<
           ReturnType<typeof SessionManager.create>
         > => {
-          if (resume !== undefined && resume !== "") {
-            if (resume.includes("/")) {
-              // Full path provided — open directly
-              return SessionManager.open(resume);
+          // forkFrom wins over sessionId: snapshot-clone the source session
+          // into a fresh session file (new id, header.parentSession = source)
+          // and run the current turn on top of that copy. The new id is
+          // emitted back via message-metadata so callers can resume from it.
+          if (forkFrom) {
+            const sourcePath = resolveSessionPathById(cwd, forkFrom);
+            console.error(
+              `${LOG_PREFIX} fork: sourceId=${forkFrom} sourcePath=${sourcePath ?? "(not found)"}`,
+            );
+            if (!sourcePath) {
+              throw new Error(
+                `Pi runner: forkFrom source session not found: ${forkFrom}`,
+              );
             }
-            // Find session file by id without parsing contents (OOM fix)
+            // SessionManager.forkFrom copies every non-header entry verbatim
+            // into a new file; the OOM guard used on resume does not apply
+            // because forkFrom is intended to preserve the full history.
+            return SessionManager.forkFrom(sourcePath, cwd);
+          }
+          if (resume) {
             const sessionPath = resolveSessionPathById(cwd, resume);
             console.error(
               `${LOG_PREFIX} resume: id=${resume} path=${sessionPath ?? "(not found)"}`,

--- a/packages/runner-pi/src/session-utils.ts
+++ b/packages/runner-pi/src/session-utils.ts
@@ -23,21 +23,26 @@ export const MAX_SESSION_FILE_BYTES =
   Number(process.env.SANDAGENT_MAX_SESSION_BYTES) || 10 * 1024 * 1024; // 10 MB
 
 /**
- * Resolve a session file path by id without loading/parsing session contents.
+ * Resolve a session reference to an on-disk path without loading/parsing
+ * session contents.
  *
- * Pi session files are named `<timestamp>_<id>.jsonl`. This only reads
- * directory entry names — no content parsing.
+ * Accepts either:
+ *  - A full session file path (contains '/') — returned as-is.
+ *  - A bare pi session id — resolved against the pi sessions directory for
+ *    `cwd` by scanning filenames (`<timestamp>_<id>.jsonl`). Only entry names
+ *    are read; no JSON is parsed.
  *
  * @returns Full path to the session file, or undefined if not found.
  */
 export function resolveSessionPathById(
   cwd: string,
-  sessionId: string,
+  sessionIdOrPath: string,
 ): string | undefined {
+  if (sessionIdOrPath.includes("/")) return sessionIdOrPath;
   const tempMgr = SessionManager.create(cwd);
   const sessionsDir = tempMgr.getSessionDir();
   try {
-    const suffix = `_${sessionId}.jsonl`;
+    const suffix = `_${sessionIdOrPath}.jsonl`;
     const match = readdirSync(sessionsDir).find((f) => f.endsWith(suffix));
     return match ? join(sessionsDir, match) : undefined;
   } catch {


### PR DESCRIPTION
## Summary

Adds a `forkFrom?: string` option to `runner-pi`, `runner-harness`, and the daemon `/api/coding/run` request. When set, the runner resolves the source pi session (bare id or full path), calls `SessionManager.forkFrom(sourcePath, cwd)` from `@earendil-works/pi-coding-agent`, and continues the current turn on top of the copied history. Mutually exclusive with `sessionId`; the new session id flows back through the existing `message-metadata.sessionId` channel so subsequent resumes work with no extra plumbing.

Also collapses the "path or bare id" ternary in `pi-runner.ts` into `resolveSessionPathById` itself, so fork and resume share one resolver.

## Motivation

Product apps that share agent sessions (e.g. buda "Save & Continue" from a public share) need a way to hand the receiver a working session that keeps the source history, has a **new** pi session id, and lives under the receiver's cwd/sandbox. `SessionManager.forkFrom` already does this at the jsonl level, but the runner only exposed `sessionId` (resume). Without this hook, callers either reimplement jsonl copy outside pi-mono or re-seed all prior history into a fresh session — which loses pi-mono's compaction and blows up context on long conversations.

## Test plan
- [x] `pnpm --filter @bunny-agent/runner-pi test` — 128 pass
- [x] `pnpm --filter @bunny-agent/daemon test` — 103 pass
- [x] `pnpm -r typecheck` — clean (rebuild runner-pi/runner-harness first so downstream `dist/*.d.ts` picks up the new field)
- [x] `pnpm run -w lint` — clean
- [ ] Manual: buda `continueFromSharedSession` follow-up PR uses `forkFrom` and verifies the receiver session keeps history and continues without context reset

## Non-goals
- No fork-time size guard. Existing `MAX_SESSION_FILE_BYTES = 10MB` resume guard bounds source sessions upstream; a fork-time cap can be added later without changing the API.
- No cross-sandbox fork. `forkFrom` operates on files already visible to the calling daemon. Getting a source session onto the target sandbox is a caller concern.

## Follow-up
- kapps repo: `continueFromSharedSession` persists source pi session id, `chat-service` sets `forkFrom` on the first turn of a cloned session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)