### PR TITLE
fix(runner-pi): expose web tool fetch error causes

### DIFF
--- a/docs/changelog/2026-07-18-web-tool-fetch-error-details.md
+++ b/docs/changelog/2026-07-18-web-tool-fetch-error-details.md
@@ -1,0 +1,28 @@
+# Web Tool Fetch Error Details
+
+Date: 2026-07-18
+
+## Request
+
+Improve `web_search` and `web_fetch` diagnostics so network failures expose the
+selected provider and safe nested cause details in both tool output and daemon
+stderr. Preserve existing HTTP API error output and do not expose API keys or
+request bodies.
+
+## Changes
+
+- Added the selected search provider and safe nested network cause fields to
+  `web_search` failures.
+- Added the same nested cause diagnostics to `web_fetch` failures and daemon
+  stderr, while logging only the destination origin.
+- Preserved provider HTTP status and response-body errors, including Tavily
+  quota and authentication responses.
+- Added coverage for timeout, socket disconnect, and HTTP provider failures.
+
+## Verification
+
+- `runner-pi` typecheck passed.
+- All 137 `runner-pi` tests passed on Node.js 24.
+- Biome checks passed for the changed TypeScript files.
+- A real local socket disconnect produced `UND_ERR_SOCKET` in both the tool
+  result and stderr diagnostics.

--- a/packages/runner-pi/src/__tests__/web-tools.test.ts
+++ b/packages/runner-pi/src/__tests__/web-tools.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildWebFetchTool,
   buildWebSearchTool,
   resolveSearchProvider,
   resolveSearchProviders,
@@ -106,6 +107,7 @@ describe("buildWebSearchTool", () => {
   afterEach(() => {
     process.env = { ...originalEnv };
     globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
   });
 
   it("returns Brave usage details in tool result", async () => {
@@ -159,5 +161,110 @@ describe("buildWebSearchTool", () => {
         },
       },
     });
+  });
+
+  it("reports the provider and nested fetch cause", async () => {
+    const cause = Object.assign(
+      new Error("connect ETIMEDOUT 203.0.113.1:443"),
+      {
+        code: "ETIMEDOUT",
+        errno: -60,
+        syscall: "connect",
+        hostname: "api.tavily.com",
+        address: "203.0.113.1",
+        port: 443,
+      },
+    );
+    const fetchError = Object.assign(new TypeError("fetch failed"), { cause });
+    globalThis.fetch = (async () => {
+      throw fetchError;
+    }) as typeof fetch;
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const tool = buildWebSearchTool({ TAVILY_API_KEY: "tvly-test" });
+    const result = await (
+      tool.execute as (...args: unknown[]) => Promise<{
+        content: Array<{ type: string; text?: string }>;
+      }>
+    )("call_2", { query: "NVDA historical data" }, undefined, undefined, {});
+
+    expect(result.content[0]?.text).toContain(
+      "Web search error (Tavily): TypeError: fetch failed (cause: code=ETIMEDOUT",
+    );
+    expect(result.content[0]?.text).toContain("hostname=api.tavily.com");
+    expect(result.content[0]?.text).toContain("port=443");
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[bunny-agent:pi] Tavily web_search failed: TypeError: fetch failed (cause: code=ETIMEDOUT",
+      ),
+    );
+  });
+
+  it("preserves HTTP provider error details", async () => {
+    globalThis.fetch = (async () =>
+      ({
+        ok: false,
+        status: 432,
+        statusText: "Request Failed",
+        text: async () => '{"detail":"usage limit exceeded"}',
+      }) as unknown as Response) as typeof fetch;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const tool = buildWebSearchTool({ TAVILY_API_KEY: "tvly-test" });
+    const result = await (
+      tool.execute as (...args: unknown[]) => Promise<{
+        content: Array<{ type: string; text?: string }>;
+      }>
+    )("call_3", { query: "NVDA historical data" }, undefined, undefined, {});
+
+    expect(result.content[0]?.text).toContain(
+      "Web search error (Tavily): Tavily API 432: Request Failed",
+    );
+    expect(result.content[0]?.text).toContain("usage limit exceeded");
+  });
+});
+
+describe("buildWebFetchTool", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it("reports nested fetch cause and logs only the target origin", async () => {
+    const cause = Object.assign(new Error("socket disconnected"), {
+      code: "UND_ERR_SOCKET",
+    });
+    globalThis.fetch = (async () => {
+      throw Object.assign(new TypeError("fetch failed"), { cause });
+    }) as typeof fetch;
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const tool = buildWebFetchTool();
+    const result = await (
+      tool.execute as (...args: unknown[]) => Promise<{
+        content: Array<{ type: string; text?: string }>;
+      }>
+    )(
+      "call_4",
+      { url: "https://example.com/article" },
+      undefined,
+      undefined,
+      {},
+    );
+
+    expect(result.content[0]?.text).toContain(
+      "TypeError: fetch failed (cause: code=UND_ERR_SOCKET, message=socket disconnected)",
+    );
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "web_fetch failed target=https://example.com: TypeError: fetch failed",
+      ),
+    );
   });
 });

--- a/packages/runner-pi/src/web-tools.ts
+++ b/packages/runner-pi/src/web-tools.ts
@@ -224,6 +224,61 @@ function isRateLimitError(err: unknown): boolean {
   );
 }
 
+function getErrorField(error: object, key: string): string | undefined {
+  if (!(key in error)) return undefined;
+  const value = (error as Record<string, unknown>)[key];
+  if (typeof value === "string" || typeof value === "number") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function formatErrorCause(cause: unknown): string {
+  if (cause === null || cause === undefined) return "unknown";
+  if (typeof cause !== "object") return String(cause);
+
+  const details = [
+    ["code", getErrorField(cause, "code")],
+    [
+      "message",
+      cause instanceof Error ? cause.message : getErrorField(cause, "message"),
+    ],
+    ["errno", getErrorField(cause, "errno")],
+    ["syscall", getErrorField(cause, "syscall")],
+    ["hostname", getErrorField(cause, "hostname")],
+    ["address", getErrorField(cause, "address")],
+    ["port", getErrorField(cause, "port")],
+  ]
+    .filter((entry): entry is [string, string] => Boolean(entry[1]))
+    .map(([key, value]) => `${key}=${value}`);
+
+  const nestedErrors =
+    "errors" in cause && Array.isArray(cause.errors) ? cause.errors : [];
+  if (nestedErrors.length > 0) {
+    const nested = nestedErrors.slice(0, 3).map(formatErrorCause).join("; ");
+    details.push(`errors=[${nested}]`);
+  }
+
+  return details.length > 0 ? details.join(", ") : String(cause);
+}
+
+function formatWebToolError(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const cause =
+    "cause" in error ? (error as Error & { cause?: unknown }).cause : undefined;
+  return cause === undefined
+    ? error.message
+    : `${error.name}: ${error.message} (cause: ${formatErrorCause(cause)})`;
+}
+
+function getSafeTarget(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return "invalid-url";
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -280,7 +335,10 @@ async function fetchPageContent(
       ? `${text.slice(0, 50_000)}\n\n[Truncated]`
       : text;
   } catch (e: unknown) {
-    const msg = e instanceof Error ? e.message : String(e);
+    const msg = formatWebToolError(e);
+    console.error(
+      `[bunny-agent:pi] web_fetch failed target=${getSafeTarget(url)}: ${msg}`,
+    );
     return `(Error fetching ${url}: ${msg})`;
   } finally {
     clearTimeout(timeout);
@@ -401,7 +459,9 @@ export function buildWebSearchTool(
 
       // Try each provider in order; fallback on rate-limit errors
       let lastError: unknown;
+      let lastProviderLabel = "unknown provider";
       for (const { provider, apiKey } of providers) {
+        lastProviderLabel = provider.label;
         try {
           const { results } = await provider.search({
             apiKey,
@@ -442,6 +502,10 @@ export function buildWebSearchTool(
           };
         } catch (e: unknown) {
           lastError = e;
+          const diagnostic = formatWebToolError(e);
+          console.error(
+            `[bunny-agent:pi] ${provider.label} web_search failed: ${diagnostic}`,
+          );
           if (isRateLimitError(e) && providers.length > 1) {
             console.error(
               `[bunny-agent:pi] ${provider.label} rate-limited, trying next provider...`,
@@ -453,13 +517,12 @@ export function buildWebSearchTool(
         }
       }
 
-      const msg =
-        lastError instanceof Error ? lastError.message : String(lastError);
+      const msg = formatWebToolError(lastError);
       return {
         content: [
           {
             type: "text" as const,
-            text: `Web search error: ${msg}`,
+            text: `Web search error (${lastProviderLabel}): ${msg}`,
           },
         ],
         details: undefined,
@@ -496,7 +559,7 @@ export function buildWebFetchTool(): ToolDefinition {
           details: undefined,
         };
       } catch (e: unknown) {
-        const msg = e instanceof Error ? e.message : String(e);
+        const msg = formatWebToolError(e);
         return {
           content: [
             { type: "text" as const, text: `Error fetching URL: ${msg}` },


### PR DESCRIPTION
## Problem

When `web_search` or `web_fetch` fails during DNS resolution, TLS negotiation, proxy handling, or socket connection, the tool only reports `fetch failed`, which does not expose the actionable network cause.

## Root Cause

Node.js stores the underlying network failure in `error.cause`. The existing error boundary returned only the outer `message`, discarding diagnostic fields such as the error code, target hostname, and port.

## Fix

- Include the selected search provider and safe nested network error fields in tool results.
- Log the same diagnostics to daemon stderr while recording only the destination origin, never API keys, request bodies, or URL parameters.
- Preserve the existing response details for HTTP errors such as 401 and 432.
- Keep the existing retry and provider fallback behavior unchanged.
- Add test coverage for timeouts, socket disconnects, and HTTP provider errors.

## Validation

- `runner-pi` typecheck passed.
- The complete `runner-pi` test suite passed on Node.js 24: 10 test files and 137 tests.
- Biome checks passed.
- A real local socket disconnect exposed `UND_ERR_SOCKET: other side closed` in both the tool result and stderr diagnostics.

## Known Risk

- The fix has not yet been verified on the original WSL machine. After release, the newly exposed `cause` details should identify the specific network condition in that environment.

## Files Affected

- `packages/runner-pi/src/web-tools.ts`
- `packages/runner-pi/src/__tests__/web-tools.test.ts`
- `docs/changelog/2026-07-18-web-tool-fetch-error-details.md`
