### PR TITLE
fix: sandbox robustness — process-tree cleanup, temp-dir leak, network retry, preflight

### DIFF
--- a/.changeset/sandbox-robustness-hardening.md
+++ b/.changeset/sandbox-robustness-hardening.md
@@ -1,0 +1,11 @@
+---
+"@bunny-agent/sandbox-local": patch
+"@bunny-agent/sandbox-srt": patch
+"@bunny-agent/sandbox-sandock": patch
+---
+
+Robustness hardening across the local/srt/sandock adapters:
+
+- `LocalMachine`: abort/timeout now kills the whole process tree (not just the direct child), catching backgrounded grandchild processes that previously survived as orphans.
+- `SrtSandbox`: fixed a temp-directory leak on `destroy()`; added a preflight check on `attach()` with an actionable, platform-aware error when bubblewrap/socat/ripgrep are missing.
+- `SandockSandbox`: retries transient network errors (e.g. a dropped connection to sandock.ai) on safe, idempotent-ish calls; does not retry `exec`/`shell` calls, which can have non-idempotent side effects.

--- a/docs/changelog/2026-07-16-sandbox-robustness-hardening.md
+++ b/docs/changelog/2026-07-16-sandbox-robustness-hardening.md
@@ -1,0 +1,111 @@
+# Sandbox robustness hardening: process-tree cleanup, temp-dir leak, network retry, preflight
+
+Date: 2026-07-16
+
+Follow-up to the LocalMachine/SrtSandbox/sandbox-local+srt-package/CI work
+from earlier today (PRs #355, #356, #359, #361). Four independent
+robustness gaps, each found by reproducing the failure for real before
+fixing it (not guessed at).
+
+## 1. LocalMachine: abort/timeout orphaned backgrounded grandchildren
+
+**Repro before the fix**: ran a shell command through `LocalMachine.exec()`
+that backgrounds a long-running grandchild (`(sleep 60 &) ; sleep 60`),
+aborted it via `AbortSignal`, and confirmed via `ps` that the tagged
+grandchild process survived — `child.kill(signal)` only ever signals the
+direct child PID, not its process tree.
+
+**Fix**: `spawn(..., { detached: true })` (POSIX: makes the child the leader
+of its own process group) + a new `killProcessTree()` helper that signals
+the negative PID (whole group) on POSIX or shells out to `taskkill /T` on
+Windows. Applied to both `exec()`'s timeout/abort paths and
+`runCommand()`'s timeout path.
+
+**Also fixed in the same code path**: the existing "force SIGKILL after 5s
+if still running" escalation checked `child.killed`, which Node sets `true`
+as soon as a signal is *sent* successfully — not when the process actually
+exits. That escalation essentially never fired. Now tracked via a real
+`child.once("exit", ...)` flag.
+
+**SrtSandbox needed no equivalent fix** — confirmed by the same repro
+through `SrtSandbox`: srt passes bubblewrap `--unshare-pid`, so the kernel
+tears down every process in that PID namespace the instant its init dies.
+A regression test locks this guarantee in for both adapters.
+
+## 2. SrtSandbox: settings-dir temp leak
+
+**Repro**: ran one `SrtSandbox` command and called `destroy()`; the
+generated `srt-sandbox-*` temp directory (holding the policy JSON) was
+still there afterward. A debugging session running the test suite
+repeatedly had accumulated 80+ leaked directories in `/tmp` before this fix
+— confirmed by directly counting them.
+
+**Fix**: new `LocalMachine.onDestroy()` protected hook (mirrors the existing
+`transformCommand()` seam), threaded through `LocalMachineHandle`'s
+constructor and called from `destroy()`. `SrtSandbox` overrides it to
+`fs.rm()` the directory it created.
+
+## 3. SandockSandbox: retry transient network errors
+
+**Motivation**: today's own CI run hit a real `TypeError: terminated`
+(cause: `SocketError: other side closed`, code `UND_ERR_SOCKET`) against
+production sandock.ai — a one-off Cloudflare connection drop, not an
+application error. Nothing retried it.
+
+**Fix**: new `retry.ts` (`withNetworkRetry` + `isTransientNetworkError`,
+pattern-matches the error and its `.cause` chain against known transient
+signatures). Applied to every safe-to-retry call: `sandbox.get/start/create`,
+`volume.getByName`, `fs.read/write`, `sandbox.stop/delete`. Deliberately
+**not** applied to `sandbox.shell` (the exec/runCommand path) — an arbitrary
+user command can have already caused side effects before a connection
+drops, so blindly re-running it risks double-executing something
+non-idempotent. `create()` is retried too, accepting a documented, small
+risk: if the request reached the server but the response was lost, a retry
+could create a second sandbox — sandock's API has no idempotency-key
+mechanism to close that gap.
+
+## 4. SrtSandbox: preflight check with actionable errors
+
+**Repro before the fix**: hid `bwrap`/`socat`/`rg` from `PATH` and ran a
+real command through `SrtSandbox`. srt's own error ("Sandbox dependencies
+not available: ripgrep (rg) not found, ...") was already reasonably clear,
+but only surfaced deep inside the first `exec()` call, and had no
+installation guidance.
+
+**Fix**: `SrtSandbox.attach()` now runs a cheap srt-wrapped no-op probe
+(`node -e "process.exit(0)"` — chosen because Node is always present,
+unlike `true`/`echo`) before any real work. A failure matching srt's own
+"Sandbox dependencies not available" signature gets an appended,
+platform-aware install hint (`apt-get`/`brew`, plus the Ubuntu 24.04+
+AppArmor/userns note this repo's own CI setup needed). A failure *not*
+matching that signature gets a generic "preflight failed" wrapper instead
+of being mislabeled as a missing dependency. Only runs once per instance
+(skipped if already attached).
+
+## Testing
+
+- `sandbox-local`: 24/24 (2 new process-tree tests — confirmed they fail
+  without the fix, pass with it, by temporarily reverting the fix during
+  verification).
+- `sandbox-srt`: 14/14 (1 new PID-namespace regression test, 1 new
+  settings-dir cleanup test, 3 new `buildInstallHint` unit tests, 4 new
+  preflight tests using a fake `srtCommand` — deterministic, no real
+  bwrap/socat/rg dependency).
+- `sandbox-sandock`: 50/52 (9 new retry unit tests; 2 pre-existing live
+  tests skip without `BUNNY_INTEGRATION`+`SANDOCK_API_KEY`, as before).
+- Full live E2E (`manager-cli`'s `live-e2e.test.ts`, `BUNNY_INTEGRATION=1`):
+  3/3 — LocalMachine and SrtSandbox each completing a real agent turn
+  through the real runner-cli and the mock LLM, confirming none of the four
+  fixes regressed the actual end-to-end path.
+- `pnpm -r build`, `pnpm -r typecheck`, `pnpm run -w lint`: all green.
+
+## Known gap
+
+Live re-verification of the Sandock round trip against production
+sandock.ai could not be completed this session — `SANDOCK_API_KEY` in the
+local `.env.integration` file has been revoked/expired (confirmed with a
+raw `curl` bypassing all adapter code, ruling out a code regression). The
+retry logic is unit-tested and the one live attempt made correctly did
+**not** retry the resulting 401 (proving the transient-vs-application-error
+distinction works), but a fresh key is needed to re-run the live round trip
+end to end.

--- a/packages/sandbox-local/src/__tests__/local-machine.test.ts
+++ b/packages/sandbox-local/src/__tests__/local-machine.test.ts
@@ -1,8 +1,22 @@
+import { execSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { LocalMachine, LocalSandbox } from "../local-machine.js";
+
+/** True if a process whose argv0 is exactly `marker` is currently running
+ *  (used to detect orphaned grandchildren after abort/timeout). POSIX only —
+ *  `pgrep` isn't available on Windows, and process-group kill is POSIX-only
+ *  in local-machine.ts's killProcessTree() too. */
+function isProcessRunning(marker: string): boolean {
+  try {
+    execSync(`pgrep -f -x "${marker} 60"`, { stdio: "ignore" });
+    return true;
+  } catch {
+    return false; // pgrep exits non-zero when nothing matches
+  }
+}
 
 describe("LocalMachine", () => {
   let tempDir: string;
@@ -363,6 +377,80 @@ describe("LocalMachine", () => {
       await handle.destroy();
     });
   });
+
+  describe.skipIf(process.platform === "win32")(
+    "process tree cleanup (abort/timeout)",
+    () => {
+      // Regression: a plain child.kill(signal) only signals the direct
+      // child. If that child backgrounds its own grandchild (e.g. a shell's
+      // `cmd &`, or a coding-agent CLI spawning a tool subprocess), the
+      // grandchild survived as an orphan — confirmed by a live repro before
+      // this fix. killProcessTree() (spawn with detached:true + signaling
+      // the negative pid) reaps the whole group instead.
+      const backgroundedSleep = (marker: string) => [
+        "bash",
+        "-c",
+        `(exec -a ${marker} sleep 60) & echo started; sleep 60`,
+      ];
+
+      it("abort() kills a backgrounded grandchild, not just the direct child", async () => {
+        const sandbox = new LocalMachine({ workdir: tempDir });
+        const handle = await sandbox.attach();
+        const marker = `orphan-test-abort-${process.pid}-${Date.now()}`;
+
+        const controller = new AbortController();
+        const chunks: string[] = [];
+        const consume = (async () => {
+          try {
+            for await (const chunk of handle.exec(backgroundedSleep(marker), {
+              signal: controller.signal,
+            })) {
+              chunks.push(new TextDecoder().decode(chunk));
+            }
+          } catch {
+            // Expected: exec() rejects with "Command was aborted".
+          }
+        })();
+
+        // Wait for the shell to actually background the grandchild.
+        await new Promise((r) => setTimeout(r, 500));
+        expect(isProcessRunning(marker)).toBe(true);
+
+        controller.abort();
+        await consume;
+
+        // killProcessTree sends SIGTERM immediately; give it a moment to land.
+        await new Promise((r) => setTimeout(r, 500));
+        expect(isProcessRunning(marker)).toBe(false);
+
+        await handle.destroy();
+      }, 15000);
+
+      it("timeout kills a backgrounded grandchild, not just the direct child", async () => {
+        const sandbox = new LocalMachine({
+          workdir: tempDir,
+          defaultTimeout: 300,
+        });
+        const handle = await sandbox.attach();
+        const marker = `orphan-test-timeout-${process.pid}-${Date.now()}`;
+
+        const chunks: string[] = [];
+        try {
+          for await (const chunk of handle.exec(backgroundedSleep(marker))) {
+            chunks.push(new TextDecoder().decode(chunk));
+          }
+          throw new Error("expected exec() to reject on timeout");
+        } catch (error) {
+          expect(String(error)).toContain("timed out");
+        }
+
+        await new Promise((r) => setTimeout(r, 500));
+        expect(isProcessRunning(marker)).toBe(false);
+
+        await handle.destroy();
+      }, 15000);
+    },
+  );
 });
 
 describe("LocalSandbox (deprecated alias)", () => {

--- a/packages/sandbox-local/src/local-machine.ts
+++ b/packages/sandbox-local/src/local-machine.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { type ChildProcess, execFile, spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import {
@@ -7,6 +7,46 @@ import {
   type SandboxAdapter,
   type SandboxHandle,
 } from "@bunny-agent/manager";
+
+/**
+ * Kill an entire process tree, not just the direct child.
+ *
+ * A plain `child.kill(signal)` only signals the direct child PID. If that
+ * child forks/backgrounds its own children (e.g. a shell's `cmd &`, or a
+ * coding-agent CLI spawning a tool subprocess), those grandchildren are NOT
+ * part of a process group we control and survive as orphans — a real
+ * resource leak on abort/timeout that plain `LocalMachine` (no isolation)
+ * has no other protection against. (`SrtSandbox` doesn't need this: srt's
+ * bwrap wrapping passes `--unshare-pid`, so the kernel tears down every
+ * process in that PID namespace the instant its init dies — confirmed by a
+ * live repro that leaves an orphan under `LocalMachine` but reaps it clean
+ * under `SrtSandbox`.)
+ *
+ * Requires the child to have been spawned with `detached: true` on POSIX
+ * (making `child.pid` the process-group leader, so `process.kill(-pid, …)`
+ * signals the whole group). On Windows, `taskkill /T` walks the tree
+ * instead — Node's negative-PID group-signal trick is POSIX-only.
+ */
+function killProcessTree(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (!child.pid) {
+    return;
+  }
+  if (process.platform === "win32") {
+    execFile("taskkill", ["/pid", String(child.pid), "/T", "/F"], () => {
+      // Best-effort: nothing to recover into if taskkill itself is missing
+      // or the tree is already gone.
+    });
+    return;
+  }
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    // ESRCH (already exited) or the child wasn't actually a group leader
+    // (e.g. spawn failed before detached took effect) — fall back to
+    // signaling just the direct child so a live process still gets it.
+    child.kill(signal);
+  }
+}
 
 /**
  * Options for creating a LocalMachine instance
@@ -163,6 +203,7 @@ export class LocalMachine implements SandboxAdapter {
       this.env,
       this.label,
       (command) => this.transformCommand(command),
+      () => this.onDestroy(),
     );
 
     // Store the handle
@@ -203,6 +244,13 @@ export class LocalMachine implements SandboxAdapter {
   protected async transformCommand(command: string[]): Promise<string[]> {
     return command;
   }
+
+  /**
+   * Hook for subclasses to release resources they allocated outside the
+   * handle (e.g. a generated policy file) when the handle is destroyed. The
+   * base implementation is a no-op.
+   */
+  protected async onDestroy(): Promise<void> {}
 }
 
 /**
@@ -215,6 +263,7 @@ class LocalMachineHandle implements SandboxHandle {
   private readonly _sandboxId: string;
   private readonly label: string;
   private readonly transformCommand: (command: string[]) => Promise<string[]>;
+  private readonly onDestroyHook: () => Promise<void>;
 
   constructor(
     workDir: string,
@@ -224,12 +273,14 @@ class LocalMachineHandle implements SandboxHandle {
     transformCommand: (command: string[]) => Promise<string[]> = async (
       command,
     ) => command,
+    onDestroyHook: () => Promise<void> = async () => {},
   ) {
     this.workDir = workDir;
     this.defaultTimeout = defaultTimeout;
     this.env = env;
     this.label = label;
     this.transformCommand = transformCommand;
+    this.onDestroyHook = onDestroyHook;
     this._sandboxId = `local-${crypto.randomUUID()}`;
   }
 
@@ -291,7 +342,31 @@ class LocalMachineHandle implements SandboxHandle {
       cwd,
       env,
       shell: false,
+      // Makes `child.pid` the leader of its own process group on POSIX, so
+      // killProcessTree() can signal the whole tree (including backgrounded
+      // grandchildren) instead of just this direct child.
+      detached: process.platform !== "win32",
     });
+
+    // Tracks real process exit — NOT the same as child.killed, which Node
+    // sets true as soon as a kill() signal is successfully *sent*, whether
+    // or not the process actually died. Using child.killed to decide
+    // whether to escalate to SIGKILL (the pre-existing logic here) meant
+    // the escalation almost never fired, because killed flips true right
+    // after the SIGTERM call succeeds — before the process has had any
+    // chance to exit.
+    let hasExited = false;
+    child.once("exit", () => {
+      hasExited = true;
+    });
+
+    const escalateToSigkill = () => {
+      setTimeout(() => {
+        if (!hasExited) {
+          killProcessTree(child, "SIGKILL");
+        }
+      }, 5000);
+    };
 
     let timeoutId: NodeJS.Timeout | undefined;
     let isTimedOut = false;
@@ -301,25 +376,16 @@ class LocalMachineHandle implements SandboxHandle {
     if (timeout > 0) {
       timeoutId = setTimeout(() => {
         isTimedOut = true;
-        child.kill("SIGTERM");
-        // Force kill after 5 seconds if still running
-        setTimeout(() => {
-          if (!child.killed) {
-            child.kill("SIGKILL");
-          }
-        }, 5000);
+        killProcessTree(child, "SIGTERM");
+        escalateToSigkill();
       }, timeout);
     }
 
     // Set up abort signal if provided
     const abortHandler = () => {
       isAborted = true;
-      child.kill("SIGTERM");
-      setTimeout(() => {
-        if (!child.killed) {
-          child.kill("SIGKILL");
-        }
-      }, 5000);
+      killProcessTree(child, "SIGTERM");
+      escalateToSigkill();
     };
 
     if (opts.signal) {
@@ -466,6 +532,9 @@ class LocalMachineHandle implements SandboxHandle {
         cwd: this.workDir,
         env: { ...process.env, ...this.env }, // Use instance env
         stdio: "pipe",
+        // See killProcessTree()'s doc comment (above, in exec()'s spawn):
+        // needed so a timeout can reap backgrounded grandchildren too.
+        detached: process.platform !== "win32",
       });
 
       let stdout = "";
@@ -492,7 +561,8 @@ class LocalMachineHandle implements SandboxHandle {
       // Timeout handling
       const timeout = this.defaultTimeout;
       const timeoutId = setTimeout(() => {
-        child.kill();
+        killProcessTree(child, "SIGTERM");
+        setTimeout(() => killProcessTree(child, "SIGKILL"), 5000);
         reject(new Error(`Command timed out after ${timeout}ms`));
       }, timeout);
 
@@ -503,6 +573,7 @@ class LocalMachineHandle implements SandboxHandle {
   }
 
   async destroy(): Promise<void> {
+    await this.onDestroyHook();
     console.log(`[${this.label}] Cleanup complete for: ${this.workDir}`);
     // Note: We don't delete the directory by default to preserve work
     // Users can manually delete it if needed

--- a/packages/sandbox-sandock/src/__tests__/retry.test.ts
+++ b/packages/sandbox-sandock/src/__tests__/retry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { isTransientNetworkError, withNetworkRetry } from "../retry.js";
+
+describe("isTransientNetworkError", () => {
+  it("recognizes undici's 'terminated' TypeError with a SocketError cause", () => {
+    // The exact shape observed against production sandock.ai in CI: a
+    // TypeError('terminated') whose .cause is the underlying SocketError.
+    const socketError = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    const terminated = new TypeError("terminated", { cause: socketError });
+    expect(isTransientNetworkError(terminated)).toBe(true);
+  });
+
+  it("recognizes common POSIX network error codes", () => {
+    for (const code of ["ECONNRESET", "ETIMEDOUT", "EPIPE", "ECONNREFUSED"]) {
+      const error = Object.assign(new Error("boom"), { code });
+      expect(isTransientNetworkError(error)).toBe(true);
+    }
+  });
+
+  it("does not treat an application-level error as transient", () => {
+    expect(isTransientNetworkError(new Error("404 Not Found"))).toBe(false);
+    expect(isTransientNetworkError(new Error("Unauthorized"))).toBe(false);
+  });
+
+  it("does not treat a non-Error value as transient", () => {
+    expect(isTransientNetworkError("just a string")).toBe(false);
+    expect(isTransientNetworkError(null)).toBe(false);
+  });
+
+  it("stops walking the cause chain after a bounded depth (no infinite loop on a cyclic cause)", () => {
+    const a: Error & { cause?: unknown } = new Error("a");
+    const b: Error & { cause?: unknown } = new Error("b");
+    a.cause = b;
+    b.cause = a; // cyclic — must not hang
+    expect(isTransientNetworkError(a)).toBe(false);
+  });
+});
+
+describe("withNetworkRetry", () => {
+  it("returns the result on first success without retrying", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withNetworkRetry(fn);
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a transient failure and succeeds on the next attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error("other side closed"), {
+          code: "UND_ERR_SOCKET",
+        }),
+      )
+      .mockResolvedValue("recovered");
+
+    const result = await withNetworkRetry(fn, { baseDelayMs: 1 });
+    expect(result).toBe("recovered");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a non-transient (application-level) error", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("401 Unauthorized"));
+    await expect(withNetworkRetry(fn, { baseDelayMs: 1 })).rejects.toThrow(
+      "401 Unauthorized",
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("gives up and throws after exhausting all attempts", async () => {
+    const transientError = Object.assign(new Error("socket hang up"), {
+      code: "ECONNRESET",
+    });
+    const fn = vi.fn().mockRejectedValue(transientError);
+
+    await expect(
+      withNetworkRetry(fn, { attempts: 3, baseDelayMs: 1 }),
+    ).rejects.toThrow("socket hang up");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/sandbox-sandock/src/retry.ts
+++ b/packages/sandbox-sandock/src/retry.ts
@@ -1,0 +1,101 @@
+/**
+ * Retry helper for transient network failures against the Sandock API.
+ *
+ * Real-world motivation: a CI run hit `TypeError: terminated` (cause:
+ * `SocketError: other side closed`, code `UND_ERR_SOCKET`) mid-request
+ * against production sandock.ai — a one-off connection drop between the
+ * runner and Cloudflare, not an application error. Nothing in the adapter
+ * retried it, so the whole sandbox operation failed outright.
+ *
+ * Only applied to calls that are safe to retry blindly:
+ * - Reads (`sandbox.get`, `volume.getByName`, `fs.read`) — no side effects.
+ * - Idempotent lifecycle calls (`sandbox.start`, `sandbox.stop`,
+ *   `sandbox.delete`, `fs.write` with the same content/path) — repeating
+ *   them is safe even if the first attempt actually landed server-side.
+ * - `sandbox.create` — retried too, accepting a small, known risk: if the
+ *   create request reached the server but the *response* was lost to the
+ *   same kind of transient drop, a retry could create a second sandbox.
+ *   Sandock's API has no idempotency-key mechanism to close that gap, and
+ *   leaving `create` unprotected would leave exactly the operation that
+ *   flaked in CI unprotected too.
+ *
+ * Deliberately NOT applied to `sandbox.shell` (the exec/runCommand path):
+ * an arbitrary user command can have already caused side effects (wrote
+ * files, started a process) before the connection dropped — blindly
+ * re-running it risks double-executing something that isn't idempotent.
+ */
+
+export interface RetryOptions {
+  /** Total attempts including the first. Default 3. */
+  attempts?: number;
+  /** Delay before the first retry; doubles each subsequent attempt. Default 300ms. */
+  baseDelayMs?: number;
+}
+
+const TRANSIENT_ERROR_PATTERNS: RegExp[] = [
+  /ECONNRESET/i,
+  /ETIMEDOUT/i,
+  /EPIPE/i,
+  /ECONNREFUSED/i,
+  /EAI_AGAIN/i,
+  /UND_ERR_SOCKET/i,
+  /UND_ERR_CONNECT_TIMEOUT/i,
+  /other side closed/i,
+  /socket hang up/i,
+  /fetch failed/i,
+  /^terminated$/i, // undici's generic message when a connection is dropped mid-request
+];
+
+/**
+ * Whether `error` (or anything in its `.cause` chain) looks like a
+ * transient network failure rather than an application-level error (auth,
+ * 404, validation, etc.) that would just fail again identically.
+ */
+export function isTransientNetworkError(error: unknown): boolean {
+  let current: unknown = error;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    if (!(current instanceof Error)) {
+      break;
+    }
+    const code = (current as NodeJS.ErrnoException).code;
+    const haystack = `${current.message} ${code ?? ""}`;
+    if (TRANSIENT_ERROR_PATTERNS.some((pattern) => pattern.test(haystack))) {
+      return true;
+    }
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+/**
+ * Retries `fn` with exponential backoff, but only when the thrown error
+ * looks transient (see {@link isTransientNetworkError}). Application-level
+ * errors (thrown synchronously or returned as `{ error }` by openapi-fetch)
+ * are never retried — they would just fail again identically.
+ */
+export async function withNetworkRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const attempts = options.attempts ?? 3;
+  const baseDelayMs = options.baseDelayMs ?? 300;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      const isLastAttempt = attempt === attempts;
+      if (isLastAttempt || !isTransientNetworkError(error)) {
+        throw error;
+      }
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      console.warn(
+        `[Sandock] Transient network error (attempt ${attempt}/${attempts}), retrying in ${delayMs}ms:`,
+        error instanceof Error ? error.message : error,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  // Unreachable: the loop always returns or throws.
+  throw new Error("withNetworkRetry: exhausted attempts without a result");
+}

--- a/packages/sandbox-sandock/src/sandock-sandbox.ts
+++ b/packages/sandbox-sandock/src/sandock-sandbox.ts
@@ -8,6 +8,7 @@ import type {
   Volume,
 } from "@bunny-agent/manager";
 import { createSandockClient, type SandockClient } from "sandock";
+import { withNetworkRetry } from "./retry.js";
 
 /** Single volume mount configuration (name → get/create by name; mountPath inside container) */
 export interface SandockVolumeConfig {
@@ -220,14 +221,18 @@ export class SandockSandbox implements SandboxAdapter {
     const id = this._sandboxId;
     if (!id) return null;
     try {
-      const { data } = await this.client.sandbox.get(id);
+      const { data } = await withNetworkRetry(() =>
+        this.client.sandbox.get(id),
+      );
       const status = data.status;
 
       if (status === "STOPPED" || status === "PAUSED") {
         console.log(
           `[Sandock] Restarting existing sandbox ${id} (status: ${status})`,
         );
-        const startResult = await this.client.sandbox.start(id);
+        const startResult = await withNetworkRetry(() =>
+          this.client.sandbox.start(id),
+        );
         if (!startResult.data.started) {
           console.warn(
             `[Sandock] start() did not report started for ${id}, creating new`,
@@ -297,7 +302,9 @@ export class SandockSandbox implements SandboxAdapter {
     const volumeMounts: Volume[] = [];
     for (const v of this.volumeConfigs) {
       console.log(`[Sandock] Getting/creating volume: ${v.volumeName}`);
-      const volume = await this.client.volume.getByName(v.volumeName, true);
+      const volume = await withNetworkRetry(() =>
+        this.client.volume.getByName(v.volumeName, true),
+      );
       const mountPath = v.volumeMountPath;
 
       if (volume.data.status && volume.data.status !== "ready") {
@@ -327,7 +334,9 @@ export class SandockSandbox implements SandboxAdapter {
     maxWaitMs: number,
   ): Promise<boolean> {
     const startTime = Date.now();
-    let current = await this.client.volume.getByName(volumeName, false);
+    let current = await withNetworkRetry(() =>
+      this.client.volume.getByName(volumeName, false),
+    );
     while (
       current.data.status !== "ready" &&
       Date.now() - startTime < maxWaitMs
@@ -336,7 +345,9 @@ export class SandockSandbox implements SandboxAdapter {
         `[Sandock] Volume ${volumeName} status: ${current.data.status}, waiting...`,
       );
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      current = await this.client.volume.getByName(volumeName, false);
+      current = await withNetworkRetry(() =>
+        this.client.volume.getByName(volumeName, false),
+      );
     }
     return current.data.status === "ready";
   }
@@ -374,7 +385,12 @@ export class SandockSandbox implements SandboxAdapter {
       createOptions.env = this.env;
     }
 
-    const createResult = await this.client.sandbox.create(createOptions);
+    // Retried on transient network failure too (see retry.ts's doc comment
+    // for the accepted risk: a create() whose request landed server-side
+    // but whose response was lost would create a second sandbox on retry).
+    const createResult = await withNetworkRetry(() =>
+      this.client.sandbox.create(createOptions),
+    );
     const sandboxId = createResult.data.id;
     if (!sandboxId) {
       throw new Error("No sandbox ID returned from Sandock API");
@@ -382,7 +398,7 @@ export class SandockSandbox implements SandboxAdapter {
     console.log(
       `[Sandock] Created new sandbox: ${sandboxId} ${this.name ? `, title: ${this.name}` : ""}`,
     );
-    await this.client.sandbox.start(sandboxId);
+    await withNetworkRetry(() => this.client.sandbox.start(sandboxId));
     return { sandboxId, volumeMounts };
   }
 
@@ -860,12 +876,16 @@ class SandockHandle implements SandboxHandle {
           : new TextDecoder().decode(file.content);
 
       // Use high-level fs.write API
-      await this.client.fs.write(this.sandboxId, fullPath, content);
+      await withNetworkRetry(() =>
+        this.client.fs.write(this.sandboxId, fullPath, content),
+      );
     }
   }
 
   async readFile(filePath: string): Promise<string> {
-    const result = await this.client.fs.read(this.sandboxId, filePath);
+    const result = await withNetworkRetry(() =>
+      this.client.fs.read(this.sandboxId, filePath),
+    );
     // Sandock fs.read returns { success: true, data: { path: string, content: string } }
     if (result.success && result.data) {
       return typeof result.data === "string"
@@ -880,10 +900,10 @@ class SandockHandle implements SandboxHandle {
    */
   async destroy(): Promise<void> {
     // Stop the sandbox using high-level API
-    await this.client.sandbox.stop(this.sandboxId);
+    await withNetworkRetry(() => this.client.sandbox.stop(this.sandboxId));
 
     // Delete sandbox using high-level API
-    await this.client.sandbox.delete(this.sandboxId);
+    await withNetworkRetry(() => this.client.sandbox.delete(this.sandboxId));
 
     this.onDestroy();
   }

--- a/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
+++ b/packages/sandbox-srt/src/__tests__/srt-sandbox.test.ts
@@ -1,10 +1,10 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import type { SandboxHandle } from "@bunny-agent/manager";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { SrtSandbox } from "../srt-sandbox.js";
+import { buildInstallHint, SrtSandbox } from "../srt-sandbox.js";
 
 /**
  * These are real isolation tests: they execute commands through the actual
@@ -152,4 +152,195 @@ describe.skipIf(!sandboxingAvailable)("SrtSandbox (real isolation)", () => {
     }
     expect(deniedSomewhere).toBe(true);
   }, 120000);
+
+  it("abort/timeout leaves no orphaned grandchild process (PID namespace)", async () => {
+    // LocalMachine (no isolation) needs its own process-group kill logic to
+    // catch backgrounded grandchildren on abort/timeout (see
+    // sandbox-local's local-machine.test.ts). SrtSandbox doesn't need that
+    // extra mechanism: srt passes bwrap `--unshare-pid`, so the kernel tears
+    // down every process in that PID namespace the moment its init process
+    // dies — this test locks that guarantee in so a future srt/bwrap flag
+    // change can't silently regress it.
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+    const marker = `srt-orphan-test-${process.pid}-${Date.now()}`;
+
+    const controller = new AbortController();
+    const consume = (async () => {
+      try {
+        for await (const chunk of handle.exec(
+          [
+            "bash",
+            "-c",
+            `(exec -a ${marker} sleep 60) & echo started; sleep 60`,
+          ],
+          { signal: controller.signal },
+        )) {
+          void chunk;
+        }
+      } catch {
+        // Expected: exec() rejects once aborted.
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 3000));
+    controller.abort();
+    await consume;
+    await new Promise((r) => setTimeout(r, 3000));
+
+    let survived = false;
+    try {
+      execSync(`pgrep -f -x "${marker} 60"`, { stdio: "ignore" });
+      survived = true;
+    } catch {
+      survived = false; // pgrep exits non-zero when nothing matches
+    }
+    expect(survived).toBe(false);
+  }, 120000);
+
+  it("destroy() removes the generated srt-settings temp directory", async () => {
+    // Regression: ensureSettingsFile() mkdtemp's a `srt-sandbox-*` dir under
+    // the OS temp dir for the generated policy file, but nothing removed it
+    // — every SrtSandbox instance that ran a command leaked one directory
+    // for the life of the host. Confirmed for real: a debugging session
+    // running this suite repeatedly had accumulated 80+ leaked directories
+    // in /tmp before this fix.
+    const before = new Set(
+      (await fs.readdir(os.tmpdir())).filter((d) =>
+        d.startsWith("srt-sandbox-"),
+      ),
+    );
+
+    const sandbox = new SrtSandbox({ workdir });
+    const handle = await sandbox.attach();
+    const result = await run(handle, "echo hi");
+    expect(result.ok).toBe(true);
+
+    const afterRun = new Set(
+      (await fs.readdir(os.tmpdir())).filter((d) =>
+        d.startsWith("srt-sandbox-"),
+      ),
+    );
+    const created = [...afterRun].filter((d) => !before.has(d));
+    expect(created.length).toBeGreaterThan(0);
+
+    await handle.destroy();
+
+    const afterDestroy = new Set(
+      (await fs.readdir(os.tmpdir())).filter((d) =>
+        d.startsWith("srt-sandbox-"),
+      ),
+    );
+    for (const dir of created) {
+      expect(afterDestroy.has(dir)).toBe(false);
+    }
+  }, 120000);
+});
+
+describe("buildInstallHint", () => {
+  it("suggests installing all dependencies named in srt's message", () => {
+    const hint = buildInstallHint(
+      "Sandbox dependencies not available: ripgrep (rg) not found, bubblewrap (bwrap) not installed, socat not installed",
+    );
+    expect(hint).toContain("apt-get install -y ripgrep bubblewrap socat");
+    expect(hint).toContain("brew install ripgrep socat");
+    expect(hint).toContain("userns");
+  });
+
+  it("only mentions what the message actually names as missing", () => {
+    const hint = buildInstallHint(
+      "Sandbox dependencies not available: socat not installed",
+    );
+    expect(hint).toContain("apt-get install -y socat");
+    expect(hint).not.toContain("ripgrep");
+    expect(hint).not.toContain("bubblewrap");
+  });
+
+  it("returns an empty string for a message naming no known dependency", () => {
+    expect(buildInstallHint("some unrelated failure")).toBe("");
+  });
+});
+
+/**
+ * Preflight-check tests use a fake `srtCommand` (a tiny throwaway script)
+ * instead of the real srt/bwrap wrapper, so they exercise attach()'s
+ * fail-fast behavior deterministically on any platform/CI environment —
+ * unlike the "real isolation" suite above, they don't need bubblewrap,
+ * socat, or ripgrep actually installed.
+ */
+describe("SrtSandbox preflight check (fake wrapper)", () => {
+  let workdir: string;
+
+  beforeEach(async () => {
+    workdir = await fs.mkdtemp(path.join(os.tmpdir(), "srt-preflight-wd-"));
+  });
+
+  afterEach(async () => {
+    await fs.rm(workdir, { recursive: true, force: true }).catch(() => {});
+  });
+
+  async function writeFakeSrt(script: string): Promise<string[]> {
+    const scriptPath = path.join(workdir, "fake-srt.cjs");
+    await fs.writeFile(scriptPath, script);
+    return [process.execPath, scriptPath];
+  }
+
+  it("attach() rejects immediately with an actionable message on a missing-dependency signature", async () => {
+    const srtCommand = await writeFakeSrt(
+      'console.error("Error: Sandbox dependencies not available: ripgrep (rg) not found, bubblewrap (bwrap) not installed, socat not installed"); process.exit(1);',
+    );
+    const sandbox = new SrtSandbox({ workdir, isolation: { srtCommand } });
+
+    await expect(sandbox.attach()).rejects.toThrow(/ripgrep/);
+  });
+
+  it("does not mislabel an unrelated startup failure as a missing dependency", async () => {
+    const srtCommand = await writeFakeSrt(
+      'console.error("Error: something else entirely broke"); process.exit(1);',
+    );
+    const sandbox = new SrtSandbox({ workdir, isolation: { srtCommand } });
+
+    await expect(sandbox.attach()).rejects.toThrow(
+      /failed its startup preflight check/,
+    );
+    await expect(
+      new SrtSandbox({ workdir, isolation: { srtCommand } }).attach(),
+    ).rejects.not.toThrow(/apt-get install/);
+  });
+
+  it("attach() succeeds once the preflight probe passes", async () => {
+    const srtCommand = await writeFakeSrt("process.exit(0);");
+    const sandbox = new SrtSandbox({ workdir, isolation: { srtCommand } });
+
+    const handle = await sandbox.attach();
+    expect(handle).toBeDefined();
+  });
+
+  it("does not re-run the preflight probe on a second attach() (already attached)", async () => {
+    const scriptPath = path.join(workdir, "counting-srt.cjs");
+    const counterPath = path.join(workdir, "count.txt");
+    await fs.writeFile(counterPath, "0");
+    // Every invocation bumps a counter file — including the real payload
+    // args exec()/runCommand() would pass — but this test only calls
+    // attach() twice, so any increment beyond 1 means the probe re-ran.
+    await fs.writeFile(
+      scriptPath,
+      [
+        'const fs = require("fs");',
+        `const p = ${JSON.stringify(counterPath)};`,
+        "fs.writeFileSync(p, String(Number(fs.readFileSync(p, 'utf8')) + 1));",
+        "process.exit(0);",
+      ].join("\n"),
+    );
+    const sandbox = new SrtSandbox({
+      workdir,
+      isolation: { srtCommand: [process.execPath, scriptPath] },
+    });
+
+    await sandbox.attach();
+    expect(Number(await fs.readFile(counterPath, "utf8"))).toBe(1);
+
+    await sandbox.attach();
+    expect(Number(await fs.readFile(counterPath, "utf8"))).toBe(1);
+  });
 });

--- a/packages/sandbox-srt/src/srt-sandbox.ts
+++ b/packages/sandbox-srt/src/srt-sandbox.ts
@@ -1,13 +1,82 @@
+import { execFile } from "node:child_process";
 import * as fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
+import type { SandboxHandle } from "@bunny-agent/manager";
 import {
   LocalMachine,
   type LocalMachineOptions,
 } from "@bunny-agent/sandbox-local";
 
 const require = createRequire(import.meta.url);
+
+/** The exact prefix srt uses when a required platform binary (bubblewrap,
+ *  socat, ripgrep, ...) is missing — confirmed against
+ *  `@anthropic-ai/sandbox-runtime@0.0.65` by a live repro with those
+ *  binaries hidden from PATH. Matching on this signature (rather than
+ *  guessing at srt's exact dependency list ourselves, which could drift out
+ *  of sync with a future srt version) lets SrtSandbox tell "you're missing
+ *  a dependency" apart from "the sandbox failed to start for some other
+ *  reason" without duplicating srt's own platform-requirements logic. */
+const MISSING_DEPS_SIGNATURE = "Sandbox dependencies not available";
+
+/** Package names to suggest installing, keyed by the dependency name
+ *  substring srt's own error message uses (see MISSING_DEPS_SIGNATURE's
+ *  doc comment — these are read out of srt's message, not asserted
+ *  independently, so an unlisted dependency just gets no extra hint
+ *  rather than a wrong one). `bubblewrap` has no `brew` entry: it's a
+ *  Linux-only sandboxing primitive, macOS uses Seatbelt instead. */
+const DEPENDENCY_PACKAGE_NAMES: Record<
+  string,
+  { apt?: string; brew?: string }
+> = {
+  ripgrep: { apt: "ripgrep", brew: "ripgrep" },
+  bubblewrap: { apt: "bubblewrap" },
+  socat: { apt: "socat", brew: "socat" },
+};
+
+/**
+ * Builds an actionable "how to fix this" hint appended to srt's own missing-
+ * dependency message. Only mentions dependencies srt's message actually
+ * named (never asserts what's needed on a platform we haven't confirmed).
+ * Exported for direct unit testing — not part of the package's public API.
+ */
+export function buildInstallHint(srtMessage: string): string {
+  const lowerMessage = srtMessage.toLowerCase();
+  const missing = Object.keys(DEPENDENCY_PACKAGE_NAMES).filter((name) =>
+    lowerMessage.includes(name),
+  );
+  if (missing.length === 0) {
+    return "";
+  }
+
+  const aptPackages = missing
+    .map((name) => DEPENDENCY_PACKAGE_NAMES[name].apt)
+    .filter((pkg): pkg is string => Boolean(pkg));
+  const brewPackages = missing
+    .map((name) => DEPENDENCY_PACKAGE_NAMES[name].brew)
+    .filter((pkg): pkg is string => Boolean(pkg));
+
+  const lines = ["", "To fix:"];
+  if (aptPackages.length > 0) {
+    lines.push(
+      `  Debian/Ubuntu: sudo apt-get install -y ${aptPackages.join(" ")}`,
+    );
+  }
+  if (brewPackages.length > 0) {
+    lines.push(`  macOS:         brew install ${brewPackages.join(" ")}`);
+  }
+  if (missing.includes("bubblewrap")) {
+    lines.push(
+      "  Ubuntu 24.04+ additionally restricts unprivileged user namespaces by " +
+        "default, which bubblewrap needs — either " +
+        "`sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` or grant " +
+        "an AppArmor profile permitting bwrap's `userns` (see docs/SANDBOX_ADAPTERS.md).",
+    );
+  }
+  return lines.join("\n");
+}
 
 /**
  * Isolation policy for {@link SrtSandbox}, mapped onto
@@ -94,10 +163,74 @@ export class SrtSandbox extends LocalMachine {
   private readonly isolation: SrtIsolationOptions;
   /** Generated settings file path; created lazily, stable per instance. */
   private settingsFilePromise: Promise<string> | null = null;
+  /** The mkdtemp'd directory holding the generated settings file — tracked
+   *  separately so onDestroy() can remove it without re-deriving it from
+   *  the (possibly not-yet-created) settings path. */
+  private generatedSettingsDir: string | null = null;
 
   constructor(options: SrtSandboxOptions = {}) {
     super(options);
     this.isolation = options.isolation ?? {};
+  }
+
+  /**
+   * Runs a cheap srt-wrapped no-op before doing any real work, so a missing
+   * platform dependency (bubblewrap, socat, ripgrep, ...) or an otherwise
+   * unusable sandbox surfaces immediately with an actionable message —
+   * instead of being discovered deep inside the first real `exec()` call,
+   * where it previously arrived as a generic "Command failed (exit 1)"
+   * with srt's raw stderr buried in the trace.
+   */
+  override async attach(): Promise<SandboxHandle> {
+    if (!this.getHandle()) {
+      await this.preflightCheck();
+    }
+    return super.attach();
+  }
+
+  private async preflightCheck(): Promise<void> {
+    const settingsPath =
+      this.isolation.settingsPath ?? (await this.ensureSettingsFile());
+    const srtCommand = this.isolation.srtCommand ?? [
+      process.execPath,
+      require.resolve("@anthropic-ai/sandbox-runtime/dist/cli.js"),
+    ];
+    // A harmless payload: node itself is guaranteed present (we're running
+    // inside it right now), so the probe doesn't depend on `true`/`echo`
+    // existing, and it touches neither the filesystem nor the network.
+    const [cmd, ...args] = [
+      ...srtCommand,
+      "--settings",
+      settingsPath,
+      process.execPath,
+      "-e",
+      "process.exit(0)",
+    ];
+
+    await new Promise<void>((resolve, reject) => {
+      execFile(cmd, args, { timeout: 15000 }, (error, _stdout, stderr) => {
+        if (!error) {
+          resolve();
+          return;
+        }
+        const message = (stderr || error.message).trim();
+        if (message.includes(MISSING_DEPS_SIGNATURE)) {
+          reject(
+            new Error(
+              `SrtSandbox cannot start: ${message}${buildInstallHint(message)}`,
+            ),
+          );
+          return;
+        }
+        reject(
+          new Error(
+            "SrtSandbox failed its startup preflight check (this usually means " +
+              "the sandboxing runtime — bubblewrap on Linux, Seatbelt on macOS — " +
+              `can't run in this environment): ${message}`,
+          ),
+        );
+      });
+    });
   }
 
   protected override async transformCommand(
@@ -122,6 +255,7 @@ export class SrtSandbox extends LocalMachine {
   private ensureSettingsFile(): Promise<string> {
     this.settingsFilePromise ??= (async () => {
       const dir = await fs.mkdtemp(path.join(os.tmpdir(), "srt-sandbox-"));
+      this.generatedSettingsDir = dir;
       const settingsPath = path.join(dir, "srt-settings.json");
       const settings = {
         network: {
@@ -148,5 +282,19 @@ export class SrtSandbox extends LocalMachine {
       return settingsPath;
     })();
     return this.settingsFilePromise;
+  }
+
+  /**
+   * Removes the generated `srt-sandbox-*` settings directory, if one was
+   * created (bring-your-own `settingsPath` never triggers this). Without
+   * this, every SrtSandbox instance that actually ran a command leaked one
+   * temp directory under the OS temp dir for the lifetime of the host —
+   * across many agent runs (each gets its own SrtSandbox instance) these
+   * accumulate indefinitely.
+   */
+  protected override async onDestroy(): Promise<void> {
+    if (this.generatedSettingsDir) {
+      await fs.rm(this.generatedSettingsDir, { recursive: true, force: true });
+    }
   }
 }


### PR DESCRIPTION
Four independent robustness fixes across `sandbox-local`/`sandbox-srt`/`sandbox-sandock`. Each was reproduced for real (a live repro proving the bug exists) before being fixed, and re-verified for real after.

## 1. LocalMachine: abort/timeout orphaned backgrounded grandchild processes

**Repro**: ran a shell command through `exec()` that backgrounds a long-running grandchild (`(sleep 60 &) ; sleep 60`), aborted via `AbortSignal`, checked `ps` — the tagged grandchild survived. `child.kill(signal)` only ever signals the direct child PID.

**Fix**: `spawn(..., { detached: true })` + a new `killProcessTree()` helper (POSIX: negative-PID group signal; Windows: `taskkill /T`). Applied to `exec()`'s timeout/abort paths and `runCommand()`'s timeout path.

**Bonus fix in the same code**: the existing "SIGKILL after 5s if still running" escalation checked `child.killed`, which Node sets `true` as soon as a signal is *sent* — not when the process actually exits. It essentially never fired. Now tracked via a real `exit` event.

**SrtSandbox needed nothing here** — the same repro through SrtSandbox left no orphan: srt's `bwrap --unshare-pid` means the kernel tears down the whole PID namespace when its init dies. A regression test on both adapters locks this in.

## 2. SrtSandbox: settings-dir temp leak

**Repro**: ran one command, called `destroy()`, the generated `srt-sandbox-*` policy dir was still in `/tmp`. This session's own testing had already accumulated **80+ leaked directories** — counted directly.

**Fix**: new `LocalMachine.onDestroy()` hook (same seam-injection pattern as the existing `transformCommand()`), which `SrtSandbox` uses to `fs.rm()` its generated dir.

## 3. SandockSandbox: retry transient network errors

**Motivation**: today's own CI hit a real `TypeError: terminated` (`SocketError: other side closed`, `UND_ERR_SOCKET`) against production sandock.ai — a Cloudflare connection drop, not an app error. Nothing retried it.

**Fix**: `retry.ts` (`withNetworkRetry` + cause-chain-aware `isTransientNetworkError`), applied to `get/start/create`, volume lookups, `fs.read/write`, `stop/delete`. **Deliberately not applied to `shell`/`exec`** — an arbitrary command may have already had side effects before the drop, so blind retry risks double-execution. `create()` is retried too, with a documented small risk (no idempotency-key mechanism in sandock's API).

## 4. SrtSandbox: preflight check with actionable errors

**Repro**: hid `bwrap`/`socat`/`rg` from `PATH`, ran a real command. srt's own message was decent but only surfaced deep inside the first `exec()`, no install guidance.

**Fix**: `attach()` now runs a cheap srt-wrapped `node -e "process.exit(0)"` probe first. A missing-dependency signature gets an actionable, platform-aware install hint (apt/brew + the Ubuntu 24.04+ AppArmor/userns note this repo's own CI needed today); anything else gets a generic "preflight failed" wrapper, not a mislabeled guess.

## Validation

- `sandbox-local` 24/24 (2 new — confirmed red without the fix via `git stash`, green with it)
- `sandbox-srt` 14/14 (PID-namespace regression, settings-dir cleanup, 3 `buildInstallHint` unit tests, 4 preflight tests via a fake `srtCommand` — no real bwrap/socat/rg needed)
- `sandbox-sandock` 50/52 (9 new retry unit tests; 2 live tests skip without creds, as before)
- Full live E2E (`BUNNY_INTEGRATION=1`, real runner-cli + mock LLM, both LocalMachine and SrtSandbox): **3/3** — confirms none of the four fixes broke the real end-to-end path
- `pnpm -r build`, `pnpm -r typecheck`, `pnpm run -w lint`: green

## Known gap

Couldn't re-verify the live Sandock round trip against production this session — the `SANDOCK_API_KEY` in the local integration-test env has been revoked (confirmed with a raw `curl` bypassing all adapter code — not a regression). The retry logic is unit-tested, and the one live attempt made correctly did **not** retry the resulting 401 (proving transient-vs-application-error detection works) — but the live round trip itself needs a fresh key to re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
