### PR TITLE
feat(manager): rename LocalSandbox to LocalMachine, add SrtSandbox for real local isolation

### DIFF
--- a/apps/manager-cli/src/__tests__/manager-cli.integration.test.ts
+++ b/apps/manager-cli/src/__tests__/manager-cli.integration.test.ts
@@ -6,18 +6,18 @@
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { BunnyAgent, LocalSandbox } from "@bunny-agent/manager";
+import { BunnyAgent, LocalMachine } from "@bunny-agent/manager";
 import { describe, expect, it } from "vitest";
 
 describe("manager-cli Integration Tests", () => {
   const TIMEOUT = 30000;
 
   it(
-    "should create BunnyAgent with LocalSandbox",
+    "should create BunnyAgent with LocalMachine",
     async () => {
       const testDir = await mkdtemp(join(tmpdir(), "bunny-agent-test-"));
 
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         baseDir: testDir,
         isolate: true,
       });
@@ -43,7 +43,7 @@ describe("manager-cli Integration Tests", () => {
     async () => {
       const testDir = await mkdtemp(join(tmpdir(), "bunny-agent-test-"));
 
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         baseDir: testDir,
         isolate: true,
       });
@@ -69,7 +69,7 @@ describe("manager-cli Integration Tests", () => {
     async () => {
       const testDir = await mkdtemp(join(tmpdir(), "bunny-agent-test-"));
 
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         baseDir: testDir,
         isolate: true,
       });

--- a/apps/manager-cli/src/__tests__/sandbox-local-integration.test.ts
+++ b/apps/manager-cli/src/__tests__/sandbox-local-integration.test.ts
@@ -1,16 +1,16 @@
-import { BunnyAgent, LocalSandbox } from "@bunny-agent/manager";
+import { BunnyAgent, LocalMachine } from "@bunny-agent/manager";
 import { describe, expect, it } from "vitest";
 
 /**
- * Integration tests for BunnyAgent with LocalSandbox
+ * Integration tests for BunnyAgent with LocalMachine
  *
- * These tests verify the actual integration between BunnyAgent and LocalSandbox,
+ * These tests verify the actual integration between BunnyAgent and LocalMachine,
  * ensuring that commands execute correctly in the local environment.
  */
-describe("BunnyAgent + LocalSandbox Integration", () => {
+describe("BunnyAgent + LocalMachine Integration", () => {
   describe("Real Command Execution Tests", () => {
     it("should execute echo command and return output", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const _agent = new BunnyAgent({
         sandbox,
         runner: {
@@ -19,14 +19,14 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
       });
 
       const handle = await sandbox.attach();
-      const result = await handle.runCommand("echo 'Hello from LocalSandbox'");
+      const result = await handle.runCommand("echo 'Hello from LocalMachine'");
 
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("Hello from LocalSandbox");
+      expect(result.stdout).toContain("Hello from LocalMachine");
     });
 
     it("should execute ls command in workspace", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       // Create a test file
@@ -43,7 +43,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should handle process execution with node", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       // Create a simple Node.js script
@@ -69,7 +69,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should handle command with error exit code", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       const result = await handle.runCommand("exit 42");
@@ -78,7 +78,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should handle multi-line commands", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       const result = await handle.runCommand(
@@ -92,7 +92,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should handle file operations", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       // Create directory and files
@@ -111,7 +111,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should execute Python script", async () => {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalMachine();
       const handle = await sandbox.attach();
 
       // Create Python script
@@ -139,7 +139,7 @@ describe("BunnyAgent + LocalSandbox Integration", () => {
     });
 
     it("should handle environment variables", async () => {
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         env: {
           TEST_VAR: "test_value",
           CUSTOM_VAR: "custom_value",

--- a/apps/manager-cli/src/commands/run.ts
+++ b/apps/manager-cli/src/commands/run.ts
@@ -108,8 +108,8 @@ export async function runCommand(args: string[]): Promise<void> {
     const { SandockSandbox } = await import("@bunny-agent/sandbox-sandock");
     sandboxAdapter = new SandockSandbox();
   } else if (values.sandbox === "local") {
-    const { LocalSandbox } = await import("@bunny-agent/manager");
-    sandboxAdapter = new LocalSandbox({
+    const { LocalMachine } = await import("@bunny-agent/manager");
+    sandboxAdapter = new LocalMachine({
       workdir: values.workspace,
     });
     console.log(

--- a/apps/web/lib/example/create-sandbox.ts
+++ b/apps/web/lib/example/create-sandbox.ts
@@ -5,7 +5,7 @@ import { E2BSandbox } from "@bunny-agent/sandbox-e2b";
 import { SandockSandbox } from "@bunny-agent/sandbox-sandock";
 import {
   buildRunnerEnv,
-  LocalSandbox,
+  LocalMachine,
   type SandboxAdapter,
 } from "@bunny-agent/sdk";
 import type { RunnerType } from "@/lib/runner";
@@ -265,7 +265,7 @@ async function buildSandbox(
 
   const localWorkdir =
     params.localWorkdir ?? path.join(process.cwd(), "workspace");
-  return new LocalSandbox({
+  return new LocalMachine({
     workdir: localWorkdir,
     templatesPath: path.join(TEMPLATES_PATH, template),
     env: {

--- a/docs/changelog/2026-07-16-local-machine-rename-srt-sandbox.md
+++ b/docs/changelog/2026-07-16-local-machine-rename-srt-sandbox.md
@@ -1,0 +1,90 @@
+# Rename LocalSandbox → LocalMachine; add SrtSandbox (real local isolation)
+
+Date: 2026-07-16
+
+## Why
+
+`LocalSandbox` was a misleading name: the adapter runs commands directly on
+the host with the caller's user permissions — there is no sandbox. Anyone
+picking it from the API surface could reasonably assume it was safe for
+untrusted code. Meanwhile there was no way to run an agent locally *with*
+actual isolation short of standing up a cloud sandbox or Docker.
+
+## What Changed
+
+### `LocalMachine` (was `LocalSandbox`) — packages/manager
+
+- `packages/manager/src/local-sandbox.ts` → `local-machine.ts` (`git mv`).
+- Class renamed `LocalSandbox` → `LocalMachine`, options type
+  `LocalSandboxOptions` → `LocalMachineOptions`. Docs now state plainly that
+  it provides **no isolation**.
+- Deprecated aliases (`LocalSandbox`, `LocalSandboxOptions`) are still
+  exported from `@bunny-agent/manager` and `@bunny-agent/sdk`, so existing
+  consumers keep compiling; removal is deferred to the next major version.
+- Log prefixes switched from `[LocalSandbox]` to a `label` field so
+  subclasses log under their own name.
+- New protected `transformCommand(command)` hook: subclasses can rewrite the
+  argv before it is spawned. Both `exec()` and `runCommand()` route through
+  it (`runCommand` now spawns the transformed `["sh", "-c", …]` argv instead
+  of a hardcoded `sh` spawn).
+
+### `SrtSandbox` — new adapter in packages/manager
+
+Same lifecycle/API as `LocalMachine`, but every command is wrapped with
+Anthropic's sandbox runtime (`@anthropic-ai/sandbox-runtime`, the sandbox
+used by Claude Code): bubblewrap + network-namespace isolation on Linux,
+Seatbelt (`sandbox-exec`) on macOS, `srt-sandbox` user + WFP egress fence on
+Windows (alpha).
+
+- Policy is generated from `isolation` options into a per-instance
+  `srt-settings.json` under the OS temp dir:
+  - Network: allow-only (`allowedDomains`, default `[]` = fully blocked),
+    `deniedDomains`, `allowLocalBinding`, `allowAllUnixSockets`.
+  - Writes: allow-only — workdir + OS temp dir always writable, plus
+    user-supplied `allowWrite`; `denyWrite` wins over allows and always
+    includes the policy file's own directory, so a sandboxed process cannot
+    rewrite its own policy.
+  - Reads: allowed except `denyRead` (e.g. `~/.ssh`).
+  - Escape hatches: `settingsPath` (bring your own srt settings file) and
+    `srtCommand` (override the wrapper argv).
+- The wrapper is invoked as `node <resolved srt cli.js> --settings <file> …`
+  so no PATH setup is required.
+
+### Consumers updated
+
+- `apps/manager-cli` (run command + both integration test suites),
+  `apps/web` example, `packages/sdk` re-exports/README, provider error
+  message — all now use `LocalMachine`; sdk additionally re-exports
+  `SrtSandbox` and its option types.
+
+## Testing
+
+- `packages/manager/src/__tests__/srt-sandbox.test.ts`: **real isolation
+  tests** through the actual srt wrapper (skipped automatically where the
+  platform primitive is unavailable). Verified on Linux (bwrap 0.9.0):
+  - command runs + write inside workdir lands on the host FS (positive
+    control — this catches "srt failed to start so everything fails" false
+    positives),
+  - write outside allowed paths denied,
+  - `denyRead` path unreadable,
+  - network fully blocked by default,
+  - sandboxed process cannot overwrite its own policy file.
+- `local-machine.test.ts` (renamed): all prior behavior + a regression test
+  that the deprecated `LocalSandbox` alias is the same class.
+- `pnpm -r build`, `pnpm -r typecheck`, `pnpm run -w lint`: green.
+- `@bunny-agent/manager` 93/93, `@bunny-agent/sdk` 30/30,
+  `@bunny-agent/manager-cli` 11/11 tests pass.
+
+## Environment notes (for anyone running the srt tests locally)
+
+- Linux needs `bubblewrap` and `socat` installed. Without socat, srt fails
+  with "Sandbox dependencies not available" — and because *everything* fails,
+  deny-tests can false-pass; the positive-control test exists to catch this.
+- Ubuntu 24.04+ restricts unprivileged user namespaces
+  (`kernel.apparmor_restrict_unprivileged_userns=1`); bwrap needs an AppArmor
+  profile granting `userns` (e.g. `/etc/apparmor.d/bwrap` with
+  `profile bwrap /usr/bin/bwrap flags=(unconfined) { userns, }`).
+
+## Breaking Changes
+
+None — `LocalSandbox` / `LocalSandboxOptions` remain as deprecated aliases.

--- a/packages/manager/package.json
+++ b/packages/manager/package.json
@@ -46,5 +46,8 @@
     "@types/node": "^20.10.0",
     "typescript": "^5.3.0",
     "vitest": "^1.6.1"
+  },
+  "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "^0.0.65"
   }
 }

--- a/packages/manager/src/__tests__/local-machine.test.ts
+++ b/packages/manager/src/__tests__/local-machine.test.ts
@@ -2,14 +2,14 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { LocalSandbox } from "../local-sandbox.js";
+import { LocalMachine, LocalSandbox } from "../local-machine.js";
 
-describe("LocalSandbox", () => {
+describe("LocalMachine", () => {
   let tempDir: string;
 
   beforeEach(async () => {
     // Create a temporary directory for testing
-    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-sandbox-test-"));
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "local-machine-test-"));
   });
 
   afterEach(async () => {
@@ -23,27 +23,27 @@ describe("LocalSandbox", () => {
 
   describe("constructor", () => {
     it("should create an instance with default options", () => {
-      const sandbox = new LocalSandbox();
-      expect(sandbox).toBeInstanceOf(LocalSandbox);
+      const sandbox = new LocalMachine();
+      expect(sandbox).toBeInstanceOf(LocalMachine);
     });
 
     it("should accept custom options", () => {
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         workdir: tempDir,
         defaultTimeout: 30000,
       });
-      expect(sandbox).toBeInstanceOf(LocalSandbox);
+      expect(sandbox).toBeInstanceOf(LocalMachine);
     });
 
     it("should use process.cwd() as default workdir", () => {
-      const sandbox = new LocalSandbox();
-      expect(sandbox).toBeInstanceOf(LocalSandbox);
+      const sandbox = new LocalMachine();
+      expect(sandbox).toBeInstanceOf(LocalMachine);
     });
   });
 
   describe("attach", () => {
     it("should use workdir as working directory", async () => {
-      const sandbox = new LocalSandbox({
+      const sandbox = new LocalMachine({
         workdir: tempDir,
       });
 
@@ -55,7 +55,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should return a SandboxHandle", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       expect(typeof handle.exec).toBe("function");
@@ -68,7 +68,7 @@ describe("LocalSandbox", () => {
 
   describe("SandboxHandle.exec", () => {
     it("should execute a simple command", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       const chunks: string[] = [];
@@ -83,7 +83,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should execute commands in specified working directory", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       // Create a subdirectory
@@ -109,7 +109,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should pass environment variables", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       const chunks: string[] = [];
@@ -126,7 +126,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should throw error for non-existent command", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await expect(async () => {
@@ -142,7 +142,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should throw error for empty command", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await expect(async () => {
@@ -156,7 +156,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should handle command timeout", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await expect(async () => {
@@ -172,7 +172,7 @@ describe("LocalSandbox", () => {
     }, 10000); // Test timeout of 10 seconds
 
     it("should support abort signal", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       const abortController = new AbortController();
@@ -195,7 +195,7 @@ describe("LocalSandbox", () => {
 
   describe("SandboxHandle.upload", () => {
     it("should upload a single file", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await handle.upload(
@@ -212,7 +212,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should upload multiple files", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await handle.upload(
@@ -235,7 +235,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should upload binary content", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       const binaryData = new Uint8Array([0x48, 0x65, 0x6c, 0x6c, 0x6f]); // "Hello"
@@ -251,7 +251,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should create nested directories", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await handle.upload(
@@ -268,7 +268,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should upload to custom target directory", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await handle.upload(
@@ -287,14 +287,14 @@ describe("LocalSandbox", () => {
 
   describe("SandboxHandle.destroy", () => {
     it("should complete successfully", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await expect(handle.destroy()).resolves.toBeUndefined();
     });
 
     it("should not delete the working directory by default", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       await handle.upload([{ path: "file.txt", content: "Test" }], ".");
@@ -312,7 +312,7 @@ describe("LocalSandbox", () => {
 
   describe("Integration tests", () => {
     it("should support a complete workflow", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       // Upload a Python script
@@ -340,7 +340,7 @@ describe("LocalSandbox", () => {
     });
 
     it("should handle multiple sequential commands", async () => {
-      const sandbox = new LocalSandbox({ workdir: tempDir });
+      const sandbox = new LocalMachine({ workdir: tempDir });
       const handle = await sandbox.attach();
 
       // Create a file
@@ -362,5 +362,13 @@ describe("LocalSandbox", () => {
 
       await handle.destroy();
     });
+  });
+});
+
+describe("LocalSandbox (deprecated alias)", () => {
+  it("is the same class as LocalMachine", () => {
+    expect(LocalSandbox).toBe(LocalMachine);
+    const sandbox = new LocalSandbox();
+    expect(sandbox).toBeInstanceOf(LocalMachine);
   });
 });

--- a/packages/manager/src/__tests__/srt-sandbox.test.ts
+++ b/packages/manager/src/__tests__/srt-sandbox.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SrtSandbox } from "../srt-sandbox.js";
+import type { SandboxHandle } from "../types.js";
+
+/**
+ * These are real isolation tests: they execute commands through the actual
+ * srt wrapper (bubblewrap on Linux, Seatbelt on macOS). They are skipped on
+ * hosts where the platform sandboxing primitive is unavailable (e.g. Linux
+ * without bubblewrap installed, CI containers without user namespaces).
+ */
+const sandboxingAvailable = (() => {
+  if (process.platform === "darwin") {
+    return true; // sandbox-exec ships with macOS
+  }
+  if (process.platform === "linux") {
+    try {
+      // srt needs bwrap (with permission to create user namespaces — on
+      // Ubuntu 24.04+ that requires an AppArmor profile or
+      // kernel.apparmor_restrict_unprivileged_userns=0) AND socat for its
+      // network proxy bridge.
+      execFileSync("bwrap", ["--ro-bind", "/", "/", "true"], {
+        stdio: "ignore",
+        timeout: 10000,
+      });
+      execFileSync("socat", ["-V"], { stdio: "ignore", timeout: 10000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+})();
+
+/** Run a shell script through the sandbox's primary exec() path. exec()
+ *  throws on non-zero exit, which is exactly the signal these tests assert. */
+async function run(
+  handle: SandboxHandle,
+  script: string,
+): Promise<{ ok: boolean; output: string }> {
+  const chunks: string[] = [];
+  try {
+    for await (const chunk of handle.exec(["sh", "-c", script])) {
+      chunks.push(new TextDecoder().decode(chunk));
+    }
+    return { ok: true, output: chunks.join("") };
+  } catch {
+    return { ok: false, output: chunks.join("") };
+  }
+}
+
+describe.skipIf(!sandboxingAvailable)("SrtSandbox (real isolation)", () => {
+  let workdir: string;
+  let outsideDir: string;
+
+  beforeEach(async () => {
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), "srt-sandbox-wd-"));
+    // A directory the policy does NOT allow writes to. It must live outside
+    // the OS temp dir (which SrtSandbox always allows), so a repo-local
+    // scratch dir is used instead of the user's real home.
+    outsideDir = await fs.mkdtemp(
+      path.join(process.cwd(), ".srt-test-outside-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(workdir, { recursive: true, force: true }).catch(() => {});
+    await fs.rm(outsideDir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  it("runs commands and allows writes inside the workdir", async () => {
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+
+    const result = await run(
+      handle,
+      "echo sandboxed-ok > inside.txt && cat inside.txt",
+    );
+    expect(result.ok).toBe(true);
+    expect(result.output).toContain("sandboxed-ok");
+
+    // The write really landed on the host filesystem.
+    const content = await fs.readFile(path.join(workdir, "inside.txt"), "utf8");
+    expect(content).toContain("sandboxed-ok");
+  }, 120000);
+
+  it("denies writes outside the allowed paths", async () => {
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+
+    const target = path.join(outsideDir, "escape.txt");
+    const result = await run(handle, `touch ${target}`);
+    expect(result.ok).toBe(false);
+
+    await expect(fs.access(target)).rejects.toThrow();
+  }, 120000);
+
+  it("denies reads of paths listed in denyRead", async () => {
+    const secretDir = path.join(outsideDir, "secrets");
+    await fs.mkdir(secretDir, { recursive: true });
+    await fs.writeFile(path.join(secretDir, "key.txt"), "top-secret");
+
+    const sandbox = new SrtSandbox({
+      workdir,
+      isolation: { denyRead: [secretDir] },
+    });
+    const handle = await sandbox.attach();
+
+    const result = await run(handle, `cat ${secretDir}/key.txt`);
+    expect(result.ok).toBe(false);
+    expect(result.output).not.toContain("top-secret");
+  }, 120000);
+
+  it("blocks network access by default", async () => {
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+
+    // 5s timeout so a (wrongly) reachable network still fails fast.
+    const result = await run(
+      handle,
+      "curl -sS --max-time 5 https://example.com",
+    );
+    expect(result.ok).toBe(false);
+  }, 120000);
+
+  it("sandboxed process cannot rewrite its own policy file", async () => {
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+
+    // Locate the generated settings file via the wrapper command itself:
+    // it is passed as `--settings <path>` and lives under an srt-sandbox-*
+    // temp dir that the policy denies writes to.
+    const probe = await run(handle, "echo policy-probe");
+    expect(probe.ok).toBe(true);
+
+    const dirs = await fs.readdir(os.tmpdir());
+    const policyDirs = dirs.filter((d) => d.startsWith("srt-sandbox-"));
+    expect(policyDirs.length).toBeGreaterThan(0);
+
+    let deniedSomewhere = false;
+    for (const dir of policyDirs) {
+      const settingsPath = path.join(os.tmpdir(), dir, "srt-settings.json");
+      const result = await run(handle, `echo '{}' > ${settingsPath}`);
+      if (!result.ok) {
+        deniedSomewhere = true;
+      }
+    }
+    expect(deniedSomewhere).toBe(true);
+  }, 120000);
+});

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -13,9 +13,17 @@ export { isBunnyAgentDaemonHealthy } from "./daemon-health.js";
 export type { RunnerEnvParams, RunnerType } from "./env.js";
 // Env helpers
 export { buildRunnerEnv } from "./env.js";
-export type { LocalSandboxOptions } from "./local-sandbox.js";
-// Default sandbox adapter (built-in)
-export { LocalSandbox } from "./local-sandbox.js";
+export type {
+  LocalMachineOptions,
+  LocalSandboxOptions,
+} from "./local-machine.js";
+// Default local adapter (built-in, NO isolation). `LocalSandbox` is the
+// deprecated pre-rename alias.
+export { LocalMachine, LocalSandbox } from "./local-machine.js";
+export type { SrtIsolationOptions, SrtSandboxOptions } from "./srt-sandbox.js";
+// Locally-isolated sandbox adapter (wraps commands with
+// @anthropic-ai/sandbox-runtime)
+export { SrtSandbox } from "./srt-sandbox.js";
 export {
   ConsoleTranscriptWriter,
   JsonlTranscriptWriter,

--- a/packages/manager/src/local-machine.ts
+++ b/packages/manager/src/local-machine.ts
@@ -5,9 +5,9 @@ import { buildRunnerEnv } from "./env.js";
 import type { ExecOptions, SandboxAdapter, SandboxHandle } from "./types.js";
 
 /**
- * Options for creating a LocalSandbox instance
+ * Options for creating a LocalMachine instance
  */
-export interface LocalSandboxOptions {
+export interface LocalMachineOptions {
   /** Working directory for all operations (defaults to process.cwd()) */
   workdir?: string;
   /** Path to the agent template directory to copy into the sandbox workdir */
@@ -21,22 +21,28 @@ export interface LocalSandboxOptions {
 }
 
 /**
- * Local sandbox implementation that runs commands on the local machine.
+ * Runs commands directly on the local machine — with NO isolation.
  *
  * This adapter is useful for:
  * - Development and testing
  * - Running agents locally without cloud dependencies
  * - Quick prototyping
  *
- * Warning: This runs commands directly on your local machine with your user's
- * permissions. Use with caution and only with trusted code.
+ * Warning: commands run directly on your local machine with your user's
+ * permissions — there is no sandbox here. Use with caution and only with
+ * trusted code. For actual OS-level isolation on the local machine, use
+ * `SrtSandbox` (same API, wraps every command with
+ * `@anthropic-ai/sandbox-runtime`).
+ *
+ * Note: this class was previously (mis)named `LocalSandbox`; that name is
+ * still exported as a deprecated alias.
  *
  * @example
  * ```typescript
- * import { LocalSandbox, BunnyAgent } from "@bunny-agent/manager";
+ * import { LocalMachine, BunnyAgent } from "@bunny-agent/manager";
  *
  * // Create sandbox with template
- * const sandbox = new LocalSandbox({
+ * const sandbox = new LocalMachine({
  *   workdir: "/tmp/my-sandbox",
  *   templatesPath: "/path/to/agent-template",
  * });
@@ -54,7 +60,10 @@ export interface LocalSandboxOptions {
  * console.log(result.stdout);
  * ```
  */
-export class LocalSandbox implements SandboxAdapter {
+export class LocalMachine implements SandboxAdapter {
+  /** Log prefix; subclasses override so their logs are attributable. */
+  protected readonly label: string = "LocalMachine";
+
   private readonly workdir: string;
   private readonly templatesPath: string | undefined;
   private readonly defaultTimeout: number;
@@ -62,9 +71,9 @@ export class LocalSandbox implements SandboxAdapter {
   private readonly runnerCommand: string[];
 
   /** Current handle for the sandbox instance */
-  private currentHandle: LocalSandboxHandle | null = null;
+  private currentHandle: LocalMachineHandle | null = null;
 
-  constructor(options: LocalSandboxOptions = {}) {
+  constructor(options: LocalMachineOptions = {}) {
     this.workdir = options.workdir ?? process.cwd();
     this.templatesPath = options.templatesPath;
     this.defaultTimeout = options.defaultTimeout ?? 300000; // 5 min for agent runs
@@ -114,12 +123,12 @@ export class LocalSandbox implements SandboxAdapter {
       await fs.rm(claudeDir, { recursive: true, force: true }).catch(() => {});
       await fs.rm(claudeMd, { force: true }).catch(() => {});
 
-      console.log(`[LocalSandbox] Cleared template files: .claude, CLAUDE.md`);
+      console.log(`[${this.label}] Cleared template files: .claude, CLAUDE.md`);
     }
 
     // Create the directory if it doesn't exist
     await fs.mkdir(workdir, { recursive: true });
-    console.log(`[LocalSandbox] Using directory: ${workdir}`);
+    console.log(`[${this.label}] Using directory: ${workdir}`);
 
     // Copy all files from templatesPath to workdir if specified
     if (this.templatesPath) {
@@ -128,25 +137,27 @@ export class LocalSandbox implements SandboxAdapter {
         if (stat.isDirectory()) {
           await this.copyDir(this.templatesPath, workdir);
           console.log(
-            `[LocalSandbox] Copied template directory: ${this.templatesPath} -> ${workdir}`,
+            `[${this.label}] Copied template directory: ${this.templatesPath} -> ${workdir}`,
           );
         } else {
           console.warn(
-            `[LocalSandbox] templatesPath is not a directory: ${this.templatesPath}`,
+            `[${this.label}] templatesPath is not a directory: ${this.templatesPath}`,
           );
         }
       } catch (err) {
         console.warn(
-          `[LocalSandbox] Failed to copy template directory: ${this.templatesPath}`,
+          `[${this.label}] Failed to copy template directory: ${this.templatesPath}`,
           err,
         );
       }
     }
 
-    const handle = new LocalSandboxHandle(
+    const handle = new LocalMachineHandle(
       workdir,
       this.defaultTimeout,
       this.env,
+      this.label,
+      (command) => this.transformCommand(command),
     );
 
     // Store the handle
@@ -178,25 +189,42 @@ export class LocalSandbox implements SandboxAdapter {
   reset(): void {
     this.currentHandle = null;
   }
+
+  /**
+   * Hook for subclasses to rewrite a command before it is spawned (e.g.
+   * prefixing it with a sandboxing wrapper). The base implementation is the
+   * identity — commands run as-is on the host.
+   */
+  protected async transformCommand(command: string[]): Promise<string[]> {
+    return command;
+  }
 }
 
 /**
  * Handle for a local sandbox instance
  */
-class LocalSandboxHandle implements SandboxHandle {
+class LocalMachineHandle implements SandboxHandle {
   private readonly workDir: string;
   private readonly defaultTimeout: number;
   private readonly env: Record<string, string>;
   private readonly _sandboxId: string;
+  private readonly label: string;
+  private readonly transformCommand: (command: string[]) => Promise<string[]>;
 
   constructor(
     workDir: string,
     defaultTimeout: number,
     env: Record<string, string>,
+    label = "LocalMachine",
+    transformCommand: (command: string[]) => Promise<string[]> = async (
+      command,
+    ) => command,
   ) {
     this.workDir = workDir;
     this.defaultTimeout = defaultTimeout;
     this.env = env;
+    this.label = label;
+    this.transformCommand = transformCommand;
     this._sandboxId = `local-${crypto.randomUUID()}`;
   }
 
@@ -236,22 +264,24 @@ class LocalSandboxHandle implements SandboxHandle {
       inherit: baseInherit,
     });
 
-    console.log(`[LocalSandbox] Executing command: ${command.join(" ")}`);
-    console.log(`[LocalSandbox] Working directory: ${cwd}`);
+    const finalCommand = await this.transformCommand(command);
+
+    console.log(`[${this.label}] Executing command: ${finalCommand.join(" ")}`);
+    console.log(`[${this.label}] Working directory: ${cwd}`);
     console.log(
-      `[LocalSandbox] ENV AWS_BEARER_TOKEN_BEDROCK: ${env.AWS_BEARER_TOKEN_BEDROCK ? "SET" : "NOT SET"}`,
+      `[${this.label}] ENV AWS_BEARER_TOKEN_BEDROCK: ${env.AWS_BEARER_TOKEN_BEDROCK ? "SET" : "NOT SET"}`,
     );
     console.log(
-      `[LocalSandbox] ENV CLAUDE_CODE_USE_BEDROCK: ${env.CLAUDE_CODE_USE_BEDROCK || "NOT SET"}`,
+      `[${this.label}] ENV CLAUDE_CODE_USE_BEDROCK: ${env.CLAUDE_CODE_USE_BEDROCK || "NOT SET"}`,
     );
     console.log(
-      `[LocalSandbox] ENV ANTHROPIC_API_KEY: ${env.ANTHROPIC_API_KEY ? "SET" : "NOT SET"}`,
+      `[${this.label}] ENV ANTHROPIC_API_KEY: ${env.ANTHROPIC_API_KEY ? "SET" : "NOT SET"}`,
     );
 
     // Ensure the working directory exists
     await fs.mkdir(cwd, { recursive: true });
 
-    const [cmd, ...args] = command;
+    const [cmd, ...args] = finalCommand;
     const child = spawn(cmd, args, {
       cwd,
       env,
@@ -346,11 +376,11 @@ class LocalSandboxHandle implements SandboxHandle {
           : "";
         if (stderr) {
           console.error(
-            `[LocalSandbox] Command failed (exit ${exitCode}) stderr:\n${stderr}`,
+            `[${this.label}] Command failed (exit ${exitCode}) stderr:\n${stderr}`,
           );
         } else {
           console.error(
-            `[LocalSandbox] Command failed with exit ${exitCode} (no stderr). Run manually to see output: ${command.join(" ")}`,
+            `[${this.label}] Command failed with exit ${exitCode} (no stderr). Run manually to see output: ${finalCommand.join(" ")}`,
           );
         }
         // User-facing message: show the actual error from stderr (where it failed)
@@ -383,7 +413,7 @@ class LocalSandboxHandle implements SandboxHandle {
   ): Promise<void> {
     const resolvedTargetDir = path.resolve(this.workDir, targetDir);
     console.log(
-      `[LocalSandbox] Uploading ${files.length} file(s) to ${resolvedTargetDir}`,
+      `[${this.label}] Uploading ${files.length} file(s) to ${resolvedTargetDir}`,
     );
 
     // Create target directory
@@ -404,7 +434,7 @@ class LocalSandboxHandle implements SandboxHandle {
           : file.content;
 
       await fs.writeFile(filePath, content);
-      console.log(`[LocalSandbox] Wrote file: ${filePath}`);
+      console.log(`[${this.label}] Wrote file: ${filePath}`);
     }
   }
 
@@ -420,11 +450,14 @@ class LocalSandboxHandle implements SandboxHandle {
   async runCommand(
     command: string,
   ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-    console.log(`[LocalSandbox] Running command: ${command}`);
+    console.log(`[${this.label}] Running command: ${command}`);
+
+    // Route through the same transform hook as exec() so subclasses that
+    // wrap commands (e.g. with a sandboxing wrapper) cover this path too.
+    const [cmd, ...args] = await this.transformCommand(["sh", "-c", command]);
 
     return new Promise((resolve, reject) => {
-      // Use sh -c to execute the command
-      const child = spawn("sh", ["-c", command], {
+      const child = spawn(cmd, args, {
         cwd: this.workDir,
         env: { ...process.env, ...this.env }, // Use instance env
         stdio: "pipe",
@@ -465,8 +498,20 @@ class LocalSandboxHandle implements SandboxHandle {
   }
 
   async destroy(): Promise<void> {
-    console.log(`[LocalSandbox] Cleanup complete for: ${this.workDir}`);
+    console.log(`[${this.label}] Cleanup complete for: ${this.workDir}`);
     // Note: We don't delete the directory by default to preserve work
     // Users can manually delete it if needed
   }
 }
+
+/**
+ * @deprecated Renamed to {@link LocalMachine} — this adapter provides NO
+ * isolation (commands run directly on the host with your user's permissions),
+ * so the "sandbox" name was misleading. For actual OS-level local isolation,
+ * use `SrtSandbox`. This alias will be removed in the next major version.
+ */
+export const LocalSandbox = LocalMachine;
+/** @deprecated Renamed to {@link LocalMachine}. */
+export type LocalSandbox = LocalMachine;
+/** @deprecated Renamed to {@link LocalMachineOptions}. */
+export type LocalSandboxOptions = LocalMachineOptions;

--- a/packages/manager/src/srt-sandbox.ts
+++ b/packages/manager/src/srt-sandbox.ts
@@ -1,0 +1,148 @@
+import * as fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import * as os from "node:os";
+import * as path from "node:path";
+import { LocalMachine, type LocalMachineOptions } from "./local-machine.js";
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Isolation policy for {@link SrtSandbox}, mapped onto
+ * `@anthropic-ai/sandbox-runtime` (srt) settings.
+ *
+ * Defaults are deny-by-default where srt is deny-by-default:
+ * - Network: fully blocked unless domains are listed in `allowedDomains`.
+ * - Filesystem writes: only the sandbox workdir and the OS temp dir are
+ *   writable unless more paths are listed in `allowWrite`.
+ * - Filesystem reads: allowed except paths listed in `denyRead`.
+ */
+export interface SrtIsolationOptions {
+  /** Domains the sandboxed process may reach (supports `*.example.com`).
+   *  Default: `[]` — no network access. */
+  allowedDomains?: string[];
+  /** Domains to always block (takes precedence over `allowedDomains`). */
+  deniedDomains?: string[];
+  /** Paths the sandboxed process may NOT read (e.g. `~/.ssh`). */
+  denyRead?: string[];
+  /** Extra writable paths, in addition to the workdir and the OS temp dir.
+   *  Runners that write to the home directory (npm cache, session stores)
+   *  need those paths listed here — e.g. `["~/.npm", "~/.bunny-agent"]`. */
+  allowWrite?: string[];
+  /** Paths to deny writes to even inside allowed paths. */
+  denyWrite?: string[];
+  /** Allow binding local ports (dev servers inside the sandbox). Default false. */
+  allowLocalBinding?: boolean;
+  /** Disable Unix-socket blocking (Linux: seccomp; macOS: Seatbelt). Default false. */
+  allowAllUnixSockets?: boolean;
+  /**
+   * Bring-your-own srt settings file. When set, it is passed to srt as-is and
+   * every other option in this object is ignored.
+   */
+  settingsPath?: string;
+  /**
+   * Override the wrapper invocation (argv prefix). Defaults to running the
+   * `srt` CLI bundled with `@anthropic-ai/sandbox-runtime` via the current
+   * Node executable.
+   */
+  srtCommand?: string[];
+}
+
+export interface SrtSandboxOptions extends LocalMachineOptions {
+  isolation?: SrtIsolationOptions;
+}
+
+/**
+ * A locally-isolated sandbox: same lifecycle and API as {@link LocalMachine},
+ * but every command is wrapped with Anthropic's sandbox runtime
+ * (`@anthropic-ai/sandbox-runtime`, the sandbox used by Claude Code), which
+ * enforces OS-level boundaries:
+ *
+ * - Linux: bubblewrap + network-namespace isolation (traffic must go through
+ *   srt's host-side proxies)
+ * - macOS: `sandbox-exec` with a generated Seatbelt profile
+ * - Windows (alpha): a dedicated `srt-sandbox` user account + WFP egress fence
+ *
+ * The policy is allow-only for network and writes: by default the process
+ * can read the filesystem (minus `denyRead`), write only to the workdir and
+ * the OS temp dir, and reach no network at all.
+ *
+ * @example
+ * ```typescript
+ * import { SrtSandbox, BunnyAgent } from "@bunny-agent/manager";
+ *
+ * const sandbox = new SrtSandbox({
+ *   workdir: "/tmp/my-sandbox",
+ *   isolation: {
+ *     allowedDomains: ["api.anthropic.com", "*.npmjs.org"],
+ *     denyRead: ["~/.ssh", "~/.aws"],
+ *     allowWrite: ["~/.npm"],
+ *   },
+ * });
+ *
+ * const handle = await sandbox.attach();
+ * // Runs inside the OS sandbox; writing outside the workdir fails.
+ * const result = await handle.runCommand("id && touch out.txt");
+ * ```
+ */
+export class SrtSandbox extends LocalMachine {
+  protected override readonly label: string = "SrtSandbox";
+
+  private readonly isolation: SrtIsolationOptions;
+  /** Generated settings file path; created lazily, stable per instance. */
+  private settingsFilePromise: Promise<string> | null = null;
+
+  constructor(options: SrtSandboxOptions = {}) {
+    super(options);
+    this.isolation = options.isolation ?? {};
+  }
+
+  protected override async transformCommand(
+    command: string[],
+  ): Promise<string[]> {
+    const settingsPath =
+      this.isolation.settingsPath ?? (await this.ensureSettingsFile());
+    const srtCommand = this.isolation.srtCommand ?? [
+      process.execPath,
+      require.resolve("@anthropic-ai/sandbox-runtime/dist/cli.js"),
+    ];
+    return [...srtCommand, "--settings", settingsPath, ...command];
+  }
+
+  /**
+   * Write the srt settings file derived from {@link SrtIsolationOptions}.
+   * The file lives under the OS temp dir, which is inside the sandbox's
+   * writable paths — so the policy explicitly denies writes to its own
+   * directory (`denyWrite` takes precedence over `allowWrite` in srt): a
+   * sandboxed process cannot edit its own policy for the next run.
+   */
+  private ensureSettingsFile(): Promise<string> {
+    this.settingsFilePromise ??= (async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), "srt-sandbox-"));
+      const settingsPath = path.join(dir, "srt-settings.json");
+      const settings = {
+        network: {
+          allowedDomains: this.isolation.allowedDomains ?? [],
+          deniedDomains: this.isolation.deniedDomains ?? [],
+          allowLocalBinding: this.isolation.allowLocalBinding ?? false,
+          allowAllUnixSockets: this.isolation.allowAllUnixSockets ?? false,
+        },
+        filesystem: {
+          denyRead: this.isolation.denyRead ?? [],
+          allowWrite: [
+            this.getWorkdir(),
+            os.tmpdir(),
+            ...(this.isolation.allowWrite ?? []),
+          ],
+          // The policy file itself (and its directory) must never be
+          // writable from inside the sandbox, even though it lives under
+          // the OS temp dir.
+          denyWrite: [dir, ...(this.isolation.denyWrite ?? [])],
+        },
+      };
+      await fs.writeFile(settingsPath, JSON.stringify(settings, null, 2));
+      console.log(`[${this.label}] Wrote srt settings: ${settingsPath}`);
+      return settingsPath;
+    })();
+    return this.settingsFilePromise;
+  }
+}

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -39,7 +39,7 @@ Your App  →  @bunny-agent/sdk  →  Coding Agent (Claude / Codex / …)
 |---------|-------------|
 | 🔌 **AI SDK Provider** | `createBunnyAgent()` returns a model you pass to `streamText` / `generateText` |
 | ⚛️ **React Hooks** | `useBunnyAgentChat`, `useArtifacts`, `useWriteTool`, `useAskUserQuestion` |
-| 🖥️ **Local Mode** | Built-in `LocalSandbox` — run on your machine for Desktop apps & debugging |
+| 🖥️ **Local Mode** | Built-in `LocalMachine` (no isolation) and `SrtSandbox` (OS-level isolation) — run on your machine for Desktop apps & debugging |
 | ☁️ **Cloud Sandboxes** | Plug in [Sandock](https://sandock.ai), E2B, or Daytona for isolated cloud execution |
 | 🎨 **Agent Templates** | Markdown-based templates turn a generic agent into a domain expert |
 | 🔄 **Multi-turn Sessions** | Resume conversations with full filesystem continuity |
@@ -58,7 +58,7 @@ npm install @bunny-agent/sdk ai
 
 ```typescript
 // app/api/ai/route.ts
-import { createBunnyAgent, LocalSandbox } from "@bunny-agent/sdk";
+import { createBunnyAgent, LocalMachine } from "@bunny-agent/sdk";
 import {
   convertToModelMessages,
   createUIMessageStream,
@@ -69,7 +69,7 @@ import {
 export async function POST(request: Request) {
   const { messages } = await request.json();
 
-  const sandbox = new LocalSandbox({
+  const sandbox = new LocalMachine({
     workdir: process.cwd(),
     templatesPath: process.cwd(),
     runnerCommand: ["npx", "-y", "@bunny-agent/runner-cli@latest", "run"],
@@ -138,12 +138,27 @@ That's it — you now have a full Coding Agent streaming into your app.
 
 ### Local Mode (Desktop apps & debugging)
 
-`LocalSandbox` is built-in — no extra packages needed. The agent runs directly on your machine's filesystem.
+`LocalMachine` is built-in — no extra packages needed. The agent runs directly on your machine's filesystem, with your user's permissions and **no isolation** (it was previously named `LocalSandbox`; that alias still works but is deprecated). When you want actual OS-level isolation on the local machine, use `SrtSandbox` instead — same API, but every command is wrapped with [Anthropic's sandbox runtime](https://www.npmjs.com/package/@anthropic-ai/sandbox-runtime) (bubblewrap on Linux, Seatbelt on macOS): writes are restricted to the workdir, network access is blocked unless you allowlist domains.
 
 ```typescript
-import { createBunnyAgent, LocalSandbox } from "@bunny-agent/sdk";
+import { createBunnyAgent, SrtSandbox } from "@bunny-agent/sdk";
 
-const sandbox = new LocalSandbox({
+const sandbox = new SrtSandbox({
+  workdir: "/path/to/project",
+  isolation: {
+    allowedDomains: ["api.anthropic.com", "*.npmjs.org"],
+    denyRead: ["~/.ssh", "~/.aws"],
+    allowWrite: ["~/.npm"], // runners that write to the home dir need this
+  },
+});
+```
+
+Linux needs `bubblewrap` + `socat` installed (and on Ubuntu 24.04+, an AppArmor profile that grants `userns` to bwrap). macOS works out of the box.
+
+```typescript
+import { createBunnyAgent, LocalMachine } from "@bunny-agent/sdk";
+
+const sandbox = new LocalMachine({
   workdir: "/path/to/project",
   templatesPath: "./my-agent-template",
   env: { ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY! },
@@ -224,7 +239,7 @@ my-agent/
 ```
 
 ```typescript
-const sandbox = new LocalSandbox({
+const sandbox = new LocalMachine({
   workdir: process.cwd(),
   templatesPath: "./templates/analyst",  // Point to your template
 });
@@ -256,10 +271,10 @@ import {
 #### `createBunnyAgent` — sandbox transport (cloud / local filesystem)
 
 ```typescript
-import { createBunnyAgent, LocalSandbox } from "@bunny-agent/sdk";
+import { createBunnyAgent, LocalMachine } from "@bunny-agent/sdk";
 
 const bunnyAgent = createBunnyAgent({
-  sandbox: SandboxAdapter,       // LocalSandbox, SandockSandbox, E2BSandbox, etc.
+  sandbox: SandboxAdapter,       // LocalMachine, SrtSandbox, SandockSandbox, E2BSandbox, etc.
   cwd?: string,                  // Working directory inside sandbox
   env?: Record<string, string>,  // Environment variables
   template?: string,             // Template name
@@ -272,7 +287,7 @@ const model = bunnyAgent("claude-sonnet-4-20250514");
 
 #### Daemon HTTP transport (same provider)
 
-**With any sandbox adapter** (E2B, Sandock, `LocalSandbox`, etc.): pass **`sandbox` + `daemonUrl`**. The URL is resolved **inside** the sandbox (the `vikadata/bunny-agent` image starts `bunny-agent-daemon` on port 3080). The SDK streams via `streamCodingRunFromSandbox` (`curl -N` in the sandbox, including `LocalSandbox`), not `fetch` from your server. It does **not** call `/healthz` for you — use `isBunnyAgentDaemonHealthy` from `@bunny-agent/sdk` when you want a probe before setting `daemonUrl` (e.g. to fall back to the CLI runner).
+**With any sandbox adapter** (E2B, Sandock, `LocalMachine`, etc.): pass **`sandbox` + `daemonUrl`**. The URL is resolved **inside** the sandbox (the `vikadata/bunny-agent` image starts `bunny-agent-daemon` on port 3080). The SDK streams via `streamCodingRunFromSandbox` (`curl -N` in the sandbox, including `LocalMachine`), not `fetch` from your server. It does **not** call `/healthz` for you — use `isBunnyAgentDaemonHealthy` from `@bunny-agent/sdk` when you want a probe before setting `daemonUrl` (e.g. to fall back to the CLI runner).
 
 ```typescript
 import { createBunnyAgent, DEFAULT_BUNNY_AGENT_DAEMON_URL } from "@bunny-agent/sdk";
@@ -291,7 +306,7 @@ Omit `daemonUrl` to use the **CLI runner** in the same sandbox. `createBunnyAgen
 
 | Entry Point | Exports |
 |-------------|---------|
-| `@bunny-agent/sdk` | `createBunnyAgent`, `LocalSandbox`, `BunnyAgentLanguageModel`, `submitAnswer`, `DEFAULT_BUNNY_AGENT_DAEMON_URL` (re-exported from `@bunny-agent/manager`) |
+| `@bunny-agent/sdk` | `createBunnyAgent`, `LocalMachine`, `SrtSandbox`, `BunnyAgentLanguageModel`, `submitAnswer`, `DEFAULT_BUNNY_AGENT_DAEMON_URL` (re-exported from `@bunny-agent/manager`) |
 | `@bunny-agent/sdk/react` | `useBunnyAgentChat`, `useArtifacts`, `useWriteTool`, `useAskUserQuestion`, `DEFAULT_BUNNY_AGENT_DAEMON_URL` (re-exported from `@bunny-agent/manager`) |
 
 ---

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -21,17 +21,23 @@
 
 export type {
   IsBunnyAgentDaemonHealthyOptions,
+  LocalMachineOptions,
   LocalSandboxOptions,
   RunnerEnvParams,
   RunnerType,
+  SrtIsolationOptions,
+  SrtSandboxOptions,
 } from "@bunny-agent/manager";
-// Re-export LocalSandbox for convenience
+// Re-export the local adapters for convenience (LocalSandbox is the
+// deprecated pre-rename alias of LocalMachine)
 // Re-export env helpers
 export {
   buildRunnerEnv,
   DEFAULT_BUNNY_AGENT_DAEMON_URL,
   isBunnyAgentDaemonHealthy,
+  LocalMachine,
   LocalSandbox,
+  SrtSandbox,
 } from "@bunny-agent/manager";
 export type {
   ArtifactProcessor,

--- a/packages/sdk/src/provider/bunny-agent-provider.ts
+++ b/packages/sdk/src/provider/bunny-agent-provider.ts
@@ -65,7 +65,7 @@ export function createBunnyAgent(
 
   if (!defaultOptions.sandbox) {
     throw new Error(
-      "Provide a `sandbox` adapter (e.g. E2BSandbox, LocalSandbox). " +
+      "Provide a `sandbox` adapter (e.g. E2BSandbox, LocalMachine). " +
         "Optional `daemonUrl` uses in-sandbox HTTP to bunny-agent-daemon (no automatic `/healthz` probe). Use `isBunnyAgentDaemonHealthy` from `@bunny-agent/sdk` if you want to probe and omit `daemonUrl` for CLI fallback. Omit `daemonUrl` to always use CLI.",
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -482,6 +482,10 @@ importers:
         version: 5.9.3
 
   packages/manager:
+    dependencies:
+      '@anthropic-ai/sandbox-runtime':
+        specifier: ^0.0.65
+        version: 0.0.65
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -745,6 +749,11 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sandbox-runtime@0.0.65':
+    resolution: {integrity: sha512-0uW2bMIBLT45tehULlohOnco71xCJzrb4h7pQSUnMYfMJAJ77sMAI3Q9jP2h973hw5tg6dfEjyayc85rXixuAg==}
+    engines: {node: '>=20.11.0'}
+    hasBin: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -1330,9 +1339,11 @@ packages:
 
   '@daytonaio/sdk@0.130.0':
     resolution: {integrity: sha512-/hGpu6216dCnNFeB24H0ZtCExYy5I/nQAjlp110SdMcIhTkN8CHLcfvnTKSz6Xq200hvhU+K5UGyClJwA099JQ==}
+    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
 
   '@daytonaio/sdk@0.134.0':
     resolution: {integrity: sha512-ZJjvkPIm4IYEFL5YEHE2lXlBdNiQ/DMqYudruCTRXvEjNidikmd0aD97s++/jA5U1m9tXNJiSkmY8h/4ssBuNg==}
+    deprecated: 'Moved to @daytona/sdk, same API, no breaking changes. Please update: npm uninstall @daytonaio/sdk && npm i @daytona/sdk'
 
   '@daytonaio/toolbox-api-client@0.130.0':
     resolution: {integrity: sha512-5cnq9MAm5C9yNDqL1dwe4LIdRVy1iu2ORLeMPj/4ur2tmykGFbHjUkSH8qc3MTK3ep7jyTVBLk+ZvO2Dyqkljw==}
@@ -2236,6 +2247,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@pondwader/socks5-server@1.0.10':
+    resolution: {integrity: sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -4240,6 +4254,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@12.1.0:
+    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
+    engines: {node: '>=18'}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -5913,6 +5931,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
+
   npm-run-path@5.3.0:
     resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -7115,6 +7137,9 @@ packages:
     peerDependencies:
       zod: ^3.25 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -7190,6 +7215,13 @@ snapshots:
       '@img/sharp-linuxmusl-x64': 0.34.5
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+
+  '@anthropic-ai/sandbox-runtime@0.0.65':
+    dependencies:
+      '@pondwader/socks5-server': 1.0.10
+      commander: 12.1.0
+      node-forge: 1.4.0
+      zod: 3.25.76
 
   '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
     dependencies:
@@ -9417,6 +9449,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@pondwader/socks5-server@1.0.10': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -11771,6 +11805,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@12.1.0: {}
+
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -13857,6 +13893,8 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  node-forge@1.4.0: {}
+
   npm-run-path@5.3.0:
     dependencies:
       path-key: 4.0.0
@@ -15279,6 +15317,8 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
## Problem

`LocalSandbox` claimed isolation it never provided: it spawns commands directly on the host with the caller's user permissions. Anyone picking it from the API surface could reasonably assume untrusted code was contained. And there was no way to run an agent locally *with* isolation short of a cloud sandbox or Docker.

## Fix

**1. Honest name.** `LocalSandbox` → `LocalMachine` (`local-sandbox.ts` → `local-machine.ts` via `git mv`). `LocalSandbox` / `LocalSandboxOptions` remain exported as deprecated aliases from both `@bunny-agent/manager` and `@bunny-agent/sdk` — no breaking change; removal deferred to the next major.

**2. Real local isolation: `SrtSandbox`.** Same lifecycle/API as `LocalMachine`, but every command is wrapped with Anthropic's sandbox runtime ([`@anthropic-ai/sandbox-runtime`](https://www.npmjs.com/package/@anthropic-ai/sandbox-runtime), the sandbox used by Claude Code):

- Linux: bubblewrap + network-namespace isolation
- macOS: Seatbelt (`sandbox-exec`)
- Windows (alpha): dedicated `srt-sandbox` user + WFP egress fence

Policy is allow-only where it matters: network fully blocked unless domains are allowlisted; writes restricted to the workdir + OS temp dir (+ opt-in paths); reads open minus `denyRead`. The generated policy file's own directory is deny-written, so a sandboxed process cannot rewrite its policy. Escape hatches: `settingsPath` (BYO settings), `srtCommand` (override wrapper argv).

```ts
const sandbox = new SrtSandbox({
  workdir: "/tmp/my-sandbox",
  isolation: {
    allowedDomains: ["api.anthropic.com", "*.npmjs.org"],
    denyRead: ["~/.ssh", "~/.aws"],
    allowWrite: ["~/.npm"],
  },
});
```

Mechanically, `LocalMachine` gained a protected `transformCommand(argv)` hook that both `exec()` and `runCommand()` route through; `SrtSandbox` overrides it to prefix `node <srt cli.js> --settings <file>`. Log prefixes moved to a `label` field so subclass logs are attributable.

## Validation

Real isolation tests (`packages/manager/src/__tests__/srt-sandbox.test.ts`), executed through the actual srt wrapper on Linux (bwrap 0.9.0, socat 1.8), auto-skipped where the platform primitive is unavailable:

- ✅ command runs; write **inside** workdir lands on the host FS (positive control — catches "srt failed to start so every deny-test false-passes"; this exact false pass was hit and fixed during development when socat was missing)
- ✅ write **outside** allowed paths → denied
- ✅ `denyRead` path → unreadable
- ✅ network → fully blocked by default
- ✅ sandboxed process **cannot rewrite its own policy file**

Plus: renamed `local-machine.test.ts` suite (22 tests incl. deprecated-alias regression), `@bunny-agent/manager` 93/93, `@bunny-agent/sdk` 30/30, `@bunny-agent/manager-cli` 11/11, `pnpm -r build` + `pnpm -r typecheck` + `pnpm run -w lint` all green.

Environment notes for running the srt tests locally are in `docs/changelog/2026-07-16-local-machine-rename-srt-sandbox.md` (Linux needs bubblewrap + socat; Ubuntu 24.04+ additionally needs an AppArmor profile granting bwrap `userns`).

## Files Affected

- `packages/manager/src/local-machine.ts` (renamed from `local-sandbox.ts`) — rename, `label`, `transformCommand()` hook, deprecated aliases
- `packages/manager/src/srt-sandbox.ts` — new `SrtSandbox` adapter
- `packages/manager/src/__tests__/srt-sandbox.test.ts` — new real-isolation tests
- `packages/manager/src/__tests__/local-machine.test.ts` (renamed) — updated + alias regression test
- `packages/manager/src/index.ts`, `packages/sdk/src/index.ts` — export updates
- `packages/sdk/README.md`, `packages/sdk/src/provider/bunny-agent-provider.ts`, `apps/manager-cli/*`, `apps/web/lib/example/create-sandbox.ts` — consumer updates
- `docs/changelog/2026-07-16-local-machine-rename-srt-sandbox.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
