### PR TITLE
fix(release): publish local and srt sandbox packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,7 +8,9 @@
       "@bunny-agent/manager",
       "@bunny-agent/runner-cli",
       "@bunny-agent/sandbox-e2b",
+      "@bunny-agent/sandbox-local",
       "@bunny-agent/sandbox-sandock",
+      "@bunny-agent/sandbox-srt",
       "@bunny-agent/sandbox-daytona",
       "@bunny-agent/sdk"
     ]

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -104,6 +104,8 @@ jobs:
           }
           publish "@bunny-agent/sdk" "packages/sdk"
           publish "@bunny-agent/manager" "packages/manager"
+          publish "@bunny-agent/sandbox-local" "packages/sandbox-local"
+          publish "@bunny-agent/sandbox-srt" "packages/sandbox-srt"
           publish "@bunny-agent/sandbox-sandock" "packages/sandbox-sandock"
           publish "@bunny-agent/runner-cli" "apps/runner-cli"
           publish "@bunny-agent/daemon" "apps/daemon"

--- a/docs/changelog/2026-07-17-publish-local-srt-packages.md
+++ b/docs/changelog/2026-07-17-publish-local-srt-packages.md
@@ -1,0 +1,28 @@
+# Publish Local and SRT Sandbox Packages
+
+## Session Log
+
+- Added `@bunny-agent/sandbox-local` and `@bunny-agent/sandbox-srt` to the
+  explicit package list in the tag release workflow.
+- Added both packages to the Changesets fixed group so tag releases assign
+  them the same version as `@bunny-agent/manager` and `@bunny-agent/sdk`.
+- Aligned both package manifests with the current fixed-group version,
+  `0.9.52`.
+- Future tag releases now publish the SDK and both adapters with one shared
+  version, ensuring the SDK's internal dependencies are available from npm.
+- The omission was detected after `@bunny-agent/sdk@0.9.52` referenced the two
+  adapters while neither package had been published to npm.
+
+## Validation
+
+- Parsed `.github/workflows/release-tag.yml` with the repository's installed
+  YAML parser.
+- Ran `pnpm lint` successfully.
+- Built `@bunny-agent/manager`, `@bunny-agent/sandbox-local`, and
+  `@bunny-agent/sandbox-srt` in dependency order.
+- Passed all 24 `sandbox-local` tests and all 7 runnable `sandbox-srt` tests;
+  7 environment-dependent SRT tests remained skipped.
+- Packed both adapters locally and confirmed pnpm rewrites their `workspace:*`
+  dependencies to `0.9.52`, matching `@bunny-agent/manager`.
+- Confirmed both package paths and names match their package manifests and
+  the Changesets fixed group.

--- a/packages/sandbox-local/package.json
+++ b/packages/sandbox-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunny-agent/sandbox-local",
-  "version": "0.9.51-release.1",
+  "version": "0.9.52",
   "description": "Local machine adapter for BunnyAgent — runs commands directly on the host (NO isolation)",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sandbox-srt/package.json
+++ b/packages/sandbox-srt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bunny-agent/sandbox-srt",
-  "version": "0.9.51-release.1",
+  "version": "0.9.52",
   "description": "Locally-isolated sandbox adapter for BunnyAgent — wraps commands with Anthropic's sandbox runtime (srt)",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

- add `@bunny-agent/sandbox-local` and `@bunny-agent/sandbox-srt` to the Changesets fixed group
- publish both adapters from the tag release workflow alongside `@bunny-agent/manager`
- align both adapter manifests with the current fixed-group version `0.9.52`

## Why

`@bunny-agent/sdk@0.9.52` was published with dependencies on the new adapters, but the tag workflow omitted those packages from its explicit publish list. Future tags must version and publish the SDK and adapters together.

Because npm versions and the existing `v0.9.52` tag are immutable, this workflow fix must merge before cutting the next release tag. The next release should be `v0.9.53`.

## Validation

- `pnpm lint`
- dependency-order build for manager, sandbox-local, and sandbox-srt
- sandbox-local: 24 tests passed
- sandbox-srt: 7 tests passed, 7 environment-dependent tests skipped
- workflow YAML parsed successfully
- packed manifests resolve all internal dependencies to `0.9.52`