### PR TITLE
feat(sdk,manager,cli): thread pi-runner forkFrom end-to-end

### DIFF
--- a/.changeset/pi-runner-fork-from-sdk-manager.md
+++ b/.changeset/pi-runner-fork-from-sdk-manager.md
@@ -1,0 +1,11 @@
+---
+"@bunny-agent/daemon": minor
+"@bunny-agent/manager": minor
+"@bunny-agent/runner-cli": minor
+"@bunny-agent/sandbox-e2b": minor
+"@bunny-agent/sandbox-sandock": minor
+"@bunny-agent/sandbox-daytona": minor
+"@bunny-agent/sdk": minor
+---
+
+Thread the pi-runner `forkFrom` option all the way from the CLI (`--fork-from`), the SDK (`createBunnyAgent({ forkFrom })`) and the manager (`StreamInput.forkFrom` / `BunnyAgentCodingRunBody.forkFrom`) down into the daemon `/api/coding/run` request body. When set, the pi runner snapshot-clones the source pi session and continues chat on top of the copied history; the new session id flows back through the existing `message-metadata.sessionId` channel. Mutually exclusive with `resume`.

--- a/apps/runner-cli/src/cli.ts
+++ b/apps/runner-cli/src/cli.ts
@@ -74,6 +74,7 @@ interface ParsedRunArgs {
   maxTurns?: number;
   allowedTools?: string[];
   resume?: string;
+  forkFrom?: string;
   skillPaths?: string[];
   yolo?: boolean;
   effort?: string;
@@ -100,6 +101,7 @@ function parseRunArgs(): ParsedRunArgs {
       "allowed-tools": { type: "string", short: "a" },
       "skill-path": { type: "string", multiple: true },
       resume: { type: "string" },
+      "fork-from": { type: "string" },
       yolo: { type: "boolean" },
       effort: { type: "string" },
       help: { type: "boolean", short: "h" },
@@ -148,6 +150,7 @@ function parseRunArgs(): ParsedRunArgs {
     allowedTools: values["allowed-tools"]?.split(",").map((t) => t.trim()),
     skillPaths: values["skill-path"] as string[] | undefined,
     resume: values.resume,
+    forkFrom: values["fork-from"],
     yolo: values["yolo"],
     effort: values["effort"],
     userInput,
@@ -220,6 +223,9 @@ Options:
   -a, --allowed-tools <tools>  Comma-separated allowed tools
       --skill-path <path>      Additional skill path (can be repeated, for pi runner)
       --resume <session-id>    Resume a previous session
+      --fork-from <session-id> Snapshot-clone the given source session into a
+                               fresh session and run the current turn on it
+                               (pi runner only, mutually exclusive with --resume)
   -h, --help                   Show this help
 
 Environment:
@@ -314,6 +320,7 @@ async function main(): Promise<void> {
         allowedTools: args.allowedTools,
         skillPaths: args.skillPaths,
         resume: args.resume,
+        forkFrom: args.forkFrom,
         yolo: args.yolo,
         effort: args.effort,
         ...(toolRefs ? { toolRefs: toolRefs.tools } : {}),

--- a/docs/changelog/2026-07-03-sdk-manager-fork-from.md
+++ b/docs/changelog/2026-07-03-sdk-manager-fork-from.md
@@ -1,0 +1,75 @@
+# SDK + manager + runner-cli: expose forkFrom end-to-end
+
+Date: 2026-07-03
+
+## Summary
+
+Thread the pi-runner `forkFrom` option (added in the earlier runner-pi PR)
+through every downstream layer:
+
+- `@bunny-agent/manager` — add `forkFrom` to `StreamInput` and
+  `BunnyAgentCodingRunBody`. `BunnyAgent.buildCommand` emits
+  `--fork-from <id>` when set, so CLI-mode consumers can also snapshot-clone.
+- `@bunny-agent/sdk` — add `forkFrom` to `BunnyAgentRunnerOptions`. Both
+  the daemon path (`buildCodingRunBody`) and the CLI/agent-stream fallback
+  now forward the field.
+- `apps/runner-cli` — add `--fork-from <session-id>` flag, threaded into
+  `runAgent`.
+- `apps/daemon` (from the earlier PR) already accepts `forkFrom` on
+  `/api/coding/run`.
+
+Without this SDK-layer plumbing, `createBunnyAgent({ forkFrom: … })` would
+be a type error — product apps (buda) can't reach the daemon feature that
+already shipped.
+
+## Motivation
+
+Buda's "Save & Continue from shared session" flow triggers the fork on
+the receiver's first turn in a cloned session. The kapps side calls
+`createBunnyAgent(...)` (from `@bunny-agent/sdk`) rather than hitting the
+daemon HTTP directly, so the SDK needs a first-class `forkFrom` option;
+the manager needs to accept it in `StreamInput` for the CLI fallback path.
+
+## Changes
+
+- `packages/manager/src/types.ts`
+  - `BunnyAgentCodingRunBody`: add `forkFrom?: string` (matches the daemon
+    `RunRequest` field added earlier).
+  - `StreamInput`: add `forkFrom?: string` — the CLI-mode entry point.
+- `packages/manager/src/bunny-agent.ts`
+  - `buildCommand`: append `--fork-from <input.forkFrom>` after `--resume`
+    when set. Mutually exclusive at the runner level (pi ignores
+    `--resume` when `--fork-from` is present), so this stays a
+    fire-and-forget parameter here.
+- `packages/manager/src/__tests__/bunny-agent.test.ts`
+  - Covers both branches: `--fork-from` appears when
+    `StreamInput.forkFrom` is set; and does not appear when unset.
+- `packages/sdk/src/provider/types.ts`
+  - `BunnyAgentRunnerOptions.forkFrom?: string`, mutually exclusive with
+    `resume` at the runner level.
+- `packages/sdk/src/provider/bunny-agent-language-model.ts`
+  - `buildCodingRunBody`: include `forkFrom: this.options.forkFrom` in the
+    request body for the daemon path.
+  - CLI fallback (`agent.stream({ ... })`): forward `forkFrom` too, so
+    both transport modes behave the same.
+- `packages/sdk/src/__tests__/tool-refs.test.ts`
+  - Adds a case that captures the daemon body and asserts
+    `forkFrom: "sess_source_abc"` is on the wire.
+- `apps/runner-cli/src/cli.ts`
+  - `--fork-from <session-id>` option in the parser, help text, and
+    dispatched into `runAgent`.
+
+## Verification
+
+- `pnpm -r typecheck` — clean (manager built first so downstream tsconfigs
+  see the new field via `dist/*.d.ts`)
+- `pnpm run -w lint` — clean
+- `pnpm --filter @bunny-agent/manager test` — 87 pass
+- `pnpm --filter @bunny-agent/sdk test` — 22 pass (new forkFrom body test)
+- `pnpm --filter @bunny-agent/runner-cli test` — 24 pass
+
+## Follow-up
+
+- kapps (buda) `continueFromSharedSession` + `chat-service.ts` will set
+  `forkFrom` on the first turn of a cloned session, once this cut is
+  published (0.9.49-beta.1 or similar).

--- a/packages/manager/src/__tests__/bunny-agent.test.ts
+++ b/packages/manager/src/__tests__/bunny-agent.test.ts
@@ -125,6 +125,45 @@ describe("BunnyAgent", () => {
       );
     });
 
+    it("passes --fork-from when StreamInput.forkFrom is set", async () => {
+      const sandbox = createMockSandbox();
+      const agent = new BunnyAgent({
+        sandbox,
+        runner: {
+          model: "google:gemini-2.5-pro",
+          runnerType: "pi",
+        },
+      });
+
+      await agent.stream({
+        messages: [{ role: "user", content: "continue from shared" }],
+        forkFrom: "sess_source_abc",
+      });
+
+      expect(sandbox.handle.exec).toHaveBeenCalledWith(
+        expect.arrayContaining(["--fork-from", "sess_source_abc"]),
+        expect.any(Object),
+      );
+    });
+
+    it("omits --fork-from when StreamInput.forkFrom is unset", async () => {
+      const sandbox = createMockSandbox();
+      const agent = new BunnyAgent({
+        sandbox,
+        runner: {
+          model: "google:gemini-2.5-pro",
+          runnerType: "pi",
+        },
+      });
+
+      await agent.stream({
+        messages: [{ role: "user", content: "fresh session" }],
+      });
+
+      const call = vi.mocked(sandbox.handle.exec).mock.calls[0];
+      expect(call?.[0]).not.toContain("--fork-from");
+    });
+
     it("should pass through stdout without modification", async () => {
       const testData = "test streaming data";
       const sandbox = createMockSandbox();

--- a/packages/manager/src/bunny-agent.ts
+++ b/packages/manager/src/bunny-agent.ts
@@ -94,6 +94,12 @@ export class BunnyAgent {
       cmd.push("--resume", input.resume);
     }
 
+    // Add fork-from parameter: snapshot-clone the source session before running
+    // the current turn. Mutually exclusive with --resume at the runner level.
+    if (input.forkFrom) {
+      cmd.push("--fork-from", input.forkFrom);
+    }
+
     // runner-cli always outputs AI SDK stream; --output-format is no longer accepted
 
     // Add separator and user input

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -70,6 +70,15 @@ export interface BunnyAgentCodingRunBody {
   maxTurns?: number;
   allowedTools?: string[];
   resume?: string;
+  /**
+   * Source pi session id to fork from before running the current turn. When
+   * set, the runner snapshot-clones the source session into a fresh session
+   * (new id, header.parentSession = source) and continues chat on top of the
+   * copied history. Mutually exclusive with `resume`.
+   *
+   * Currently only the `pi` runner consumes this; other runners ignore it.
+   */
+  forkFrom?: string;
   skillPaths?: string[];
   cwd?: string;
   /**
@@ -290,6 +299,15 @@ export interface StreamInput {
   transcriptWriter?: TranscriptWriter;
   /** Runner session ID to resume a previous conversation (from assistant message metadata) */
   resume?: string;
+  /**
+   * Source pi session id to fork from before running the current turn. When
+   * set, the runner snapshot-clones the source session into a fresh session
+   * (new id, header.parentSession = source) and continues chat on top of the
+   * copied history. Mutually exclusive with `resume`.
+   *
+   * Currently only the `pi` runner consumes this; other runners ignore it.
+   */
+  forkFrom?: string;
   /** AbortSignal for cancelling the operation */
   signal?: AbortSignal;
   /**

--- a/packages/sdk/src/__tests__/tool-refs.test.ts
+++ b/packages/sdk/src/__tests__/tool-refs.test.ts
@@ -356,6 +356,27 @@ describe("Bunny provider tool refs", () => {
       ],
     });
   });
+
+  it("forwards forkFrom into the daemon coding-run body", async () => {
+    const capturedBodies: BunnyAgentCodingRunBody[] = [];
+    const sandbox = createCodingRunSandbox(capturedBodies);
+    const bunnyAgent = createBunnyAgent({
+      sandbox,
+      daemonUrl: "http://127.0.0.1:3080",
+      forkFrom: "sess_source_abc",
+    });
+
+    const result = streamText({
+      model: bunnyAgent("google:gemini-2.5-pro", { runnerType: "pi" }),
+      messages: [{ role: "user", content: "continue from shared" }],
+    });
+
+    await result.consumeStream();
+
+    expect(capturedBodies[0]).toMatchObject({
+      forkFrom: "sess_source_abc",
+    });
+  });
 });
 
 function createCodingRunSandbox(

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -375,6 +375,7 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
           path: sandboxWorkdir,
         },
         resume: this.options.resume,
+        forkFrom: this.options.forkFrom,
         signal: abortSignal,
         ...(toolRefs && toolRefs.length > 0 ? { toolRefs } : {}),
       });
@@ -405,6 +406,7 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
       userInput: getLastUserTextFromMessages(messages),
       cwd,
       resume: this.options.resume,
+      forkFrom: this.options.forkFrom,
       systemPrompt: this.options.systemPrompt ?? runner.systemPrompt,
       maxTurns: this.options.maxTurns ?? runner.maxTurns,
       allowedTools: runner.allowedTools ?? this.options.allowedTools,

--- a/packages/sdk/src/provider/types.ts
+++ b/packages/sdk/src/provider/types.ts
@@ -109,6 +109,15 @@ export interface BunnyAgentProviderSettings
   cwd?: string;
   /** Resume session ID for multi-turn conversation. */
   resume?: string;
+  /**
+   * Source pi session id to fork from before running the current turn. When
+   * set, the runner snapshot-clones the source session into a fresh session
+   * (new id, header.parentSession = source) and continues chat on top of the
+   * copied history. Mutually exclusive with `resume`.
+   *
+   * Currently only the `pi` runner consumes this; other runners ignore it.
+   */
+  forkFrom?: string;
   /** Enable verbose logging for debugging. */
   verbose?: boolean;
   /** Custom logger for handling warnings and errors. */


### PR DESCRIPTION
## Summary

Follows up on the earlier runner-pi PR that landed `forkFrom` on the daemon `/api/coding/run` endpoint. That change alone isn't enough — `@bunny-agent/sdk` consumers (e.g. buda calling `createBunnyAgent(...)`) hit a TS error before the field ever reaches the wire.

This PR wires `forkFrom` through every remaining layer:

- **`@bunny-agent/manager`**: `BunnyAgentCodingRunBody.forkFrom` and `StreamInput.forkFrom`; `BunnyAgent.buildCommand` emits `--fork-from <id>` for CLI-mode.
- **`@bunny-agent/sdk`**: `BunnyAgentRunnerOptions.forkFrom`; both the daemon body (`buildCodingRunBody`) and the CLI fallback (`agent.stream(...)`) forward it.
- **`apps/runner-cli`**: `--fork-from <session-id>` flag, help text, dispatched into `runAgent`.

The daemon side already accepts and forwards `forkFrom`, so once this is cut and published, product apps can call `createBunnyAgent({ forkFrom: sourceSessionId })` and get a snapshot-clone-then-chat in one request.

## Semantics

`forkFrom` is mutually exclusive with `resume`; the pi runner snapshot-clones the source pi session (new id, `header.parentSession = source`) via `SessionManager.forkFrom` and continues chat on top of the copied history. The new session id flows back through the existing `message-metadata.sessionId` channel so subsequent turns can resume normally.

## Test plan
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm run -w lint` — clean
- [x] `pnpm --filter @bunny-agent/manager test` — 87 pass (new `--fork-from` command test present/absent)
- [x] `pnpm --filter @bunny-agent/sdk test` — 22 pass (new daemon body capture asserts `forkFrom` on the wire)
- [x] `pnpm --filter @bunny-agent/runner-cli test` — 24 pass
- [ ] Manual: buda calls `createBunnyAgent({ forkFrom })` and observes a fresh pi session id in `message-metadata`

## Non-goals
- No CLI mode → daemon mode routing changes; both transports get the field independently.
- No pi-mono changes (already landed via `SessionManager.forkFrom` upstream).

## Follow-up
- kapps repo: `continueFromSharedSession` persists source pi session id, `chat-service` sets `forkFrom` on the first turn of a cloned session. Depends on a published SDK/manager cut carrying this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)