### PR TITLE
fix(sandbox-sandock): use bunny-agent-runner bin for bootstrapped runner

### DIFF
--- a/.changeset/sandock-runner-bin-fix.md
+++ b/.changeset/sandock-runner-bin-fix.md
@@ -1,0 +1,5 @@
+---
+"@bunny-agent/sandbox-sandock": patch
+---
+
+Fix the bootstrap runner path: `@bunny-agent/runner-cli` publishes its bin as `bunny-agent-runner`, not `bunny-agent`. Fresh sandboxes (non-`skipBootstrap`) previously failed their first run with "bunny-agent: not found".

--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ output
 .codex/
 *.tgz
 apps/daemon/.bunny-agent-daemon/
+.env.integration

--- a/docs/changelog/2026-07-16-sandock-runner-bin-fix.md
+++ b/docs/changelog/2026-07-16-sandock-runner-bin-fix.md
@@ -1,0 +1,31 @@
+# Fix SandockSandbox runner bin path (bunny-agent → bunny-agent-runner)
+
+Date: 2026-07-16
+
+## Why
+
+`SandockSandbox.getRunnerCommand()` (non-`skipBootstrap` path) pointed at
+`<workdir>/node_modules/.bin/bunny-agent`, but `@bunny-agent/runner-cli`
+publishes its bin as **`bunny-agent-runner`**. Every fresh (non-prebuilt-image)
+sandock sandbox failed its first agent run with
+`sh: 1: /workspace/node_modules/.bin/bunny-agent: not found`.
+
+The 39 existing unit tests all pass with the bug in place — none asserted the
+runner command. It was caught by a live integration run against production
+sandock.ai (BunnyAgent end-to-end with a real LLM turn), which now succeeds
+(marker echoed in ~29s).
+
+## What Changed
+
+- `packages/sandbox-sandock/src/sandock-sandbox.ts`: `.bin/bunny-agent` →
+  `.bin/bunny-agent-runner` in the bootstrap path. The `skipBootstrap` path
+  (global `bunny-agent` CLI in the prebuilt image) is unchanged.
+- Regression tests for both `getRunnerCommand()` branches.
+- `.gitignore`: `.env.integration` (local credentials file used for live
+  integration runs).
+
+## Testing
+
+- Unit: 41/41 (2 new regression tests).
+- Live: real sandock.ai sandbox — attach → npm bootstrap → real `bunny-agent
+  run` (claude runner via LLM proxy) → marker echoed → destroy.

--- a/packages/sandbox-sandock/src/__tests__/sandock-sandbox.test.ts
+++ b/packages/sandbox-sandock/src/__tests__/sandock-sandbox.test.ts
@@ -652,3 +652,28 @@ describe("Shell Escaping", () => {
     expect(result).toBe("'cmd' '--' 'arg'");
   });
 });
+
+describe("getRunnerCommand", () => {
+  beforeEach(() => {
+    process.env.SANDOCK_API_KEY = "test-api-key";
+  });
+
+  it("uses the npm-installed bunny-agent-runner bin when bootstrapping", () => {
+    // Regression: @bunny-agent/runner-cli publishes its bin as
+    // `bunny-agent-runner`; pointing at `.bin/bunny-agent` fails with
+    // "not found" on a real sandbox (caught by live integration, 2026-07-16).
+    const sandbox = new SandockSandbox({ workdir: "/workspace" });
+    expect(sandbox.getRunnerCommand()).toEqual([
+      "/workspace/node_modules/.bin/bunny-agent-runner",
+      "run",
+    ]);
+  });
+
+  it("uses the global bunny-agent CLI when skipBootstrap is set", () => {
+    const sandbox = new SandockSandbox({
+      workdir: "/workspace",
+      skipBootstrap: true,
+    });
+    expect(sandbox.getRunnerCommand()).toEqual(["bunny-agent", "run"]);
+  });
+});

--- a/packages/sandbox-sandock/src/sandock-sandbox.ts
+++ b/packages/sandbox-sandock/src/sandock-sandbox.ts
@@ -189,7 +189,9 @@ export class SandockSandbox implements SandboxAdapter {
       }
       return ["bunny-agent", "run"];
     }
-    return [`${this.workdir}/node_modules/.bin/bunny-agent`, "run"];
+    // @bunny-agent/runner-cli publishes its bin as `bunny-agent-runner`
+    // (not `bunny-agent`, which is the pre-built image's global CLI above).
+    return [`${this.workdir}/node_modules/.bin/bunny-agent-runner`, "run"];
   }
 
   /**


### PR DESCRIPTION
## Problem

`SandockSandbox.getRunnerCommand()` (bootstrap path) pointed at `<workdir>/node_modules/.bin/bunny-agent`, but `@bunny-agent/runner-cli` publishes its bin as **`bunny-agent-runner`**. Every fresh (non-prebuilt-image) sandock sandbox failed its first agent run:

```
sh: 1: /workspace/node_modules/.bin/bunny-agent: not found
```

All 39 existing unit tests pass **with the bug in place** — none asserted the runner command; the SDK is fully mocked. It was caught by a live end-to-end run against production sandock.ai.

## Fix

- `.bin/bunny-agent` → `.bin/bunny-agent-runner` in the bootstrap path (the `skipBootstrap` path — global `bunny-agent` CLI in the prebuilt image — is unchanged).
- Regression tests for both `getRunnerCommand()` branches (41/41 now).
- `.gitignore`: `.env.integration` for local live-integration credentials.

## Validation

Live against production sandock.ai (real sandbox `sdbBVdwOmZwF…`): attach → npm bootstrap of `@bunny-agent/runner-cli@latest` → real `BunnyAgent.stream()` with a real LLM turn (claude runner) → the exact-echo marker came back in 29.3s → destroy. Before the fix the same run failed with "not found"; after, it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
