### PR TITLE
fix(runner-pi): wait for compaction continuation

### DIFF
--- a/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
+++ b/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
@@ -10,11 +10,13 @@
 - Deferred final stream completion until the full Pi prompt, including automatic compaction and continuation, has settled.
 - Buffered intermediate `agent_end` events and finalized the stream from the last event only.
 - Added regression coverage for overflow recovery continuing successfully without exposing the intermediate context-window error, while preserving terminal model errors.
+- Initialized the buffered terminal event explicitly so clean TypeScript builds can prove it is safe to read before any `agent_end` event arrives.
 
 ## Verification
 
 - `pnpm --filter @bunny-agent/runner-pi test` (`132` tests passed)
 - `pnpm --filter @bunny-agent/runner-pi typecheck`
 - `pnpm --filter @bunny-agent/runner-pi build`
+- `pnpm build`
 - `pnpm exec biome check packages/runner-pi/src/pi-runner.ts packages/runner-pi/src/__tests__/pi-runner.test.ts docs/changelog/2026-07-13-pi-runner-compaction-continuation.md`
 - `git diff --check`

--- a/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
+++ b/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
@@ -1,0 +1,20 @@
+# Fix Pi Runner Compaction Continuation
+
+## Summary
+
+- Diagnosed Pi runner sessions that stopped after a context-window overflow instead of compacting and continuing.
+- Identified that the runner finalized its AI SDK stream on the first low-level `agent_end` event, before `session.prompt()` completed Pi's overflow recovery flow.
+
+## Changes
+
+- Deferred final stream completion until the full Pi prompt, including automatic compaction and continuation, has settled.
+- Buffered intermediate `agent_end` events and finalized the stream from the last event only.
+- Added regression coverage for overflow recovery continuing successfully without exposing the intermediate context-window error, while preserving terminal model errors.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/runner-pi test` (`132` tests passed)
+- `pnpm --filter @bunny-agent/runner-pi typecheck`
+- `pnpm --filter @bunny-agent/runner-pi build`
+- `pnpm exec biome check packages/runner-pi/src/pi-runner.ts packages/runner-pi/src/__tests__/pi-runner.test.ts docs/changelog/2026-07-13-pi-runner-compaction-continuation.md`
+- `git diff --check`

--- a/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
+++ b/docs/changelog/2026-07-13-pi-runner-compaction-continuation.md
@@ -10,7 +10,7 @@
 - Deferred final stream completion until the full Pi prompt, including automatic compaction and continuation, has settled.
 - Buffered intermediate `agent_end` events and finalized the stream from the last event only.
 - Added regression coverage for overflow recovery continuing successfully without exposing the intermediate context-window error, while preserving terminal model errors.
-- Initialized the buffered terminal event explicitly so clean TypeScript builds can prove it is safe to read before any `agent_end` event arrives.
+- Declared the buffered terminal event as optional so clean TypeScript builds can prove it is safe to read before any `agent_end` event arrives.
 
 ## Verification
 
@@ -18,5 +18,6 @@
 - `pnpm --filter @bunny-agent/runner-pi typecheck`
 - `pnpm --filter @bunny-agent/runner-pi build`
 - `pnpm build`
+- `pnpm run -w lint`
 - `pnpm exec biome check packages/runner-pi/src/pi-runner.ts packages/runner-pi/src/__tests__/pi-runner.test.ts docs/changelog/2026-07-13-pi-runner-compaction-continuation.md`
 - `git diff --check`

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -11,7 +11,9 @@ class MockSession {
   private behavior:
     | "normal"
     | "pending"
+    | "terminal_error"
     | "tool_error"
+    | "overflow_compaction_continue"
     | "text_tool_text_with_boundaries" = "normal";
 
   subscribe(fn: Listener): () => void {
@@ -25,7 +27,9 @@ class MockSession {
     behavior:
       | "normal"
       | "pending"
+      | "terminal_error"
       | "tool_error"
+      | "overflow_compaction_continue"
       | "text_tool_text_with_boundaries",
   ): void {
     this.behavior = behavior;
@@ -36,6 +40,26 @@ class MockSession {
       return new Promise(() => {
         // Keep pending forever so the abort test can fire.
       });
+    }
+
+    if (this.behavior === "terminal_error") {
+      this.emit({
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "Terminal model error",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          },
+        ],
+      });
+      return;
     }
 
     if (this.behavior === "tool_error") {
@@ -57,6 +81,73 @@ class MockSession {
         isError: true,
       });
       this.emit({ type: "agent_end", messages: [] });
+      return;
+    }
+
+    if (this.behavior === "overflow_compaction_continue") {
+      this.emit({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta: "before compaction",
+        },
+      });
+      this.emit({
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "error",
+            errorMessage: "Your input exceeds the context window.",
+            usage: {
+              input: 0,
+              output: 0,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          },
+        ],
+      });
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      this.emit({ type: "compaction_start", reason: "overflow" });
+      this.emit({
+        type: "compaction_end",
+        reason: "overflow",
+        result: {
+          summary: "Compacted context",
+          firstKeptEntryId: "kept-entry",
+          tokensBefore: 130000,
+        },
+        aborted: false,
+        willRetry: true,
+      });
+      this.emit({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_start" },
+      });
+      this.emit({
+        type: "message_update",
+        assistantMessageEvent: {
+          type: "text_delta",
+          delta: "after compaction",
+        },
+      });
+      this.emit({
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "stop",
+            usage: {
+              input: 100,
+              output: 20,
+              cacheRead: 0,
+              cacheWrite: 0,
+            },
+          },
+        ],
+      });
       return;
     }
 
@@ -138,7 +229,9 @@ const createdSessions: MockSession[] = [];
 let nextSessionBehavior:
   | "normal"
   | "pending"
+  | "terminal_error"
   | "tool_error"
+  | "overflow_compaction_continue"
   | "text_tool_text_with_boundaries" = "normal";
 
 /** When set, `createAgentSession` seeds `agent.state.systemPrompt` (simulates Pi after _rebuildSystemPrompt). */
@@ -534,6 +627,47 @@ describe("createPiRunner", () => {
     expect(chunks.some((c) => c.includes('"type":"error"'))).toBe(true);
     expect(chunks.some((c) => c.includes('"type":"finish"'))).toBe(true);
     expect(chunks.some((c) => c.includes("[DONE]"))).toBe(true);
+  });
+
+  it("waits for overflow compaction and continuation before finishing", async () => {
+    nextSessionBehavior = "overflow_compaction_continue";
+    const runner = createPiRunner({ model: "google:gemini-2.5-pro" });
+    const chunks: string[] = [];
+
+    for await (const chunk of runner.run("continue after compaction")) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.includes("before compaction"))).toBe(true);
+    expect(chunks.some((c) => c.includes("after compaction"))).toBe(true);
+    expect(chunks.some((c) => c.includes('"type":"error"'))).toBe(false);
+
+    const finishChunks = chunks.filter((c) =>
+      c.includes('"type":"finish"'),
+    );
+    expect(finishChunks).toHaveLength(1);
+    expect(finishChunks[0]).toContain('"finishReason":"stop"');
+    expect(chunks.filter((c) => c.includes("[DONE]"))).toHaveLength(1);
+  });
+
+  it("emits an error when the final agent_end remains an error", async () => {
+    nextSessionBehavior = "terminal_error";
+    const runner = createPiRunner({ model: "google:gemini-2.5-pro" });
+    const chunks: string[] = [];
+
+    for await (const chunk of runner.run("fail after retries")) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks.some((c) => c.includes("Terminal model error"))).toBe(true);
+    expect(
+      chunks.some(
+        (c) =>
+          c.includes('"type":"finish"') &&
+          c.includes('"finishReason":"error"'),
+      ),
+    ).toBe(true);
+    expect(chunks.filter((c) => c.includes("[DONE]"))).toHaveLength(1);
   });
 
   it("creates separate text parts for text before and after tool", async () => {

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -642,9 +642,7 @@ describe("createPiRunner", () => {
     expect(chunks.some((c) => c.includes("after compaction"))).toBe(true);
     expect(chunks.some((c) => c.includes('"type":"error"'))).toBe(false);
 
-    const finishChunks = chunks.filter((c) =>
-      c.includes('"type":"finish"'),
-    );
+    const finishChunks = chunks.filter((c) => c.includes('"type":"finish"'));
     expect(finishChunks).toHaveLength(1);
     expect(finishChunks[0]).toContain('"finishReason":"stop"');
     expect(chunks.filter((c) => c.includes("[DONE]"))).toHaveLength(1);
@@ -663,8 +661,7 @@ describe("createPiRunner", () => {
     expect(
       chunks.some(
         (c) =>
-          c.includes('"type":"finish"') &&
-          c.includes('"finishReason":"error"'),
+          c.includes('"type":"finish"') && c.includes('"finishReason":"error"'),
       ),
     ).toBe(true);
     expect(chunks.filter((c) => c.includes("[DONE]"))).toHaveLength(1);

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -514,10 +514,9 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         const eventQueue: AgentSessionEvent[] = [];
         let promptSettled = false;
         let promptError: unknown;
-        let finalAgentEnd: Extract<
-          AgentSessionEvent,
-          { type: "agent_end" }
-        > | undefined = undefined;
+        let finalAgentEnd:
+          | Extract<AgentSessionEvent, { type: "agent_end" }>
+          | undefined;
         let aborted = false;
         let wakeConsumer: (() => void) | null = null;
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -512,7 +512,12 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         });
 
         const eventQueue: AgentSessionEvent[] = [];
-        let isComplete = false;
+        let promptSettled = false;
+        let promptError: unknown;
+        let finalAgentEnd: Extract<
+          AgentSessionEvent,
+          { type: "agent_end" }
+        >;
         let aborted = false;
         let wakeConsumer: (() => void) | null = null;
 
@@ -523,16 +528,12 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
 
         const unsubscribe = session.subscribe((e) => {
           eventQueue.push(e);
-          if (e.type === "agent_end") {
-            isComplete = true;
-          }
           notify();
         });
 
         const abortSignal = options.abortController?.signal;
         const abortHandler = () => {
           aborted = true;
-          isComplete = true;
           void session.abort();
           notify();
         };
@@ -549,6 +550,17 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
 
           const promptText = userInput;
           const promptPromise = session.prompt(promptText);
+          void promptPromise.then(
+            () => {
+              promptSettled = true;
+              notify();
+            },
+            (error: unknown) => {
+              promptError = error;
+              promptSettled = true;
+              notify();
+            },
+          );
 
           const streamConverter = new PiAISDKStreamConverter({
             sessionId: session.sessionId,
@@ -558,10 +570,14 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
             getErrorFromAgentEndMessages,
           });
 
-          while (!isComplete || eventQueue.length > 0) {
+          while ((!promptSettled && !aborted) || eventQueue.length > 0) {
             while (eventQueue.length > 0) {
               const event = eventQueue.shift()!;
               traceRawMessage(cwd, event, false, options.env);
+              if (event.type === "agent_end") {
+                finalAgentEnd = event;
+                continue;
+              }
               const chunks = streamConverter.handleEvent(event, aborted);
               for (const chunk of chunks) {
                 yield chunk;
@@ -577,33 +593,42 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
               break;
             }
 
-            if (!isComplete && eventQueue.length === 0) {
+            if (!promptSettled && !aborted && eventQueue.length === 0) {
               await new Promise<void>((resolve) => {
                 wakeConsumer = resolve;
               });
             }
           }
 
-          if (streamConverter.finished) {
+          if (aborted) {
             return;
           }
 
-          try {
-            await promptPromise;
-          } catch (error) {
-            if (!streamConverter.finished) {
-              const message =
-                error instanceof Error ? error.message : "Pi agent run failed.";
-              for (const chunk of streamConverter.forceError(message)) {
-                yield chunk;
-              }
+          if (promptError !== undefined) {
+            const message =
+              promptError instanceof Error
+                ? promptError.message
+                : "Pi agent run failed.";
+            for (const chunk of streamConverter.forceError(message)) {
+              yield chunk;
             }
             return;
           }
 
-          if (!streamConverter.finished && session.agent.state.errorMessage) {
+          if (finalAgentEnd) {
+            const chunks = streamConverter.handleEvent(finalAgentEnd, false);
+            for (const chunk of chunks) {
+              yield chunk;
+            }
+          } else if (session.agent.state.errorMessage) {
             for (const chunk of streamConverter.forceError(
               session.agent.state.errorMessage,
+            )) {
+              yield chunk;
+            }
+          } else {
+            for (const chunk of streamConverter.forceError(
+              "Pi agent run completed without an agent_end event.",
             )) {
               yield chunk;
             }

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -517,7 +517,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         let finalAgentEnd: Extract<
           AgentSessionEvent,
           { type: "agent_end" }
-        >;
+        > | undefined = undefined;
         let aborted = false;
         let wakeConsumer: (() => void) | null = null;
 


### PR DESCRIPTION
## Summary

- keep the Pi runner stream open until `session.prompt()` settles
- defer intermediate `agent_end` events so overflow compaction and continuation can finish
- preserve terminal model errors and immediate abort behavior
- add regression tests for overflow recovery and terminal errors

## Root cause

Pi emits a low-level `agent_end` before `AgentSession` runs post-agent overflow recovery. The runner treated that first event as the end of the full prompt, emitted the AI SDK finish/error chunks, and disposed the session while compaction could still be running.

## Verification

- `pnpm --filter @bunny-agent/runner-pi test` (132 tests passed)
- `pnpm --filter @bunny-agent/runner-pi typecheck`
- `pnpm --filter @bunny-agent/runner-pi build`
- targeted Biome check
- `git diff --check`