### PR TITLE
ci: live integration tests — local/srt/sandock sandboxes with mock LLM

### DIFF
--- a/.changeset/manager-cli-live-e2e.md
+++ b/.changeset/manager-cli-live-e2e.md
@@ -1,0 +1,5 @@
+---
+"@bunny-agent/manager-cli": patch
+---
+
+Add opt-in live E2E tests (BUNNY_INTEGRATION=1) covering LocalMachine and SrtSandbox with the mock LLM server; manager-cli now depends on @bunny-agent/sandbox-srt.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,10 @@
 name: Integration
 
-# Live integration tests, opt-in via BUNNY_INTEGRATION=1:
-# - local-srt: LocalMachine (host exec) + SrtSandbox (REAL bubblewrap
-#   isolation on the runner) + a full BunnyAgent turn through the real
-#   runner-cli against the deterministic mock-ai-server (OpenAI protocol,
-#   no key, no token cost).
+# Full test suite with the live tiers enabled (BUNNY_INTEGRATION=1), on every PR:
+# - local-srt: ALL packages' tests, including SrtSandbox's REAL bubblewrap
+#   isolation tests and a full BunnyAgent turn through the real runner-cli
+#   in LocalMachine + SrtSandbox, against the deterministic mock-ai-server
+#   (deployed Cloudflare Worker, OpenAI protocol, no key, no token cost).
 # - sandock: real sandboxes on sandock.ai — needs the SANDOCK_API_KEY repo
 #   secret; the tests skip cleanly when it is absent (e.g. fork PRs).
 
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   local-srt:
-    name: Local + SRT (real isolation, mock LLM)
+    name: Full suite + local/srt live (mock LLM)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -59,13 +59,15 @@ jobs:
           bwrap --ro-bind / / true
           socat -V > /dev/null
 
-      - name: Sandbox adapter tests (real bwrap isolation)
-        run: pnpm --filter @bunny-agent/sandbox-local --filter @bunny-agent/sandbox-srt test
-
-      - name: Live E2E — LocalMachine + SrtSandbox × mock LLM
+      # Full suite: every package's unit tests PLUS the live tiers unlocked
+      # by BUNNY_INTEGRATION=1 — sandbox-srt's real bwrap isolation tests and
+      # manager-cli's live E2E (LocalMachine + SrtSandbox × mock LLM at
+      # https://mock-ai-server.vika.workers.dev). The sandock live suite
+      # skips here (no SANDOCK_API_KEY) — the dedicated job below runs it.
+      - name: Full test suite (live tiers enabled)
         env:
           BUNNY_INTEGRATION: "1"
-        run: pnpm --filter @bunny-agent/manager-cli test
+        run: pnpm test
 
   sandock:
     name: Sandock live (cloud)

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,99 @@
+name: Integration
+
+# Live integration tests, opt-in via BUNNY_INTEGRATION=1:
+# - local-srt: LocalMachine (host exec) + SrtSandbox (REAL bubblewrap
+#   isolation on the runner) + a full BunnyAgent turn through the real
+#   runner-cli against the deterministic mock-ai-server (OpenAI protocol,
+#   no key, no token cost).
+# - sandock: real sandboxes on sandock.ai — needs the SANDOCK_API_KEY repo
+#   secret; the tests skip cleanly when it is absent (e.g. fork PRs).
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+      - "release/**"
+  workflow_dispatch:
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-srt:
+    name: Local + SRT (real isolation, mock LLM)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Node >= 24: the SrtSandbox live E2E needs NODE_USE_ENV_PROXY so
+          # the runner's fetch goes through srt's network proxy.
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Install srt platform deps (bubblewrap + socat)
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq bubblewrap socat
+          # Ubuntu 24.04+ blocks unprivileged user namespaces by default,
+          # which bubblewrap needs. The runner VM is ephemeral — relaxing
+          # this here affects nothing beyond this job.
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          # Sanity: the srt test suites skip silently when this probe fails,
+          # so fail loudly here instead of green-but-skipped.
+          bwrap --ro-bind / / true
+          socat -V > /dev/null
+
+      - name: Sandbox adapter tests (real bwrap isolation)
+        run: pnpm --filter @bunny-agent/sandbox-local --filter @bunny-agent/sandbox-srt test
+
+      - name: Live E2E — LocalMachine + SrtSandbox × mock LLM
+        env:
+          BUNNY_INTEGRATION: "1"
+        run: pnpm --filter @bunny-agent/manager-cli test
+
+  sandock:
+    name: Sandock live (cloud)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Live Sandock integration (skips without SANDOCK_API_KEY secret)
+        env:
+          BUNNY_INTEGRATION: "1"
+          SANDOCK_API_KEY: ${{ secrets.SANDOCK_API_KEY }}
+          # Optional: point at a non-production Sandock deployment
+          # SANDOCK_BASE_URL: ${{ vars.SANDOCK_BASE_URL }}
+        run: pnpm --filter @bunny-agent/sandbox-sandock test

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,10 +46,10 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Install srt platform deps (bubblewrap + socat)
+      - name: Install srt platform deps (bubblewrap + socat + ripgrep)
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq bubblewrap socat
+          sudo apt-get install -y -qq bubblewrap socat ripgrep
           # Ubuntu 24.04+ blocks unprivileged user namespaces by default,
           # which bubblewrap needs. The runner VM is ephemeral — relaxing
           # this here affects nothing beyond this job.
@@ -58,6 +58,7 @@ jobs:
           # so fail loudly here instead of green-but-skipped.
           bwrap --ro-bind / / true
           socat -V > /dev/null
+          rg --version > /dev/null
 
       # Full suite: every package's unit tests PLUS the live tiers unlocked
       # by BUNNY_INTEGRATION=1 — sandbox-srt's real bwrap isolation tests and

--- a/apps/manager-cli/package.json
+++ b/apps/manager-cli/package.json
@@ -39,7 +39,8 @@
     "@bunny-agent/runner-claude": "workspace:*",
     "@bunny-agent/sandbox-e2b": "workspace:*",
     "@bunny-agent/sandbox-local": "workspace:*",
-    "@bunny-agent/sandbox-sandock": "workspace:*"
+    "@bunny-agent/sandbox-sandock": "workspace:*",
+    "@bunny-agent/sandbox-srt": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/apps/manager-cli/src/__tests__/live-e2e.test.ts
+++ b/apps/manager-cli/src/__tests__/live-e2e.test.ts
@@ -37,7 +37,8 @@ const MOCK_ENV = {
 };
 
 /** Same platform probe as sandbox-srt's own tests: srt needs bwrap with
- *  user-namespace permission plus socat on Linux; Seatbelt ships with macOS. */
+ *  user-namespace permission, socat, and ripgrep on Linux; Seatbelt ships
+ *  with macOS. */
 const srtAvailable = (() => {
   if (process.platform === "darwin") return true;
   if (process.platform !== "linux") return false;
@@ -47,6 +48,7 @@ const srtAvailable = (() => {
       timeout: 10000,
     });
     execFileSync("socat", ["-V"], { stdio: "ignore", timeout: 10000 });
+    execFileSync("rg", ["--version"], { stdio: "ignore", timeout: 10000 });
     return true;
   } catch {
     return false;

--- a/apps/manager-cli/src/__tests__/live-e2e.test.ts
+++ b/apps/manager-cli/src/__tests__/live-e2e.test.ts
@@ -1,0 +1,153 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { BunnyAgent } from "@bunny-agent/manager";
+import { LocalMachine } from "@bunny-agent/sandbox-local";
+import { SrtSandbox } from "@bunny-agent/sandbox-srt";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Live end-to-end tests: a REAL BunnyAgent.stream() turn — sandbox attach,
+ * runner-cli spawn, an actual HTTP round trip to an LLM endpoint — using the
+ * deterministic mock-ai-server (OpenAI protocol, always replies with fixed
+ * prose mentioning "mock-ai-server"), so no real key and no token cost.
+ *
+ * Opt-in via BUNNY_INTEGRATION=1 (set by .github/workflows/integration.yml);
+ * skipped otherwise so `pnpm -r test` stays offline-friendly on dev machines.
+ */
+const LIVE = process.env.BUNNY_INTEGRATION === "1";
+
+const REPO_ROOT = fileURLToPath(new URL("../../../../", import.meta.url));
+const RUNNER_BUNDLE = path.join(REPO_ROOT, "apps/runner-cli/dist/bundle.mjs");
+const RUNNER_CMD = [process.execPath, RUNNER_BUNDLE, "run"];
+
+const MOCK_BASE_URL =
+  process.env.MOCK_OPENAI_BASE_URL ??
+  "https://mock-ai-server.vika.workers.dev/v1";
+const MOCK_HOST = new URL(MOCK_BASE_URL).hostname;
+const MOCK_MARKER = "mock-ai-server";
+
+/** pi runner: multi-provider, speaks the OpenAI protocol the mock implements. */
+const RUNNER = { runnerType: "pi", model: "openai:gpt-4o-mini", maxTurns: 1 };
+const MOCK_ENV = {
+  OPENAI_API_KEY: "mock", // any value; the mock ignores it
+  OPENAI_BASE_URL: MOCK_BASE_URL,
+};
+
+/** Same platform probe as sandbox-srt's own tests: srt needs bwrap with
+ *  user-namespace permission plus socat on Linux; Seatbelt ships with macOS. */
+const srtAvailable = (() => {
+  if (process.platform === "darwin") return true;
+  if (process.platform !== "linux") return false;
+  try {
+    execFileSync("bwrap", ["--ro-bind", "/", "/", "true"], {
+      stdio: "ignore",
+      timeout: 10000,
+    });
+    execFileSync("socat", ["-V"], { stdio: "ignore", timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+async function streamToText(
+  agent: BunnyAgent,
+  prompt: string,
+): Promise<string> {
+  const stream = await agent.stream({
+    messages: [{ role: "user", content: prompt }],
+  });
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let raw = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    raw += decoder.decode(value);
+    if (raw.length > 500_000) break;
+  }
+  return extractAssistantText(raw);
+}
+
+/** Join the AI SDK stream's `text-delta` events — the SSE chunking can split
+ *  a word (even the assertion marker) across deltas, so matching on the raw
+ *  stream text is not reliable. */
+function extractAssistantText(raw: string): string {
+  let text = "";
+  for (const line of raw.split("\n")) {
+    if (!line.startsWith("data: {")) continue;
+    try {
+      const event = JSON.parse(line.slice(6)) as {
+        type?: string;
+        delta?: string;
+      };
+      if (event.type === "text-delta" && typeof event.delta === "string") {
+        text += event.delta;
+      }
+    } catch {
+      // partial/non-JSON line — ignore
+    }
+  }
+  return text;
+}
+
+describe.skipIf(!LIVE)("live e2e: BunnyAgent × mock LLM", () => {
+  it("runner bundle exists (run `pnpm -r build` first)", () => {
+    expect(fs.existsSync(RUNNER_BUNDLE)).toBe(true);
+  });
+
+  it("LocalMachine: full turn through the real runner", async () => {
+    const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "live-e2e-local-"));
+    const agent = new BunnyAgent({
+      sandbox: new LocalMachine({ workdir, runnerCommand: RUNNER_CMD }),
+      runner: RUNNER,
+      env: MOCK_ENV,
+    });
+    try {
+      const raw = await streamToText(agent, "Say hello.");
+      expect(raw).toContain(MOCK_MARKER);
+    } finally {
+      await agent.destroy().catch(() => {});
+      fs.rmSync(workdir, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  describe.skipIf(!srtAvailable)("SrtSandbox", () => {
+    it("full turn through the real runner, inside OS-level isolation", async () => {
+      const workdir = fs.mkdtempSync(path.join(os.tmpdir(), "live-e2e-srt-"));
+      const agent = new BunnyAgent({
+        sandbox: new SrtSandbox({
+          workdir,
+          runnerCommand: RUNNER_CMD,
+          isolation: {
+            // ONLY the mock endpoint is reachable — the turn completing at
+            // all also proves the srt allowlist lets the LLM call through.
+            allowedDomains: [MOCK_HOST],
+            // pi/runner session + config writes outside the workdir
+            // (pi stores sessions under ~/.bunny/agent/sessions)
+            allowWrite: ["~/.bunny", "~/.config", "~/.cache"],
+          },
+        }),
+        runner: RUNNER,
+        env: {
+          ...MOCK_ENV,
+          // srt removes the network namespace and injects HTTP(S)_PROXY for
+          // its host-side proxies. curl honors those; Node's fetch (undici)
+          // does not — unless Node's built-in env-proxy support is enabled.
+          // Requires Node >= 24 for the spawned runner.
+          NODE_USE_ENV_PROXY: "1",
+        },
+      });
+      try {
+        const raw = await streamToText(agent, "Say hello.");
+        expect(raw).toContain(MOCK_MARKER);
+      } finally {
+        await agent.destroy().catch(() => {});
+        fs.rmSync(workdir, { recursive: true, force: true });
+      }
+    }, 180_000);
+  });
+});

--- a/docs/changelog/2026-07-16-ci-integration-tests.md
+++ b/docs/changelog/2026-07-16-ci-integration-tests.md
@@ -1,0 +1,59 @@
+# CI: live integration tests (local / srt / sandock × mock LLM)
+
+Date: 2026-07-16
+
+## Why
+
+Every sandbox adapter's unit suite mocks its SDK, so an entire class of
+breakage is invisible to CI — the sandock runner-bin bug
+(`2026-07-16-sandock-runner-bin-fix.md`) shipped with 39/39 unit tests green
+and was only caught by a live run. This adds an opt-in live tier that
+exercises real isolation and a real BunnyAgent turn end to end on every PR.
+
+## What Changed
+
+- `.github/workflows/integration.yml`, two jobs:
+  - **local-srt**: installs bubblewrap + socat, relaxes Ubuntu 24.04's
+    unprivileged-userns restriction on the ephemeral runner, fails loudly if
+    the bwrap probe fails (instead of green-but-skipped), then runs the
+    sandbox-local/sandbox-srt suites (REAL bwrap isolation) and the new live
+    E2E in manager-cli.
+  - **sandock**: runs the live sandock suite against sandock.ai using the
+    `SANDOCK_API_KEY` repo secret; skips cleanly when the secret is absent
+    (fork PRs).
+- `apps/manager-cli/src/__tests__/live-e2e.test.ts` (opt-in via
+  `BUNNY_INTEGRATION=1`): full `BunnyAgent.stream()` turn — attach, real
+  runner-cli spawn, real HTTP — through LocalMachine and SrtSandbox, using
+  the deterministic mock-ai-server (`https://mock-ai-server.vika.workers.dev`,
+  OpenAI protocol; override with `MOCK_OPENAI_BASE_URL`) and the **pi**
+  runner, so no LLM key and zero token cost. The SrtSandbox case allowlists
+  only the mock host, which also proves srt's domain allowlist end to end.
+- `packages/sandbox-sandock/src/__tests__/sandock-live.test.ts` (opt-in via
+  `BUNNY_INTEGRATION=1` + `SANDOCK_API_KEY`): adapter round trip
+  (attach/exec/upload/readFile) plus a full BunnyAgent turn through the
+  npm-bootstrapped runner in a real cloud sandbox; always destroys the
+  sandbox in `afterEach` (120s hook timeout — cloud teardown exceeds the 10s
+  default).
+- `apps/manager-cli` gains a `@bunny-agent/sandbox-srt` dependency.
+
+## Gotchas encoded in the tests (found by running them for real)
+
+- The AI SDK stream's SSE chunking can split a word across `text-delta`
+  events (observed: `"mock-ai-serve" + "r, ..."`), so assertions join the
+  deltas instead of matching the raw stream.
+- srt removes the network namespace and injects `HTTP(S)_PROXY`; Node's
+  fetch (undici) ignores those env vars, so the spawned runner needs
+  `NODE_USE_ENV_PROXY=1` (Node ≥ 24) — otherwise every LLM call inside
+  SrtSandbox fails with "Connection error." while curl works fine.
+- pi stores sessions under `~/.bunny/agent/sessions`, which must be in
+  srt's `allowWrite`.
+
+## Testing
+
+All live suites were run for real before landing:
+
+- local-srt: 3/3 (LocalMachine turn 3.7s; SrtSandbox turn with only the mock
+  host allowlisted).
+- sandock: 2/2 against production sandock.ai (round trip + full turn,
+  ~106s including sandbox create/destroy).
+- Without `BUNNY_INTEGRATION` everything skips: `pnpm -r test` unchanged.

--- a/packages/sandbox-sandock/src/__tests__/sandock-live.test.ts
+++ b/packages/sandbox-sandock/src/__tests__/sandock-live.test.ts
@@ -1,0 +1,101 @@
+import { BunnyAgent } from "@bunny-agent/manager";
+import { afterEach, describe, expect, it } from "vitest";
+import { SandockSandbox } from "../sandock-sandbox.js";
+
+/**
+ * Live integration against a REAL Sandock service (sandock.ai by default,
+ * or SANDOCK_BASE_URL). Creates and destroys real cloud sandboxes.
+ *
+ * Opt-in: needs BUNNY_INTEGRATION=1 AND SANDOCK_API_KEY (a repo secret in
+ * CI — forks without the secret skip cleanly). The LLM turn uses the
+ * deterministic mock-ai-server, so no LLM key and no token cost.
+ */
+const LIVE =
+  process.env.BUNNY_INTEGRATION === "1" && !!process.env.SANDOCK_API_KEY;
+
+const MOCK_BASE_URL =
+  process.env.MOCK_OPENAI_BASE_URL ??
+  "https://mock-ai-server.vika.workers.dev/v1";
+const MOCK_MARKER = "mock-ai-server";
+
+describe.skipIf(!LIVE)("live: SandockSandbox × sandock.ai", () => {
+  let sandbox: SandockSandbox | null = null;
+
+  afterEach(async () => {
+    // Always tear the cloud sandbox down, even when an assertion failed.
+    await sandbox
+      ?.getHandle()
+      ?.destroy()
+      .catch(() => {});
+    sandbox = null;
+  }, 120_000); // destroying a real cloud sandbox can exceed the 10s default
+
+  it("adapter round trip: attach → exec → upload → readFile", async () => {
+    sandbox = new SandockSandbox({
+      baseUrl: process.env.SANDOCK_BASE_URL,
+      name: "bunny-ci-roundtrip",
+    });
+    const handle = await sandbox.attach();
+    expect(handle.getSandboxId()).toBeTruthy();
+
+    let out = "";
+    for await (const chunk of handle.exec([
+      "sh",
+      "-c",
+      "echo live-$((6*7)) && uname -s",
+    ])) {
+      out += new TextDecoder().decode(chunk);
+    }
+    expect(out).toContain("live-42");
+    expect(out).toContain("Linux");
+
+    await handle.upload([{ path: "ci.txt", content: "sandock-live-ci" }], ".");
+    const content = await handle.readFile("ci.txt");
+    expect(content).toContain("sandock-live-ci");
+  }, 300_000);
+
+  it("full BunnyAgent turn through the bootstrapped runner + mock LLM", async () => {
+    sandbox = new SandockSandbox({
+      baseUrl: process.env.SANDOCK_BASE_URL,
+      name: "bunny-ci-e2e",
+    });
+    const agent = new BunnyAgent({
+      sandbox,
+      // pi runner: multi-provider, speaks the OpenAI protocol the mock implements
+      runner: { runnerType: "pi", model: "openai:gpt-4o-mini", maxTurns: 1 },
+      env: {
+        OPENAI_API_KEY: "mock", // any value; the mock ignores it
+        OPENAI_BASE_URL: MOCK_BASE_URL,
+      },
+    });
+    const stream = await agent.stream({
+      messages: [{ role: "user", content: "Say hello." }],
+    });
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let raw = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      raw += decoder.decode(value);
+      if (raw.length > 500_000) break;
+    }
+    // Join text-delta events — SSE chunking can split the marker mid-word.
+    let text = "";
+    for (const line of raw.split("\n")) {
+      if (!line.startsWith("data: {")) continue;
+      try {
+        const event = JSON.parse(line.slice(6)) as {
+          type?: string;
+          delta?: string;
+        };
+        if (event.type === "text-delta" && typeof event.delta === "string") {
+          text += event.delta;
+        }
+      } catch {
+        // partial/non-JSON line — ignore
+      }
+    }
+    expect(text).toContain(MOCK_MARKER);
+  }, 300_000);
+});

--- a/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
+++ b/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
@@ -20,13 +20,14 @@ const sandboxingAvailable = (() => {
     try {
       // srt needs bwrap (with permission to create user namespaces — on
       // Ubuntu 24.04+ that requires an AppArmor profile or
-      // kernel.apparmor_restrict_unprivileged_userns=0) AND socat for its
-      // network proxy bridge.
+      // kernel.apparmor_restrict_unprivileged_userns=0), socat for its
+      // network proxy bridge, and ripgrep.
       execFileSync("bwrap", ["--ro-bind", "/", "/", "true"], {
         stdio: "ignore",
         timeout: 10000,
       });
       execFileSync("socat", ["-V"], { stdio: "ignore", timeout: 10000 });
+      execFileSync("rg", ["--version"], { stdio: "ignore", timeout: 10000 });
       return true;
     } catch {
       return false;
@@ -62,7 +63,9 @@ describe.skipIf(!sandboxingAvailable)("SrtSandbox (real isolation)", () => {
     // the OS temp dir (which SrtSandbox always allows) — and the repo itself
     // can sit under the temp dir (e.g. a /tmp git worktree), so anchor to
     // the user's home rather than process.cwd(). Removed in afterEach.
-    outsideDir = await fs.mkdtemp(path.join(os.homedir(), ".srt-test-outside-"));
+    outsideDir = await fs.mkdtemp(
+      path.join(os.homedir(), ".srt-test-outside-"),
+    );
   });
 
   afterEach(async () => {

--- a/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
+++ b/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
@@ -59,11 +59,10 @@ describe.skipIf(!sandboxingAvailable)("SrtSandbox (real isolation)", () => {
   beforeEach(async () => {
     workdir = await fs.mkdtemp(path.join(os.tmpdir(), "srt-sandbox-wd-"));
     // A directory the policy does NOT allow writes to. It must live outside
-    // the OS temp dir (which SrtSandbox always allows), so a repo-local
-    // scratch dir is used instead of the user's real home.
-    outsideDir = await fs.mkdtemp(
-      path.join(process.cwd(), ".srt-test-outside-"),
-    );
+    // the OS temp dir (which SrtSandbox always allows) — and the repo itself
+    // can sit under the temp dir (e.g. a /tmp git worktree), so anchor to
+    // the user's home rather than process.cwd(). Removed in afterEach.
+    outsideDir = await fs.mkdtemp(path.join(os.homedir(), ".srt-test-outside-"));
   });
 
   afterEach(async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,6 +124,9 @@ importers:
       '@bunny-agent/sandbox-sandock':
         specifier: workspace:*
         version: link:../../packages/sandbox-sandock
+      '@bunny-agent/sandbox-srt':
+        specifier: workspace:*
+        version: link:../../packages/sandbox-srt
     devDependencies:
       '@types/node':
         specifier: ^20.10.0


### PR DESCRIPTION
> Stacked on #356 (which is stacked on #355). Also contains a cherry-pick of #359's one-line sandock bin fix (the live sandock E2E depends on it; identical change, merges cleanly in any order).

## Why

Every sandbox adapter's unit suite mocks its SDK, so an entire class of breakage is invisible to CI — the sandock runner-bin bug (#359) shipped with 39/39 unit tests green and was only caught by a live run. This adds an opt-in live tier on every PR.

## What

**`.github/workflows/integration.yml`** — two jobs:

| Job | What it proves | Needs |
|---|---|---|
| **local-srt** | sandbox-local + sandbox-srt suites under **real bubblewrap isolation** (installs bwrap+socat, relaxes Ubuntu 24.04's userns restriction on the ephemeral runner, fails loudly if the probe fails instead of green-but-skipped), then a **full `BunnyAgent.stream()` turn** through the real runner-cli in LocalMachine and SrtSandbox | nothing — LLM is the deterministic [mock-ai-server](https://mock-ai-server.vika.workers.dev) (pi runner, OpenAI protocol, no key, zero token cost) |
| **sandock** | adapter round trip (attach/exec/upload/readFile) + full turn through the npm-bootstrapped runner in a **real sandock.ai sandbox** | `SANDOCK_API_KEY` repo secret — skips cleanly when absent (fork PRs) |

**New live suites** (gated by `BUNNY_INTEGRATION=1`, so `pnpm -r test` on dev machines is unchanged):
- `apps/manager-cli/src/__tests__/live-e2e.test.ts` — the SrtSandbox case allowlists **only the mock host**, which also proves srt's domain allowlist end to end.
- `packages/sandbox-sandock/src/__tests__/sandock-live.test.ts` — always destroys the cloud sandbox in `afterEach` (120s hook timeout).

## Real-world gotchas encoded in the tests (all found by actually running them)

1. SSE chunking can split a word across `text-delta` events (observed `"mock-ai-serve" + "r, …"`) — assertions join deltas, never match raw stream text.
2. srt removes the network namespace and injects `HTTP(S)_PROXY`; Node's fetch (undici) ignores those, so the spawned runner needs **`NODE_USE_ENV_PROXY=1` (Node ≥ 24)** — without it every LLM call inside SrtSandbox dies with "Connection error." while curl works.
3. pi stores sessions under `~/.bunny/agent/sessions` → must be in srt `allowWrite`.
4. Destroying a real cloud sandbox exceeds vitest's 10s default hook timeout.

## Validation (all run for real before pushing)

- local-srt live: **3/3** (LocalMachine turn 3.7s; SrtSandbox turn through srt's proxy with only the mock host allowlisted)
- sandock live: **2/2** against production sandock.ai (~106s incl. create/destroy)
- Without `BUNNY_INTEGRATION`: everything skips, unit suites unchanged; lint + typecheck green

## Setup needed from repo admin

Add the **`SANDOCK_API_KEY`** repo secret (Settings → Secrets → Actions). Optionally a `SANDOCK_BASE_URL` repo variable for a non-production deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
