### PR TITLE
fix: guard post-run continuation from assistant tails

### DIFF
--- a/.changeset/quiet-wolves-settle.md
+++ b/.changeset/quiet-wolves-settle.md
@@ -3,4 +3,4 @@
 "@bunny-agent/runner-cli": patch
 ---
 
-Prevent Pi's post-run threshold compaction from continuing an assistant-tailed transcript when no steering or follow-up messages are queued.
+Guard Pi's post-run continuations so assistant-tailed sessions with empty steering and follow-up queues settle instead of repeatedly throwing `Cannot continue from message role: assistant`.

--- a/.changeset/quiet-wolves-settle.md
+++ b/.changeset/quiet-wolves-settle.md
@@ -1,0 +1,6 @@
+---
+"@bunny-agent/daemon": patch
+"@bunny-agent/runner-cli": patch
+---
+
+Prevent Pi's post-run threshold compaction from continuing an assistant-tailed transcript when no steering or follow-up messages are queued.

--- a/docs/changelog/2026-07-17-post-run-compaction-continue.md
+++ b/docs/changelog/2026-07-17-post-run-compaction-continue.md
@@ -1,39 +1,45 @@
-# Fix post-run compaction continuation
+# Guard post-run continuation from assistant-tailed sessions
 
 ## Summary
 
-BunnyAgent's patched `@earendil-works/pi-coding-agent@0.80.7` no longer calls `agent.continue()` after threshold auto-compaction finishes a normal assistant turn with no queued work.
+BunnyAgent's patched `@earendil-works/pi-coding-agent@0.80.7` now guards every continuation requested by Pi's post-run retry/compaction handler. It does not call `agent.continue()` when the rebuilt transcript ends with an assistant message and no steering or follow-up messages remain.
 
 ## Root cause
 
-Pi's post-run handler treated every successful compaction as a reason to continue the agent:
+Pi's post-run loop asks `_handlePostAgentRun()` whether more work should run, then calls `agent.continue()`:
 
 ```ts
-if (await this._checkCompaction(msg)) {
-  return true;
+while (await this._handlePostAgentRun()) {
+  await this.agent.continue();
 }
 ```
 
-Threshold compaction can complete after a final assistant response without adding a user, steering, or follow-up message. The subsequent `agent.continue()` therefore received an assistant-tailed transcript with empty queues and failed deterministically:
+Compaction and retry rebuild or trim the in-memory transcript. In affected sessions that transcript can still end with an assistant message while both queues are empty. Calling `continue()` from that state fails deterministically:
 
 ```text
 Cannot continue from message role: assistant
 ```
 
-This is distinct from the pre-prompt compaction path fixed previously. It occurs after the response has completed, most often in long sessions crossing the automatic compaction threshold.
+Because the failed continuation may be persisted as another assistant error, later prompts can encounter the same stale assistant-tailed state and repeat the failure.
 
 ## Fix
 
-After a successful post-run compaction, continue only when an `agent_end` handler queued steering or follow-up work:
+All post-run continuations now go through a guarded helper:
 
 ```ts
-if (await this._checkCompaction(msg)) {
-  return this.agent.hasQueuedMessages();
+async _continueAgentIfPossible() {
+  const lastMessage = this.agent.state.messages.at(-1);
+  if (!lastMessage ||
+      (lastMessage.role === "assistant" && !this.agent.hasQueuedMessages())) {
+    return false;
+  }
+  await this.agent.continue();
+  return true;
 }
 ```
 
-Overflow recovery remains unchanged: Pi removes the overflow error message before retrying and returns through its existing retry path.
+The loop stops if there is nothing valid to continue. Valid overflow retries still continue from a non-assistant tail, and queued steering/follow-up messages are still consumed from an assistant tail.
 
 ## Upstream status
 
-As of `@earendil-works/pi-coding-agent@0.80.10` and upstream `earendil-works/pi` main on 2026-07-17, this exact unconditional continuation is still present. The issue is tracked upstream in [#5463](https://github.com/earendil-works/pi/issues/5463) and the broader lifecycle discussion in [#5886](https://github.com/earendil-works/pi/issues/5886).
+As of `@earendil-works/pi-coding-agent@0.80.10` and upstream `earendil-works/pi` main on 2026-07-17, post-run continuation is still unguarded. The issue is tracked upstream in [#5463](https://github.com/earendil-works/pi/issues/5463), with related retry and queue-race variants described in [#5445](https://github.com/earendil-works/pi/issues/5445), [#5212](https://github.com/earendil-works/pi/issues/5212), and the broader lifecycle discussion in [#5886](https://github.com/earendil-works/pi/issues/5886).

--- a/docs/changelog/2026-07-17-post-run-compaction-continue.md
+++ b/docs/changelog/2026-07-17-post-run-compaction-continue.md
@@ -1,0 +1,39 @@
+# Fix post-run compaction continuation
+
+## Summary
+
+BunnyAgent's patched `@earendil-works/pi-coding-agent@0.80.7` no longer calls `agent.continue()` after threshold auto-compaction finishes a normal assistant turn with no queued work.
+
+## Root cause
+
+Pi's post-run handler treated every successful compaction as a reason to continue the agent:
+
+```ts
+if (await this._checkCompaction(msg)) {
+  return true;
+}
+```
+
+Threshold compaction can complete after a final assistant response without adding a user, steering, or follow-up message. The subsequent `agent.continue()` therefore received an assistant-tailed transcript with empty queues and failed deterministically:
+
+```text
+Cannot continue from message role: assistant
+```
+
+This is distinct from the pre-prompt compaction path fixed previously. It occurs after the response has completed, most often in long sessions crossing the automatic compaction threshold.
+
+## Fix
+
+After a successful post-run compaction, continue only when an `agent_end` handler queued steering or follow-up work:
+
+```ts
+if (await this._checkCompaction(msg)) {
+  return this.agent.hasQueuedMessages();
+}
+```
+
+Overflow recovery remains unchanged: Pi removes the overflow error message before retrying and returns through its existing retry path.
+
+## Upstream status
+
+As of `@earendil-works/pi-coding-agent@0.80.10` and upstream `earendil-works/pi` main on 2026-07-17, this exact unconditional continuation is still present. The issue is tracked upstream in [#5463](https://github.com/earendil-works/pi/issues/5463) and the broader lifecycle discussion in [#5886](https://github.com/earendil-works/pi/issues/5886).

--- a/packages/runner-pi/src/__tests__/pi-post-run-compaction-patch.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-post-run-compaction-patch.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+describe("Pi post-run compaction patch", () => {
+  it("continues after compaction only when queued work remains", () => {
+    const packageRoot = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "../../node_modules/@earendil-works/pi-coding-agent",
+    );
+    const source = readFileSync(
+      join(packageRoot, "dist/core/agent-session.js"),
+      "utf8",
+    );
+
+    expect(source).toContain(
+      "if (await this._checkCompaction(msg)) {\n            // Threshold compaction after a completed assistant turn",
+    );
+    expect(source).toContain(
+      "return this.agent.hasQueuedMessages();\n        }\n        // The agent loop drains both queues",
+    );
+    expect(source).not.toContain(
+      "if (await this._checkCompaction(msg)) {\n            return true;\n        }",
+    );
+  });
+});

--- a/packages/runner-pi/src/__tests__/pi-post-run-compaction-patch.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-post-run-compaction-patch.test.ts
@@ -3,25 +3,32 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-describe("Pi post-run compaction patch", () => {
-  it("continues after compaction only when queued work remains", () => {
-    const packageRoot = join(
-      dirname(fileURLToPath(import.meta.url)),
-      "../../node_modules/@earendil-works/pi-coding-agent",
-    );
-    const source = readFileSync(
-      join(packageRoot, "dist/core/agent-session.js"),
-      "utf8",
-    );
+const packageRoot = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../node_modules/@earendil-works/pi-coding-agent",
+);
+const source = readFileSync(
+  join(packageRoot, "dist/core/agent-session.js"),
+  "utf8",
+);
 
+describe("Pi post-run continuation patch", () => {
+  it("guards every post-run continuation against an assistant tail with empty queues", () => {
+    expect(source).toContain("async _continueAgentIfPossible() {");
     expect(source).toContain(
-      "if (await this._checkCompaction(msg)) {\n            // Threshold compaction after a completed assistant turn",
+      'lastMessage.role === "assistant" && !this.agent.hasQueuedMessages()',
     );
     expect(source).toContain(
-      "return this.agent.hasQueuedMessages();\n        }\n        // The agent loop drains both queues",
+      "if (!(await this._continueAgentIfPossible())) {\n                    break;",
     );
     expect(source).not.toContain(
-      "if (await this._checkCompaction(msg)) {\n            return true;\n        }",
+      "while (await this._handlePostAgentRun()) {\n                await this.agent.continue();",
+    );
+  });
+
+  it("still continues when the transcript or queue state is continuable", () => {
+    expect(source).toContain(
+      "await this.agent.continue();\n        return true;",
     );
   });
 });

--- a/patches/@earendil-works__pi-coding-agent@0.80.7.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.80.7.patch
@@ -20,6 +20,21 @@ index 3298c0bf0695661165f5dfb7a4ec1f2aeeee8f45..5d9075f22e3ed4a2902d9c5ad20b1704
          prompt += appendSection;
      }
      // Append project context files
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -758,7 +758,10 @@
+             this._retryAttempt = 0;
+         }
+         if (await this._checkCompaction(msg)) {
+-            return true;
++            // Threshold compaction after a completed assistant turn does not
++            // create work that Agent.continue() can consume. Only continue
++            // when an agent_end handler queued a steering or follow-up message.
++            return this.agent.hasQueuedMessages();
+         }
+         // The agent loop drains both queues before emitting agent_end. Any messages
+         // here were queued by agent_end extension handlers and need a continuation.
 diff --git a/package.json b/package.json
 index aed830a99f3fdec6a3ce92b20c857a6b60dc02ba..61025c1bb498e685c1e4607df4798c7b8c8daaee 100644
 --- a/package.json

--- a/patches/@earendil-works__pi-coding-agent@0.80.7.patch
+++ b/patches/@earendil-works__pi-coding-agent@0.80.7.patch
@@ -23,18 +23,33 @@ index 3298c0bf0695661165f5dfb7a4ec1f2aeeee8f45..5d9075f22e3ed4a2902d9c5ad20b1704
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
-@@ -758,7 +758,10 @@
-             this._retryAttempt = 0;
+@@ -730,7 +730,9 @@
+         try {
+             await this.agent.prompt(messages);
+             while (await this._handlePostAgentRun()) {
+-                await this.agent.continue();
++                if (!(await this._continueAgentIfPossible())) {
++                    break;
++                }
+             }
          }
-         if (await this._checkCompaction(msg)) {
--            return true;
-+            // Threshold compaction after a completed assistant turn does not
-+            // create work that Agent.continue() can consume. Only continue
-+            // when an agent_end handler queued a steering or follow-up message.
-+            return this.agent.hasQueuedMessages();
+         finally {
+@@ -739,6 +741,15 @@
+             await this._emitAgentSettled();
          }
-         // The agent loop drains both queues before emitting agent_end. Any messages
-         // here were queued by agent_end extension handlers and need a continuation.
+     }
++    async _continueAgentIfPossible() {
++        const messages = this.agent.state.messages;
++        const lastMessage = messages[messages.length - 1];
++        if (!lastMessage || (lastMessage.role === "assistant" && !this.agent.hasQueuedMessages())) {
++            return false;
++        }
++        await this.agent.continue();
++        return true;
++    }
+     async _handlePostAgentRun() {
+         const msg = this._lastAssistantMessage;
+         this._lastAssistantMessage = undefined;
 diff --git a/package.json b/package.json
 index aed830a99f3fdec6a3ce92b20c857a6b60dc02ba..61025c1bb498e685c1e4607df4798c7b8c8daaee 100644
 --- a/package.json

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent@0.80.7':
-    hash: 67083dcca33ff3fe58ddeb71f272bad365235dc2ba5c85584d7c2073f938bc64
+    hash: de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9
     path: patches/@earendil-works__pi-coding-agent@0.80.7.patch
   openai@6.26.0:
     hash: f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01
@@ -154,7 +154,7 @@ importers:
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.7
-        version: 0.80.7(patch_hash=67083dcca33ff3fe58ddeb71f272bad365235dc2ba5c85584d7c2073f938bc64)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        version: 0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@openai/codex-sdk':
         specifier: ^0.144.5
         version: 0.144.5
@@ -607,7 +607,7 @@ importers:
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.7
-        version: 0.80.7(patch_hash=67083dcca33ff3fe58ddeb71f272bad365235dc2ba5c85584d7c2073f938bc64)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        version: 0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.48
@@ -8415,7 +8415,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.7(patch_hash=67083dcca33ff3fe58ddeb71f272bad365235dc2ba5c85584d7c2073f938bc64)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@earendil-works/pi-coding-agent@0.80.7':
-    hash: de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9
+    hash: 5d8971c368c9695b67ae78ca52587ad79dac93b16019e4aaee84255b74d7eeaa
     path: patches/@earendil-works__pi-coding-agent@0.80.7.patch
   openai@6.26.0:
     hash: f2a3b895e9a04ae6a0990a7d47b896599783845c7f7a3c1cad9a6f35c0010f01
@@ -154,7 +154,7 @@ importers:
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.7
-        version: 0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        version: 0.80.7(patch_hash=5d8971c368c9695b67ae78ca52587ad79dac93b16019e4aaee84255b74d7eeaa)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@openai/codex-sdk':
         specifier: ^0.144.5
         version: 0.144.5
@@ -607,7 +607,7 @@ importers:
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-coding-agent':
         specifier: 0.80.7
-        version: 0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
+        version: 0.80.7(patch_hash=5d8971c368c9695b67ae78ca52587ad79dac93b16019e4aaee84255b74d7eeaa)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@sinclair/typebox':
         specifier: ^0.34.0
         version: 0.34.48
@@ -8415,7 +8415,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.80.7(patch_hash=de065b50ac485abd12bbc7942e7f1d29e00f8b80d1cd5b730650e64ceedcf0c9)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
+  '@earendil-works/pi-coding-agent@0.80.7(patch_hash=5d8971c368c9695b67ae78ca52587ad79dac93b16019e4aaee84255b74d7eeaa)(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)':
     dependencies:
       '@earendil-works/pi-agent-core': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)
       '@earendil-works/pi-ai': 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)


### PR DESCRIPTION
## Summary

- route every continuation requested by Pi's post-run retry/compaction handler through an assistant-tail guard
- settle instead of calling `agent.continue()` when the transcript ends with an assistant message and both steering/follow-up queues are empty
- preserve valid overflow retries and queued-message continuation
- add a regression test against the installed patched Pi artifact

## Root cause

Pi currently runs post-response work like this:

```ts
while (await this._handlePostAgentRun()) {
  await this.agent.continue();
}
```

`_handlePostAgentRun()` may request continuation after retry or compaction. Those operations rebuild or trim the transcript, and in affected sessions it can still end with an assistant message while both queues are empty. `Agent.continue()` then throws:

```text
Cannot continue from message role: assistant
```

The failed attempt can leave/persist another assistant error. A later user prompt can therefore hit the same stale assistant-tailed session condition and repeat the failure. This explains production reports where the first failure does not self-heal on the next message.

This is the post-response sibling of the pre-prompt issue fixed by #357.

## Latest upstream Pi check

Checked both the latest published package and upstream source on 2026-07-17:

- `@earendil-works/pi-coding-agent@0.80.10` still calls `agent.continue()` directly in the post-run loop
- upstream `earendil-works/pi` main still has the same unguarded call
- related upstream reports: earendil-works/pi#5463, #5445, #5212, and broader lifecycle issue #5886

Therefore upgrading from BunnyAgent's current Pi `0.80.7` to `0.80.10` would **not** fix this failure.

## Fix

```ts
async _continueAgentIfPossible() {
  const lastMessage = this.agent.state.messages.at(-1);
  if (!lastMessage ||
      (lastMessage.role === "assistant" && !this.agent.hasQueuedMessages())) {
    return false;
  }
  await this.agent.continue();
  return true;
}
```

The post-run loop breaks when the helper returns `false`.

This is deliberately stronger than guarding only threshold compaction's return value: it also covers stale assistant tails produced by retry/overflow variants and queue-state races. It does not suppress arbitrary exceptions from a valid continuation.

## Validation

- `pnpm --filter @bunny-agent/runner-pi test` — 10 files, 134 tests passed
- `pnpm --filter @bunny-agent/runner-pi typecheck`
- `pnpm --filter @bunny-agent/runner-pi build`
- `pnpm lint`
- `pnpm install --frozen-lockfile --lockfile-only`
- verified the installed Pi artifact routes the post-run loop through the guard
- `git diff --check`

The unrelated Sandock cloud integration check is currently failing because its configured API key is invalid/revoked (HTTP 401); CI and the full local/SRT integration job pass.
