### PR TITLE
refactor(daemon): stream fs/download instead of buffering into memory

### DIFF
--- a/apps/daemon/src/__tests__/daemon.test.ts
+++ b/apps/daemon/src/__tests__/daemon.test.ts
@@ -143,6 +143,57 @@ describe("fs", () => {
   });
 });
 
+describe("fs download", () => {
+  it("streams raw file bytes with Content-Length and MIME type", async () => {
+    const payload = "line one\nline two\nline three\n";
+    await post("/api/fs/write", { path: "download-me.txt", content: payload });
+
+    const r = await fetch(`${BASE}/api/fs/download?path=download-me.txt`);
+    expect(r.status).toBe(200);
+    expect(r.headers.get("content-type")).toContain("text/plain");
+    expect(r.headers.get("content-length")).toBe(
+      String(Buffer.byteLength(payload)),
+    );
+
+    const bytes = await r.arrayBuffer();
+    expect(Buffer.from(bytes).toString("utf-8")).toBe(payload);
+  });
+
+  it("streams binary content without corrupting bytes", async () => {
+    // Bytes that would break under naive utf-8 round-tripping.
+    const raw = Buffer.from([0x00, 0xff, 0x7f, 0x80, 0xc3, 0x28, 0x89, 0xab]);
+    const targetDir = path.join(root, "bin");
+    await fs.mkdir(targetDir, { recursive: true });
+    await fs.writeFile(path.join(targetDir, "raw.bin"), raw);
+
+    const r = await fetch(`${BASE}/api/fs/download?path=bin/raw.bin`);
+    expect(r.status).toBe(200);
+    expect(r.headers.get("content-length")).toBe(String(raw.length));
+
+    const bytes = Buffer.from(await r.arrayBuffer());
+    expect(bytes.equals(raw)).toBe(true);
+  });
+
+  it("returns 400 when path query is missing", async () => {
+    const r = await fetch(`${BASE}/api/fs/download`);
+    expect(r.status).toBe(400);
+    const body = await r.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("returns 400 when target is a directory", async () => {
+    const dir = "some-dir";
+    await post("/api/fs/mkdir", { path: dir });
+    const r = await fetch(
+      `${BASE}/api/fs/download?path=${encodeURIComponent(dir)}`,
+    );
+    expect(r.status).toBe(400);
+    const body = await r.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain("directory");
+  });
+});
+
 describe("fs write-stream", () => {
   it("streams raw upload bytes into the target file", async () => {
     const payload = Buffer.from("hello-stream-upload");

--- a/apps/daemon/src/nextjs.ts
+++ b/apps/daemon/src/nextjs.ts
@@ -15,6 +15,7 @@
  * Requests to /api/daemon/api/coding/run    → daemon /api/coding/run (NDJSON stream)
  */
 
+import { createReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { prepareCodingRunEnv } from "./coding-run-env.js";
 import { parseMultipart } from "./multipart.js";
@@ -91,7 +92,7 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
       }
     }
 
-    // Binary file download: /api/fs/download?path=...
+    // Binary file download: /api/fs/download?path=... (streamed)
     if (method === "GET" && pathname === "/api/fs/download") {
       try {
         const filePath = url.searchParams.get("path");
@@ -101,16 +102,21 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
             status: 400,
           });
         }
-        const { path: resolvedPath, buffer } = await fsDownload(state, {
+        const { path: resolvedPath, size } = await fsDownload(state, {
           path: filePath,
           volume,
         });
         const mimeType = guessMimeType(resolvedPath);
-        return new Response(buffer, {
+        // Node's createReadStream is an async iterable — wrap it in a Web
+        // ReadableStream so we can hand it to `new Response(...)` and stream
+        // the body end-to-end without buffering the whole file.
+        const nodeStream = createReadStream(resolvedPath);
+        const webStream = Readable.toWeb(nodeStream) as ReadableStream;
+        return new Response(webStream, {
           status: 200,
           headers: {
             "Content-Type": mimeType,
-            "Content-Length": String(buffer.length),
+            "Content-Length": String(size),
           },
         });
       } catch (err) {

--- a/apps/daemon/src/routes/fs.ts
+++ b/apps/daemon/src/routes/fs.ts
@@ -119,18 +119,25 @@ export async function fsRead(state: AppState, q: PathQuery) {
 }
 
 /**
- * Read a file as raw binary Buffer (for serving images, PDFs, etc.).
- * Unlike fsRead which returns UTF-8 text inside JSON, this returns { path, buffer }
- * so the HTTP layer can stream the raw bytes with the correct Content-Type.
+ * Resolve a downloadable file's path and size without loading it into memory.
+ *
+ * Unlike {@link fsRead} which returns UTF-8 text inside JSON, this returns
+ * only the resolved path + size so the HTTP transport can `createReadStream`
+ * and pipe the raw bytes end-to-end (constant memory regardless of file size).
+ * The transport is responsible for picking the Content-Type via
+ * {@link guessMimeType} and for handling stream errors.
  */
 export async function fsDownload(
   state: AppState,
   q: PathQuery,
-): Promise<{ path: string; buffer: Buffer }> {
+): Promise<{ path: string; size: number }> {
   const root = resolveVolumeRoot(state, q.volume);
   const target = resolveUnderRoot(root, q.path);
-  const buffer = await fs.readFile(target);
-  return { path: target, buffer };
+  const stat = await fs.stat(target);
+  if (stat.isDirectory()) {
+    throw new AppError(400, `Cannot download a directory: ${target}`);
+  }
+  return { path: target, size: stat.size };
 }
 
 export async function fsStat(state: AppState, q: PathQuery) {

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -1,4 +1,6 @@
+import { createReadStream } from "node:fs";
 import * as http from "node:http";
+import { pipeline } from "node:stream/promises";
 import { URL } from "node:url";
 import {
   type CodingRunBodyWithEnv,
@@ -94,7 +96,7 @@ export function createDaemon(config: DaemonConfig): http.Server {
         return;
       }
 
-      // Binary file download: /api/fs/download?path=...
+      // Binary file download: /api/fs/download?path=... (streamed)
       if (method === "GET" && pathname === "/api/fs/download") {
         try {
           const filePath = url.searchParams.get("path");
@@ -104,16 +106,23 @@ export function createDaemon(config: DaemonConfig): http.Server {
             res.end(JSON.stringify(fail("path query parameter is required")));
             return;
           }
-          const { path: resolvedPath, buffer } = await fsDownload(state, {
+          const { path: resolvedPath, size } = await fsDownload(state, {
             path: filePath,
             volume,
           });
           const mimeType = guessMimeType(resolvedPath);
           res.writeHead(200, {
             "Content-Type": mimeType,
-            "Content-Length": buffer.length,
+            "Content-Length": size,
           });
-          res.end(buffer);
+          try {
+            await pipeline(createReadStream(resolvedPath), res);
+          } catch (streamErr) {
+            // Headers already sent; log and destroy so client sees a broken
+            // stream instead of a "success" without full bytes.
+            console.error("Unhandled request error (stream):", streamErr);
+            if (!res.destroyed) res.destroy();
+          }
         } catch (err) {
           const status = err instanceof AppError ? err.status : 500;
           const msg = err instanceof Error ? err.message : String(err);

--- a/docs/changelog/2026-07-06-daemon-fs-download-stream.md
+++ b/docs/changelog/2026-07-06-daemon-fs-download-stream.md
@@ -1,0 +1,64 @@
+# daemon: stream fs/download instead of buffering into memory
+
+Date: 2026-07-06
+
+## Summary
+
+`/api/fs/download` used to `fs.readFile(target)` the whole file into a
+Buffer and then write it to the response in one go. For small files this
+is fine; for anything > a few MB it pins that many bytes of RAM inside
+the daemon while the response streams out.
+
+Switch the transport to `createReadStream(path)` piped into the
+response. `fsDownload` now only stats the file (returns `{ path, size }`)
+so the HTTP layer can set `Content-Length`, pick the MIME type, and
+stream bytes end-to-end. Memory stays constant regardless of file size.
+
+## Motivation
+
+Upcoming work (buda's share-copy job) copies pi session files across
+sandboxes by piping `fs/download` on the source daemon into
+`fs/write-stream` on the target. `fs/write-stream` was already true
+streaming; `fs/download` was the last remaining full-buffer link on the
+copy path. Fixing it here means the whole hop is stream-only — no
+sandbox daemon RAM spikes, no buda-side buffering.
+
+## Changes
+
+- `apps/daemon/src/routes/fs.ts`
+  - `fsDownload` no longer reads the file. It stats it, rejects
+    directories (400), and returns `{ path, size }`. Callers own the
+    stream.
+- `apps/daemon/src/server.ts`
+  - The `GET /api/fs/download` handler on the Node `http` server pipes
+    `createReadStream(resolvedPath)` into `res` via
+    `stream/promises.pipeline`. Errors mid-stream destroy the response
+    (client sees a broken stream, not a truncated "success").
+- `apps/daemon/src/nextjs.ts`
+  - The `Response` variant wraps `createReadStream` with `Readable.toWeb`
+    so it can be handed to `new Response(webStream, ...)` — the Fetch
+    runtime then owns end-to-end streaming.
+
+## Tests
+
+- `apps/daemon/src/__tests__/daemon.test.ts` — new `describe("fs download")`
+  block:
+  - text file: streams the same bytes back with `Content-Length` and a
+    plain-text MIME type.
+  - binary file: writes non-UTF-8 bytes (`0x00 0xff 0x7f 0x80 …`) via
+    `node:fs` and asserts the downloaded buffer is byte-equal — protects
+    against future accidental UTF-8 round-tripping regressions.
+  - `path` missing → 400.
+  - target is a directory → 400 with a descriptive error.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/daemon test` — 107 pass (4 new)
+- `pnpm --filter @bunny-agent/daemon typecheck` — clean
+- `pnpm run -w lint` — clean
+
+## Non-goals
+
+- No API change. Query params, response headers, and success bodies are
+  identical. Only the wire behavior changes (streaming vs single write).
+- CLI / SDK / manager unchanged.


### PR DESCRIPTION
## Summary

Switches \`GET /api/fs/download\` from full-buffer (\`fs.readFile\`) to streaming (\`createReadStream\` + \`pipeline\` on Node http; \`Readable.toWeb\` on the Web Response variant). \`fsDownload\` now returns \`{ path, size }\`; the transport owns the bytes.

## Why

Upcoming work (buda's share-copy job) pipes source daemon's \`fs/download\` into target daemon's \`fs/write-stream\` across sandboxes. \`fs/write-stream\` was already true streaming; this was the last full-buffer hop. After this PR the whole copy path is stream-only — no sandbox daemon RAM spikes, no buda-side buffering, no matter the pi session file size (bounded by the existing 10MB pi guard, but we still don't want that in one Buffer).

## Test plan

- [x] \`pnpm --filter @bunny-agent/daemon test\` — 107 pass (4 new)
- [x] \`pnpm --filter @bunny-agent/daemon typecheck\` — clean
- [x] \`pnpm run -w lint\` — clean
- Text file: streams with correct \`Content-Length\` + MIME type
- Binary file (0x00, 0xff, 0x7f, 0x80, 0xc3, 0x28, …): downloaded bytes are byte-equal to source
- Missing path → 400
- Target is a directory → 400 with descriptive error

## Non-goals

- API shape unchanged. Query params, response headers, success body all identical.
- CLI / SDK / manager untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)