### PR TITLE
fix: Fix incorrect continue invocation before new prompt compression

### DIFF
--- a/.changeset/tidy-dingos-prompt.md
+++ b/.changeset/tidy-dingos-prompt.md
@@ -1,0 +1,6 @@
+---
+"@bunny-agent/daemon": patch
+"@bunny-agent/runner-cli": patch
+---
+
+Backport Pi's pre-prompt compaction fix so resumed sessions submit the pending user prompt instead of continuing from an assistant-tailed transcript.

--- a/docs/changelog/2026-07-16-pre-prompt-compaction-continue.md
+++ b/docs/changelog/2026-07-16-pre-prompt-compaction-continue.md
@@ -1,0 +1,21 @@
+# Fix pre-prompt compaction continuation
+
+## Summary
+
+BunnyAgent's patched `@earendil-works/pi-coding-agent@0.78.0` no longer calls `agent.continue()` after proactive compaction performed immediately before a new user prompt.
+
+## Root cause
+
+When a resumed long-running session needed compaction before accepting the next prompt, Pi compacted the transcript and then called `agent.continue()`. The compacted context could still end with an assistant message, causing the deterministic failure:
+
+```text
+Cannot continue from message role: assistant
+```
+
+The pending user prompt was never submitted, so retrying the same resumed session repeated the failure.
+
+## Fix
+
+The pre-prompt path now performs compaction and proceeds directly to the pending user prompt. Post-response retry and overflow continuation behavior remains unchanged.
+
+This backports upstream Pi commit `73581ea995e5e2abae51fc29cf535f42b7d31403` to the existing BunnyAgent dependency patch.

--- a/patches/@earendil-works__pi-coding-agent@0.78.0.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.78.0.patch
@@ -1,3 +1,30 @@
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index 66b2ab3334ff4318a2f6a02c5946e2b1c9702de8..5b344511e0d7fa42ee99c128d716ba28c7fbb1dd 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -761,18 +761,11 @@ export class AgentSession {
+                 }
+                 throw new Error(formatNoApiKeyFoundMessage(this.model.provider));
+             }
+-            // Check if we need to compact before sending (catches aborted responses)
++            // Check if we need to compact before sending (catches aborted responses).
++            // The user's new prompt is sent below, so do not call agent.continue() here.
+             const lastAssistant = this._findLastAssistantMessage();
+-            if (lastAssistant && (await this._checkCompaction(lastAssistant, false))) {
+-                try {
+-                    await this.agent.continue();
+-                    while (await this._handlePostAgentRun()) {
+-                        await this.agent.continue();
+-                    }
+-                }
+-                finally {
+-                    this._flushPendingBashMessages();
+-                }
++            if (lastAssistant) {
++                await this._checkCompaction(lastAssistant, false);
+             }
+             // Build messages array (custom message if any, then user message)
+             messages = [];
 diff --git a/dist/core/system-prompt.js b/dist/core/system-prompt.js
 index 4fa08b2a2665ee733849ba27ad144289a9c943e1..b59cbb23ca27bc1508161ef37b85df989b24357a 100644
 --- a/dist/core/system-prompt.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent@0.78.0':
-    hash: cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23
+    hash: 91a24e40bd8ff7c9bb04a8f0f1bf13bf86f50cfc60556bed9a1a89149235177a
     path: patches/@earendil-works__pi-coding-agent@0.78.0.patch
   openai@6.26.0:
     hash: f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01
@@ -145,7 +145,7 @@ importers:
         version: 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.78.0
-        version: 0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)
+        version: 0.78.0(patch_hash=91a24e40bd8ff7c9bb04a8f0f1bf13bf86f50cfc60556bed9a1a89149235177a)(ws@8.19.0)(zod@4.3.6)
       '@openai/codex-sdk':
         specifier: ^0.110.0
         version: 0.110.0
@@ -595,7 +595,7 @@ importers:
         version: 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.78.0
-        version: 0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)
+        version: 0.78.0(patch_hash=91a24e40bd8ff7c9bb04a8f0f1bf13bf86f50cfc60556bed9a1a89149235177a)(ws@8.19.0)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.48
@@ -8741,7 +8741,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=cdaee52d9c35ce5e15619f44907bde070dbb119eb9159f41a462b92bf4354b23)(ws@8.19.0)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.78.0(patch_hash=91a24e40bd8ff7c9bb04a8f0f1bf13bf86f50cfc60556bed9a1a89149235177a)(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.78.0(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.78.0(ws@8.19.0)(zod@4.3.6)


### PR DESCRIPTION
## Context

This PR is a re-submission of the original fix from PR #354 after `main` was force-reset to `c115036fe9aaefbc4185a26da48f327792e9cf05`.

PR #354 initially introduced this Pi `0.78.0` backport in commit `79dcc31559595ef79d366995386eeb36a3a89414`. It was later changed to upgrade the Pi dependencies to `0.80.7` before being merged. Because that merge was removed from `main` by the force reset, this PR restores only the original, minimal backport.

- Original PR: #354
- Original fix commit: `79dcc31559595ef79d366995386eeb36a3a89414`
- Restored target baseline: `c115036fe9aaefbc4185a26da48f327792e9cf05`

## Problem

A resumed long-running Pi session can perform proactive compaction immediately before accepting the next user prompt. With Pi `0.78.0`, the runtime then calls `agent.continue()`.

If the compacted transcript still ends with an assistant message, the run fails with:

```text
Cannot continue from message role: assistant
```

The pending user prompt is never submitted, so retrying the same resumed session repeats the failure.

## Solution

Backport Pi's pre-prompt compaction fix to the existing patched `@earendil-works/pi-coding-agent@0.78.0` dependency:

- submit the pending user prompt after proactive compaction
- do not call `agent.continue()` on an assistant-tailed transcript
- update the pnpm patched-dependency hash
- include the corresponding changeset and changelog

This PR intentionally does **not** restore the later Pi `0.80.7` dependency upgrade from the final version of PR #354.

## Validation

This PR preserves the patch content of the original PR #354 fix commit, `79dcc31559595ef79d366995386eeb36a3a89414`.
