### PR TITLE
fix: stage configured Pi patch for Docker builds

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -79,7 +79,18 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Stage pi-coding-agent patch into docker context
-        run: cp patches/@earendil-works__pi-coding-agent@0.78.0.patch docker/bunny-agent-claude/pi-coding-agent.patch
+        run: |
+          # Keep Docker's runtime patch aligned with pnpm's patched dependency.
+          # The Docker context intentionally excludes patches/, so copy the configured
+          # patch into the context under the filename consumed by the Dockerfile.
+          PATCH=$(node -e "
+            const workspace = require('fs').readFileSync('pnpm-workspace.yaml', 'utf8');
+            const match = workspace.match(/^\\s*['\\\"]?@earendil-works\\/pi-coding-agent@[^:'\\\"]+['\\\"]?\\s*:\\s*(\\S+)\\s*$/m);
+            if (!match) throw new Error('No patched dependency configured for @earendil-works/pi-coding-agent');
+            console.log(match[1]);
+          ")
+          test -f "$PATCH"
+          cp "$PATCH" docker/bunny-agent-claude/pi-coding-agent.patch
 
       - name: Build and push Docker image
         id: build

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -79,18 +79,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Stage pi-coding-agent patch into docker context
-        run: |
-          # Keep Docker's runtime patch aligned with pnpm's patched dependency.
-          # The Docker context intentionally excludes patches/, so copy the configured
-          # patch into the context under the filename consumed by the Dockerfile.
-          PATCH=$(node -e "
-            const workspace = require('fs').readFileSync('pnpm-workspace.yaml', 'utf8');
-            const match = workspace.match(/^\\s*['\\\"]?@earendil-works\\/pi-coding-agent@[^:'\\\"]+['\\\"]?\\s*:\\s*(\\S+)\\s*$/m);
-            if (!match) throw new Error('No patched dependency configured for @earendil-works/pi-coding-agent');
-            console.log(match[1]);
-          ")
-          test -f "$PATCH"
-          cp "$PATCH" docker/bunny-agent-claude/pi-coding-agent.patch
+        run: cp patches/@earendil-works__pi-coding-agent@*.patch docker/bunny-agent-claude/pi-coding-agent.patch
 
       - name: Build and push Docker image
         id: build

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -60,7 +60,8 @@ RUN mkdir -p /opt/bunny-agent && \
 
 # Apply pi-coding-agent patch so the harness uses the caller-provided system
 # prompt (appendSystemPrompt) as the opening identity instead of the default
-# "operating inside pi" wording. Mirrors patches/@earendil-works__pi-coding-agent@0.78.0.patch.
+# "operating inside pi" wording. The release workflow stages the patch configured
+# for @earendil-works/pi-coding-agent in pnpm-workspace.yaml.
 COPY pi-coding-agent.patch /tmp/pi-coding-agent.patch
 RUN cd /opt/bunny-agent/node_modules/@earendil-works/pi-coding-agent && \
     patch -p1 < /tmp/pi-coding-agent.patch && \


### PR DESCRIPTION
## Root cause

The Docker publish workflow was still hard-coded to stage the deleted Pi `0.78.0` patch, so `v0.9.51-beta.2` failed before Docker build started:

```text
cp: cannot stat 'patches/@earendil-works__pi-coding-agent@0.78.0.patch'
```

Failed run: https://github.com/buda-ai/bunny-agent/actions/runs/29567794742

## Fix

Use Bash glob expansion to copy the sole Pi patch into the Docker context:

```bash
cp patches/@earendil-works__pi-coding-agent@*.patch \
  docker/bunny-agent-claude/pi-coding-agent.patch
```

If a future change leaves more than one matching Pi patch, `cp` fails rather than silently choosing an arbitrary one.

Also replaces the Dockerfile's stale `0.78.0` comment.

## Validation

- glob resolves to the `0.80.7` patch and copies it successfully
- patch applies cleanly to npm `@earendil-works/pi-coding-agent@0.80.7`
- `git diff --check`

After merge, manually dispatch **Publish Docker Image** for `v0.9.51-beta.2`.