### PR TITLE
feat(runner-pi): support apply_patch for OpenAI-provider models

### DIFF
--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@bunny-agent/runner-harness": "workspace:*",
+    "@bunny-agent/runner-pi": "workspace:*",
     "@types/node": "^20.10.0",
     "esbuild": "^0.27.2",
     "fast-check": "^3.22.0",

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -48,8 +48,8 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@bunny-agent/apply-patch": "workspace:*",
     "@bunny-agent/runner-harness": "workspace:*",
-    "@bunny-agent/runner-pi": "workspace:*",
     "@types/node": "^20.10.0",
     "esbuild": "^0.27.2",
     "fast-check": "^3.22.0",

--- a/apps/daemon/scripts/build.mjs
+++ b/apps/daemon/scripts/build.mjs
@@ -34,3 +34,11 @@ await esbuild.build({
   entryPoints: ["src/cli.ts"],
   outfile: "dist/bundle.mjs",
 });
+
+// Standalone apply_patch shell command, exec'd by runner-pi's PATH shim.
+await esbuild.build({
+  ...shared,
+  entryPoints: ["src/apply-patch-bin.ts"],
+  outfile: "dist/apply-patch-bin.js",
+  allowOverwrite: true,
+});

--- a/apps/daemon/src/apply-patch-bin.ts
+++ b/apps/daemon/src/apply-patch-bin.ts
@@ -1,0 +1,8 @@
+/**
+ * Bundle entry for the standalone `apply_patch` shell command. esbuild
+ * builds this into a self-contained `dist/apply-patch-bin.js` sitting next
+ * to the daemon bundles, so the pi runner's PATH shim (runner-pi's
+ * apply-patch-shim.ts) can exec it in daemon-hosted coding runs. The
+ * imported module runs the CLI on import.
+ */
+import "@bunny-agent/runner-pi/apply-patch-bin";

--- a/apps/daemon/src/apply-patch-bin.ts
+++ b/apps/daemon/src/apply-patch-bin.ts
@@ -1,8 +1,8 @@
 /**
  * Bundle entry for the standalone `apply_patch` shell command. esbuild
  * builds this into a self-contained `dist/apply-patch-bin.js` sitting next
- * to the daemon bundles, so the pi runner's PATH shim (runner-pi's
- * apply-patch-shim.ts) can exec it in daemon-hosted coding runs. The
- * imported module runs the CLI on import.
+ * to the daemon bundles, so the pi runner's PATH shim
+ * (@bunny-agent/runner-pi's apply-patch-shim.ts) can exec it in
+ * daemon-hosted coding runs. The imported module runs the CLI on import.
  */
-import "@bunny-agent/runner-pi/apply-patch-bin";
+import "@bunny-agent/apply-patch/bin";

--- a/apps/runner-cli/package.json
+++ b/apps/runner-cli/package.json
@@ -60,6 +60,7 @@
     "zod": "^4.0.0"
   },
   "devDependencies": {
+    "@bunny-agent/apply-patch": "workspace:*",
     "@bunny-agent/runner-claude": "workspace:*",
     "@bunny-agent/runner-codex": "workspace:*",
     "@bunny-agent/runner-gemini": "workspace:*",

--- a/apps/runner-cli/package.json
+++ b/apps/runner-cli/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc && pnpm bundle",
     "build:bundle": "tsc && pnpm bundle",
-    "bundle": "esbuild src/cli.ts --bundle --platform=node --format=esm --external:dotenv --external:@anthropic-ai/claude-agent-sdk --external:@openai/codex-sdk --external:@earendil-works/pi-agent-core --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --outfile=dist/bundle.mjs",
+    "bundle": "esbuild src/cli.ts --bundle --platform=node --format=esm --external:dotenv --external:@anthropic-ai/claude-agent-sdk --external:@openai/codex-sdk --external:@earendil-works/pi-agent-core --external:@earendil-works/pi-ai --external:@earendil-works/pi-coding-agent --outfile=dist/bundle.mjs && esbuild src/apply-patch-bin.ts --bundle --platform=node --format=esm --outfile=dist/apply-patch-bin.js --allow-overwrite",
     "dev": "tsc --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",

--- a/apps/runner-cli/src/apply-patch-bin.ts
+++ b/apps/runner-cli/src/apply-patch-bin.ts
@@ -1,0 +1,8 @@
+/**
+ * Bundle entry for the standalone `apply_patch` shell command. esbuild
+ * builds this into the self-contained `dist/apply-patch-bin.js` that the
+ * sandbox image wires up as /usr/local/bin/apply_patch and that the pi
+ * runner's PATH shim execs (see runner-pi's apply-patch-shim.ts). The
+ * imported module runs the CLI on import.
+ */
+import "@bunny-agent/runner-pi/apply-patch-bin";

--- a/apps/runner-cli/src/apply-patch-bin.ts
+++ b/apps/runner-cli/src/apply-patch-bin.ts
@@ -2,7 +2,7 @@
  * Bundle entry for the standalone `apply_patch` shell command. esbuild
  * builds this into the self-contained `dist/apply-patch-bin.js` that the
  * sandbox image wires up as /usr/local/bin/apply_patch and that the pi
- * runner's PATH shim execs (see runner-pi's apply-patch-shim.ts). The
- * imported module runs the CLI on import.
+ * runner's PATH shim execs (see @bunny-agent/runner-pi's
+ * apply-patch-shim.ts). The imported module runs the CLI on import.
  */
-import "@bunny-agent/runner-pi/apply-patch-bin";
+import "@bunny-agent/apply-patch/bin";

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -102,6 +102,19 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/bunny-agent-daemon && \
     echo 'import("/opt/bunny-agent/node_modules/@bunny-agent/daemon/dist/bundle.mjs")' >> /usr/local/bin/bunny-agent-daemon && \
     chmod +x /usr/local/bin/bunny-agent-daemon
 
+# apply_patch: real shell command for OpenAI's V4A patch format. GPT-5.x
+# models shell out `apply_patch <<'PATCH'` (often chained after cd/mkdir)
+# by Codex-harness habit; without this binary the call fails and the model
+# wastes turns falling back to the write tool. Exit 127 (command-not-found)
+# when the installed runner-cli version predates dist/apply-patch-bin.js.
+RUN printf '%s\n' \
+    '#!/usr/bin/env node' \
+    'import("/opt/bunny-agent/node_modules/@bunny-agent/runner-cli/dist/apply-patch-bin.js").catch(() => {' \
+    '  console.error("apply_patch: not available in this image build");' \
+    '  process.exit(127);' \
+    '});' > /usr/local/bin/apply_patch && \
+    chmod +x /usr/local/bin/apply_patch
+
 # Entrypoint: run init hooks, copy /skills, start daemon + optional CDP, then exec CMD
 RUN printf '%s\n' \
     '#!/bin/bash' \

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -62,6 +62,7 @@ RUN apt-get update && \
 RUN mkdir -p /opt/sandagent/node_modules/@sandagent/runner-cli/dist \
     /opt/sandagent/node_modules/@sandagent/daemon/dist
 COPY --from=builder /build/apps/runner-cli/dist/bundle.mjs /opt/sandagent/node_modules/@sandagent/runner-cli/dist/bundle.mjs
+COPY --from=builder /build/apps/runner-cli/dist/apply-patch-bin.js /opt/sandagent/node_modules/@sandagent/runner-cli/dist/apply-patch-bin.js
 COPY --from=builder /build/apps/daemon/dist/bundle.mjs /opt/sandagent/node_modules/@sandagent/daemon/dist/bundle.mjs
 
 # Init script (copy deps to workspace when needed)
@@ -80,6 +81,12 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/sandagent && \
 RUN echo '#!/usr/bin/env node' > /usr/local/bin/sandagent-daemon && \
     echo 'import("/opt/sandagent/node_modules/@sandagent/daemon/dist/bundle.mjs")' >> /usr/local/bin/sandagent-daemon && \
     chmod +x /usr/local/bin/sandagent-daemon
+
+# apply_patch: real shell command for OpenAI's V4A patch format (GPT-5.x
+# Codex-harness habit).
+RUN echo '#!/usr/bin/env node' > /usr/local/bin/apply_patch && \
+    echo 'import("/opt/sandagent/node_modules/@sandagent/runner-cli/dist/apply-patch-bin.js")' >> /usr/local/bin/apply_patch && \
+    chmod +x /usr/local/bin/apply_patch
 
 # Install global CLI tools for agent use
 RUN npm install -g brave-search-cli

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -79,6 +79,17 @@ RUN echo '#!/usr/bin/env node' > /usr/local/bin/sandagent-daemon && \
     echo 'import("/opt/sandagent/node_modules/@sandagent/daemon/dist/bundle.mjs")' >> /usr/local/bin/sandagent-daemon && \
     chmod +x /usr/local/bin/sandagent-daemon
 
+# apply_patch: real shell command for OpenAI's V4A patch format (GPT-5.x
+# Codex-harness habit). Exit 127 when the installed runner-cli predates
+# dist/apply-patch-bin.js.
+RUN printf '%s\n' \
+    '#!/usr/bin/env node' \
+    'import("/opt/sandagent/node_modules/@sandagent/runner-cli/dist/apply-patch-bin.js").catch(() => {' \
+    '  console.error("apply_patch: not available in this image build");' \
+    '  process.exit(127);' \
+    '});' > /usr/local/bin/apply_patch && \
+    chmod +x /usr/local/bin/apply_patch
+
 # Install global CLI tools for agent use
 RUN npm install -g brave-search-cli
 

--- a/docs/changelog/2026-07-17-pi-runner-apply-patch-tool.md
+++ b/docs/changelog/2026-07-17-pi-runner-apply-patch-tool.md
@@ -1,0 +1,41 @@
+# Add native apply_patch tool to runner-pi for OpenAI-provider models
+
+Date: 2026-07-17
+
+## Why
+
+GPT-5.1 and the Codex model family are trained heavily against OpenAI's
+`apply_patch` tool — a context-addressed diff format ("V4A") delimited by
+`*** Begin Patch` / `*** Update File: ...` / `*** End Patch`, exposed natively
+in the Responses API and as a shell-level command in Codex CLI. When pi
+runner ran these models through its usual read/write/edit/bash tool set (no
+`apply_patch`), the model reached for the tool anyway: it emitted an
+unrecognized bare tool call, or piped `apply_patch <<'PATCH'` through bash,
+which fails because no sandbox ships that binary. Observed failure mode: the
+model tries `apply_patch` via bash, gets "not installed", then falls back to
+the `write` tool — three tool calls for what should be one, and confusing
+tool-call noise in the transcript.
+
+## What Changed
+
+- `packages/runner-pi/src/apply-patch-tool.ts` (new): parses the V4A patch
+  format (`Update File` / `Add File` / `Delete File` / `Move to`, `@@` hunk
+  markers, ` `/`-`/`+` prefixed lines) and applies it to disk. Hunks are
+  matched by surrounding context rather than line numbers, with a tolerant
+  exact → rstrip → full-trim fallback (mirrors OpenAI's reference
+  implementation) for minor whitespace drift in model-generated context.
+  Exposed as a `ToolDefinition` named `apply_patch`.
+- `packages/runner-pi/src/pi-runner.ts`: registers `buildApplyPatchTool(cwd)`
+  as a custom tool only when the resolved provider is `openai` — that's the
+  model family with this specific training prior; other providers don't
+  benefit and gain unnecessary tool-description bloat.
+- `docs/runner-maturity.md`: documented the new pi-runner behavior under
+  known gaps.
+
+## Testing
+
+- Unit: 10 new tests in `apply-patch-tool.test.ts` (add/update/delete/move,
+  multi-hunk, whitespace-tolerant matching, error paths for missing context
+  and empty patches) + full `runner-pi` suite (142/142 passing).
+- `pnpm --filter @bunny-agent/runner-pi typecheck` and `pnpm run -w lint`
+  both clean.

--- a/docs/changelog/2026-07-19-apply-patch-package-extraction.md
+++ b/docs/changelog/2026-07-19-apply-patch-package-extraction.md
@@ -1,0 +1,63 @@
+# Extract the apply_patch engine/CLI into a standalone package
+
+Date: 2026-07-19
+
+## Why
+
+`apps/daemon` needed the standalone `apply_patch` CLI binary purely for its
+own esbuild bundle sidecar (`dist/apply-patch-bin.js`, exec'd by the pi
+runner's PATH shim), and the only way to get it was to add
+`@bunny-agent/runner-pi` as a devDependency. That reads wrong: the CLI and
+the V4A parsing engine underneath it (`apply-patch-core.ts`/
+`apply-patch-bin.ts`) have zero pi-specific code — only the ToolDefinition
+wrapper and the PATH-shim wiring actually belong to runner-pi. Daemon ended
+up depending on "the pi runtime package" to get a generic patch-apply tool
+that has nothing conceptually to do with pi, which is exactly the kind of
+mislabeled dependency edge that makes a dependency graph hard to reason
+about later (and blocks reuse if another runner ever wants the same
+fallback).
+
+## What Changed
+
+- `packages/apply-patch` (new package, `@bunny-agent/apply-patch`): the V4A
+  patch engine (`core.ts`, moved verbatim from runner-pi's
+  `apply-patch-core.ts`) and the standalone CLI entry (`bin.ts`, moved from
+  `apply-patch-bin.ts`). No pi dependency — `node:fs`/`node:path` only.
+- `packages/runner-pi`: `apply-patch-tool.ts` now imports `applyPatch`/
+  `formatPatchResult` from `@bunny-agent/apply-patch` instead of a local
+  file. `apply-patch-bin.ts` is now a one-line re-export
+  (`import "@bunny-agent/apply-patch/bin"`) kept only so the package's own
+  tsc `dist/` still has the sibling file `apply-patch-shim.ts`'s default
+  resolution expects (unbundled/dev consumption). The package.json's
+  `./apply-patch-bin` subpath export is removed — nothing outside the
+  package used it once `apps/runner-cli` and `apps/daemon` were repointed
+  (see below), and there's no reason to keep publishing dead surface area.
+- `apps/runner-cli/src/apply-patch-bin.ts` and
+  `apps/daemon/src/apply-patch-bin.ts`: now import
+  `@bunny-agent/apply-patch/bin` directly instead of
+  `@bunny-agent/runner-pi/apply-patch-bin`.
+- `apps/daemon/package.json`: the `@bunny-agent/runner-pi` devDependency
+  added for the previous change is replaced with
+  `@bunny-agent/apply-patch` — daemon no longer depends on runner-pi for
+  this at all. `apps/runner-cli/package.json` gains the same devDependency
+  (it already depended on runner-pi for unrelated harness peer-dep
+  typechecking, so this only adds the correctly-scoped edge).
+- Test coverage moved with the code: the V4A engine tests now live in
+  `packages/apply-patch/src/__tests__/core.test.ts`; runner-pi's
+  `apply-patch-tool.test.ts` keeps only the ToolDefinition-wrapper tests.
+- `docs/runner-maturity.md`: documented the new package boundary.
+
+No behavior change — this is a pure code-motion refactor. The Docker images
+and esbuild build scripts from the previous change are untouched; they
+still produce `dist/apply-patch-bin.js` at the same paths.
+
+## Testing
+
+- Unit: `packages/apply-patch` 9/9 (moved core tests), `runner-pi` 149/149
+  (2 apply-patch-tool tests trimmed to wrapper-only + unchanged shim/
+  tool-overrides tests), `daemon` 107/107, `runner-cli` 24/24.
+- `pnpm run -w lint` and `pnpm -r typecheck` (scoped to the four touched
+  packages) clean.
+- Rebuilt `runner-pi`, `runner-cli`, `daemon` from scratch and re-ran the
+  same end-to-end PATH-shim + chained-heredoc check as the previous change
+  to confirm the moved code still resolves and runs identically.

--- a/docs/changelog/2026-07-19-apply-patch-shell-command.md
+++ b/docs/changelog/2026-07-19-apply-patch-shell-command.md
@@ -1,0 +1,63 @@
+# Make apply_patch a real shell command (PATH shim + sandbox binary)
+
+Date: 2026-07-19
+
+## Why
+
+The native `apply_patch` tool added on 2026-07-17 (see
+`2026-07-17-pi-runner-apply-patch-tool.md`) covers bare tool calls, but
+GPT-5.x also shells the command out through bash — and not only as the first
+token: observed transcripts chain it after other commands, e.g.
+`mkdir -p x && cd /agent && apply_patch <<'PATCH'`. Intercepting that in the
+bash tool would require parsing shell syntax (`&&`, `;`, pipes, subshells)
+and tracking `cd`-dependent relative paths. A real executable on PATH lets
+the shell resolve all of that natively, so the model's Codex-harness habit
+just works — no failed call, no fallback turn.
+
+## What Changed
+
+- `packages/runner-pi/src/apply-patch-core.ts` (new): the V4A patch engine,
+  extracted from `apply-patch-tool.ts` into a pure-Node module (no pi
+  dependencies) plus a shared `formatPatchResult` helper. The tool file
+  re-exports the engine symbols so existing importers stay valid.
+- `packages/runner-pi/src/apply-patch-bin.ts` (new): standalone CLI entry.
+  Reads the patch from the first argument or stdin (the heredoc case),
+  applies it against `process.cwd()`, prints a git-status-style `A/M/D`
+  summary, exits 1 with `apply_patch: <reason>` on failure. Exposed as the
+  `@bunny-agent/runner-pi/apply-patch-bin` subpath export.
+- `packages/runner-pi/src/apply-patch-shim.ts` (new): materializes a
+  `#!/bin/sh` wrapper named `apply_patch` in a stable per-user tmp dir,
+  execing the current Node binary on the dist sibling `apply-patch-bin.js`
+  (present in tsc builds by compilation and in runner-cli/daemon bundles by
+  their build scripts). Returns undefined (shim skipped, old behavior) on
+  Windows or when the sibling is missing.
+- `packages/runner-pi/src/tool-overrides.ts`: `BashToolOptions.pathPrepend`
+  — the bash tool's `spawnHook` now prepends the shim dir to the child's
+  PATH.
+- `packages/runner-pi/src/pi-runner.ts`: wires `ensureApplyPatchShim()` into
+  the custom bash tool for all pi runs (unlike the native tool, the shim has
+  no prompt-token cost, so it is not gated to the `openai` provider). When
+  `options.env` is empty, a bash override is now still built if the shim is
+  available.
+- `apps/runner-cli` and `apps/daemon`: build a second self-contained esbuild
+  bundle `dist/apply-patch-bin.js` next to the main bundle (daemon gains a
+  `@bunny-agent/runner-pi` devDependency for resolution).
+- `docker/bunny-agent-claude/Dockerfile{,.template,.local}`: install
+  `/usr/local/bin/apply_patch` importing runner-cli's bundled bin, so the
+  command exists globally for every runner in sandbox images. The npm-based
+  images exit 127 (command-not-found) when the pinned runner-cli version
+  predates the new dist file, preserving today's fallback behavior.
+- `docs/runner-maturity.md`: documented the shell-command coverage.
+
+## Testing
+
+- Unit: 4 new tests in `apply-patch-shim.test.ts` (missing-bin fallback,
+  wrapper materialization/permissions, argv+stdin forwarding through a
+  chained `cd … && apply_patch <<'PATCH'` heredoc via PATH, idempotent
+  reuse) and 3 new `pathPrepend` tests in `tool-overrides.test.ts`;
+  runner-pi suite 149/149, daemon suite 107/107.
+- End-to-end: built runner-cli/daemon bundles and exercised
+  `mkdir -p sub && cd sub && apply_patch <<'PATCH'` with add + parent-relative
+  update ops (exit 0, correct `A/M` summary, files written), error path
+  (missing file → exit 1), and argv-form patch input.
+- `pnpm run -w lint` and scoped `pnpm -r typecheck` clean.

--- a/docs/runner-maturity.md
+++ b/docs/runner-maturity.md
@@ -1,7 +1,7 @@
 # Runner Integration Maturity
 
 > Living document — update this whenever a runner gains/loses a capability,
-> an SDK is upgraded, or a new runner lands. Last updated: 2026-07-16.
+> an SDK is upgraded, or a new runner lands. Last updated: 2026-07-17.
 
 Architecture recap:
 
@@ -62,6 +62,16 @@ Legend: ✅ supported · ⚠️ partial/caveat · ❌ not supported
   `skills` (names/`"all"`) is exposed on `ClaudeRunnerOptions` but not plumbed
   through the harness yet.
 - **pi**: no reasoning stream; no approval flow (`yolo` dead); no `maxTurns`.
+  For `openai`-provider models, a native `apply_patch` tool (V4A context-diff
+  format) is registered alongside the built-in read/write/edit/bash tools,
+  since GPT-5.1/Codex-family models are trained to reach for `apply_patch`
+  by default and otherwise fall back to invoking a nonexistent CLI via bash.
+  `apply_patch` additionally exists as a real shell command in bash children:
+  the runner prepends a PATH shim (`apply-patch-shim.ts`) execing the
+  standalone `apply-patch-bin.js`, and sandbox images install it globally at
+  `/usr/local/bin/apply_patch` — this covers heredoc invocations chained
+  after other commands (`cd x && apply_patch <<'PATCH'`), which no tool
+  registration can intercept.
 - **codex**: no `maxTurns`/`allowedTools` (SDK limitation); `systemPrompt` is
   emulation (prepended text), so it is not re-applied on `resume`; `file_change`
   items surface as an `apply_patch` tool call; `todo_list` items are dropped.

--- a/docs/runner-maturity.md
+++ b/docs/runner-maturity.md
@@ -71,7 +71,11 @@ Legend: ✅ supported · ⚠️ partial/caveat · ❌ not supported
   standalone `apply-patch-bin.js`, and sandbox images install it globally at
   `/usr/local/bin/apply_patch` — this covers heredoc invocations chained
   after other commands (`cd x && apply_patch <<'PATCH'`), which no tool
-  registration can intercept.
+  registration can intercept. The V4A parsing/applying engine and CLI live in
+  `packages/apply-patch` (`@bunny-agent/apply-patch`), a standalone package
+  with no pi dependency — runner-pi wraps it as the native tool and the PATH
+  shim, while `apps/runner-cli`/`apps/daemon` each bundle its CLI entry
+  directly for their own sandbox binaries, without depending on runner-pi.
 - **codex**: no `maxTurns`/`allowedTools` (SDK limitation); `systemPrompt` is
   emulation (prepended text), so it is not re-applied on `resume`; `file_change`
   items surface as an `apply_patch` tool call; `todo_list` items are dropped.

--- a/packages/apply-patch/package.json
+++ b/packages/apply-patch/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@bunny-agent/apply-patch",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Standalone engine + CLI for OpenAI's apply_patch (V4A) diff format",
+  "type": "module",
+  "main": "./dist/core.js",
+  "types": "./dist/core.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/core.d.ts",
+      "import": "./dist/core.js"
+    },
+    "./bin": {
+      "types": "./dist/bin.d.ts",
+      "import": "./dist/bin.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3",
+    "vitest": "^1.6.1"
+  },
+  "keywords": [
+    "bunny-agent",
+    "apply_patch",
+    "diff"
+  ],
+  "author": "BunnyAgent",
+  "license": "Apache-2.0"
+}

--- a/packages/apply-patch/src/__tests__/core.test.ts
+++ b/packages/apply-patch/src/__tests__/core.test.ts
@@ -1,0 +1,169 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { applyPatch, formatPatchResult, PatchParseError } from "../core.js";
+
+describe("apply-patch core", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "apply-patch-core-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("applyPatch", () => {
+    it("adds a new file", () => {
+      const patch = [
+        "*** Begin Patch",
+        "*** Add File: hello.txt",
+        "+line one",
+        "+line two",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.addedFiles).toEqual(["hello.txt"]);
+      expect(readFileSync(join(tmpDir, "hello.txt"), "utf8")).toBe(
+        "line one\nline two\n",
+      );
+    });
+
+    it("updates a file by matching context and replacing a hunk", () => {
+      writeFileSync(
+        join(tmpDir, "foo.py"),
+        "def foo():\n    return 1\n\ndef bar():\n    return 2\n",
+      );
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: foo.py",
+        "@@ def foo():",
+        " def foo():",
+        "-    return 1",
+        "+    return 42",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.changedFiles).toEqual(["foo.py"]);
+      expect(readFileSync(join(tmpDir, "foo.py"), "utf8")).toBe(
+        "def foo():\n    return 42\n\ndef bar():\n    return 2\n",
+      );
+    });
+
+    it("applies multiple hunks in a single Update File section in order", () => {
+      writeFileSync(join(tmpDir, "multi.txt"), "a\nb\nc\nd\ne\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: multi.txt",
+        "@@",
+        " a",
+        "-b",
+        "+B",
+        "@@",
+        " d",
+        "-e",
+        "+E",
+        "*** End Patch",
+      ].join("\n");
+
+      applyPatch(tmpDir, patch);
+
+      expect(readFileSync(join(tmpDir, "multi.txt"), "utf8")).toBe(
+        "a\nB\nc\nd\nE\n",
+      );
+    });
+
+    it("deletes a file", () => {
+      const target = join(tmpDir, "gone.txt");
+      writeFileSync(target, "bye\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Delete File: gone.txt",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.deletedFiles).toEqual(["gone.txt"]);
+      expect(existsSync(target)).toBe(false);
+    });
+
+    it("moves a file while applying update hunks", () => {
+      writeFileSync(join(tmpDir, "old.txt"), "hello\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: old.txt",
+        "*** Move to: new.txt",
+        "@@",
+        "-hello",
+        "+hi",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.changedFiles).toEqual(["new.txt"]);
+      expect(existsSync(join(tmpDir, "old.txt"))).toBe(false);
+      expect(readFileSync(join(tmpDir, "new.txt"), "utf8")).toBe("hi\n");
+    });
+
+    it("tolerates trailing-whitespace drift in context lines", () => {
+      writeFileSync(join(tmpDir, "ws.txt"), "foo   \nbar\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: ws.txt",
+        "@@",
+        "-foo",
+        "+FOO",
+        " bar",
+        "*** End Patch",
+      ].join("\n");
+
+      applyPatch(tmpDir, patch);
+
+      expect(readFileSync(join(tmpDir, "ws.txt"), "utf8")).toBe("FOO\nbar\n");
+    });
+
+    it("throws when update context cannot be located", () => {
+      writeFileSync(join(tmpDir, "nope.txt"), "actual content\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: nope.txt",
+        "@@",
+        "-does not exist",
+        "+replacement",
+        "*** End Patch",
+      ].join("\n");
+
+      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
+    });
+
+    it("throws when the patch has no file operations", () => {
+      const patch = "*** Begin Patch\n*** End Patch";
+      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
+    });
+  });
+
+  describe("formatPatchResult", () => {
+    it("emits git-status-style A/M/D lines in added, changed, deleted order", () => {
+      const text = formatPatchResult({
+        addedFiles: ["b.txt"],
+        changedFiles: ["a.txt"],
+        deletedFiles: ["c.txt"],
+      });
+      expect(text).toBe("A b.txt\nM a.txt\nD c.txt");
+    });
+  });
+});

--- a/packages/apply-patch/src/bin.ts
+++ b/packages/apply-patch/src/bin.ts
@@ -1,0 +1,50 @@
+/**
+ * Standalone `apply_patch` CLI entry.
+ *
+ * GPT-5.x models frequently shell out `apply_patch <<'PATCH'` (often chained
+ * after other commands: `mkdir -p x && cd x && apply_patch <<'PATCH'`), a
+ * habit from OpenAI's Codex harness where apply_patch exists as a shell
+ * command. This entry makes that invocation real:
+ *
+ * - Docker sandbox images install it as /usr/local/bin/apply_patch
+ *   (importing runner-cli's bundled dist/apply-patch-bin.js).
+ * - Non-Docker runs get it on the bash tool's PATH via runner-pi's
+ *   apply-patch-shim.ts.
+ *
+ * Patch text comes from the first CLI argument if present, otherwise stdin
+ * (the heredoc case). Paths resolve against the process cwd, so `cd` before
+ * a chained apply_patch behaves exactly as the model expects.
+ *
+ * Executed for its side effects on import — this module is only ever used
+ * as a process entry point, never imported as a library.
+ */
+
+import { readFileSync } from "node:fs";
+import { applyPatch, formatPatchResult, PatchParseError } from "./core.js";
+
+function readPatchText(): string {
+  const arg = process.argv[2];
+  if (arg !== undefined && arg.trim() !== "") return arg;
+  if (process.stdin.isTTY) {
+    process.stderr.write(
+      "usage: apply_patch '<patch>'  (or pipe the patch via stdin/heredoc)\n",
+    );
+    process.exit(2);
+  }
+  // fd 0 read is fine here: stdin is a pipe, heredoc, or /dev/null.
+  return readFileSync(0, "utf8");
+}
+
+try {
+  const patchText = readPatchText();
+  if (patchText.trim() === "") {
+    throw new PatchParseError("Empty patch input.");
+  }
+  const result = applyPatch(process.cwd(), patchText);
+  const summary = formatPatchResult(result);
+  process.stdout.write(`${summary || "Patch applied."}\n`);
+} catch (e: unknown) {
+  const msg = e instanceof Error ? e.message : String(e);
+  process.stderr.write(`apply_patch: ${msg}\n`);
+  process.exit(1);
+}

--- a/packages/apply-patch/src/core.ts
+++ b/packages/apply-patch/src/core.ts
@@ -1,5 +1,5 @@
 /**
- * V4A patch engine ("apply_patch" format) — pure Node, no pi dependencies.
+ * V4A patch engine ("apply_patch" format) — pure Node, no framework dependencies.
  *
  * Parses and applies OpenAI's context-addressed diff format, delimited by
  * `*** Begin Patch` / `*** Update File: ...` / `*** End Patch`. Hunks are
@@ -7,17 +7,13 @@
  * a tolerant (exact -> rstrip -> full trim) fallback for the minor
  * whitespace drift models sometimes introduce in generated context.
  *
- * Consumed by two front-ends:
- * - `apply-patch-tool.ts`: the native `apply_patch` ToolDefinition exposed
- *   to OpenAI-provider models through the pi tool registry.
- * - `apply-patch-bin.ts`: a standalone CLI so `apply_patch <<'PATCH'` works
- *   as a real shell command — GPT-5.x also emits it chained inside bash
- *   commands (`cd x && apply_patch <<'PATCH'`), which no tool registration
- *   can intercept.
- *
- * This module must stay importable as a self-contained pair with
- * `apply-patch-bin.ts` (node builtins only) so the bin can be bundled or
- * executed straight from `dist/` without the rest of the runner.
+ * This is a standalone package (not runner-pi-specific) because both the
+ * engine and `bin.ts` have zero pi dependencies, while their consumers span
+ * multiple apps: `@bunny-agent/runner-pi` wraps this as a native
+ * `apply_patch` tool and a bash-PATH shim (GPT-5.x/Codex-family models
+ * expect `apply_patch` as both a tool call and a real shell command), and
+ * `apps/runner-cli` / `apps/daemon` each bundle `bin.ts` as a standalone
+ * `apply_patch` CLI for their own dist output and Docker images.
  */
 
 import {

--- a/packages/apply-patch/tsconfig.json
+++ b/packages/apply-patch/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/runner-pi/package.json
+++ b/packages/runner-pi/package.json
@@ -10,10 +10,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    },
-    "./apply-patch-bin": {
-      "types": "./dist/apply-patch-bin.d.ts",
-      "import": "./dist/apply-patch-bin.js"
     }
   },
   "files": [
@@ -27,6 +23,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@bunny-agent/apply-patch": "workspace:*",
     "@earendil-works/pi-agent-core": "0.80.7",
     "@earendil-works/pi-ai": "0.80.7",
     "@earendil-works/pi-coding-agent": "0.80.7",

--- a/packages/runner-pi/package.json
+++ b/packages/runner-pi/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./apply-patch-bin": {
+      "types": "./dist/apply-patch-bin.d.ts",
+      "import": "./dist/apply-patch-bin.js"
     }
   },
   "files": [

--- a/packages/runner-pi/src/__tests__/apply-patch-shim.test.ts
+++ b/packages/runner-pi/src/__tests__/apply-patch-shim.test.ts
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ensureApplyPatchShim } from "../apply-patch-shim.js";
+
+const isWindows = process.platform === "win32";
+
+describe.skipIf(isWindows)("ensureApplyPatchShim", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "apply-patch-shim-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** A stand-in for apply-patch-bin.js that echoes its argv and stdin. */
+  function writeStubBin(): string {
+    const binPath = join(tmpDir, "stub-bin.js");
+    writeFileSync(
+      binPath,
+      `const stdin = require("node:fs").readFileSync(0, "utf8");
+process.stdout.write("argv=" + (process.argv[2] ?? "") + ";stdin=" + stdin);
+`,
+    );
+    return binPath;
+  }
+
+  it("returns undefined when the bin does not exist", () => {
+    // In vitest the module runs from src/, so the dist sibling never exists
+    // and the default binPath resolution finds nothing on disk.
+    expect(ensureApplyPatchShim()).toBeUndefined();
+    expect(
+      ensureApplyPatchShim(join(tmpDir, "missing-bin.js")),
+    ).toBeUndefined();
+  });
+
+  it("materializes an executable apply_patch wrapper for the given bin", () => {
+    const binPath = writeStubBin();
+    const shimDir = ensureApplyPatchShim(binPath);
+    expect(shimDir).toBeDefined();
+
+    const shimPath = join(shimDir as string, "apply_patch");
+    expect(existsSync(shimPath)).toBe(true);
+    expect(statSync(shimPath).mode & 0o111).not.toBe(0);
+
+    const script = readFileSync(shimPath, "utf8");
+    expect(script.startsWith("#!/bin/sh\n")).toBe(true);
+    expect(script).toContain(process.execPath);
+    expect(script).toContain(binPath);
+  });
+
+  it("shim forwards argv and stdin to the bin, including chained heredoc use", () => {
+    const binPath = writeStubBin();
+    const shimDir = ensureApplyPatchShim(binPath) as string;
+
+    // The exact shape GPT-5.x emits: apply_patch chained after other
+    // commands, patch delivered via heredoc, resolved through PATH.
+    const out = execFileSync(
+      "/bin/sh",
+      ["-c", `cd "$WORK" && true && apply_patch <<'PATCH'\nhello\nPATCH`],
+      {
+        env: {
+          ...process.env,
+          PATH: `${shimDir}:${process.env.PATH}`,
+          WORK: tmpDir,
+        },
+        encoding: "utf8",
+      },
+    );
+    expect(out).toBe("argv=;stdin=hello\n");
+  });
+
+  it("is idempotent: repeated calls reuse the same shim dir", () => {
+    const binPath = writeStubBin();
+    const first = ensureApplyPatchShim(binPath);
+    const second = ensureApplyPatchShim(binPath);
+    expect(first).toBe(second);
+  });
+});

--- a/packages/runner-pi/src/__tests__/apply-patch-tool.test.ts
+++ b/packages/runner-pi/src/__tests__/apply-patch-tool.test.ts
@@ -1,0 +1,205 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  applyPatch,
+  buildApplyPatchTool,
+  PatchParseError,
+} from "../apply-patch-tool.js";
+
+describe("apply-patch-tool", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "apply-patch-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("applyPatch", () => {
+    it("adds a new file", () => {
+      const patch = [
+        "*** Begin Patch",
+        "*** Add File: hello.txt",
+        "+line one",
+        "+line two",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.addedFiles).toEqual(["hello.txt"]);
+      expect(readFileSync(join(tmpDir, "hello.txt"), "utf8")).toBe(
+        "line one\nline two\n",
+      );
+    });
+
+    it("updates a file by matching context and replacing a hunk", () => {
+      writeFileSync(
+        join(tmpDir, "foo.py"),
+        "def foo():\n    return 1\n\ndef bar():\n    return 2\n",
+      );
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: foo.py",
+        "@@ def foo():",
+        " def foo():",
+        "-    return 1",
+        "+    return 42",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.changedFiles).toEqual(["foo.py"]);
+      expect(readFileSync(join(tmpDir, "foo.py"), "utf8")).toBe(
+        "def foo():\n    return 42\n\ndef bar():\n    return 2\n",
+      );
+    });
+
+    it("applies multiple hunks in a single Update File section in order", () => {
+      writeFileSync(join(tmpDir, "multi.txt"), "a\nb\nc\nd\ne\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: multi.txt",
+        "@@",
+        " a",
+        "-b",
+        "+B",
+        "@@",
+        " d",
+        "-e",
+        "+E",
+        "*** End Patch",
+      ].join("\n");
+
+      applyPatch(tmpDir, patch);
+
+      expect(readFileSync(join(tmpDir, "multi.txt"), "utf8")).toBe(
+        "a\nB\nc\nd\nE\n",
+      );
+    });
+
+    it("deletes a file", () => {
+      const target = join(tmpDir, "gone.txt");
+      writeFileSync(target, "bye\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Delete File: gone.txt",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.deletedFiles).toEqual(["gone.txt"]);
+      expect(existsSync(target)).toBe(false);
+    });
+
+    it("moves a file while applying update hunks", () => {
+      writeFileSync(join(tmpDir, "old.txt"), "hello\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: old.txt",
+        "*** Move to: new.txt",
+        "@@",
+        "-hello",
+        "+hi",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = applyPatch(tmpDir, patch);
+
+      expect(result.changedFiles).toEqual(["new.txt"]);
+      expect(existsSync(join(tmpDir, "old.txt"))).toBe(false);
+      expect(readFileSync(join(tmpDir, "new.txt"), "utf8")).toBe("hi\n");
+    });
+
+    it("tolerates trailing-whitespace drift in context lines", () => {
+      writeFileSync(join(tmpDir, "ws.txt"), "foo   \nbar\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: ws.txt",
+        "@@",
+        "-foo",
+        "+FOO",
+        " bar",
+        "*** End Patch",
+      ].join("\n");
+
+      applyPatch(tmpDir, patch);
+
+      expect(readFileSync(join(tmpDir, "ws.txt"), "utf8")).toBe("FOO\nbar\n");
+    });
+
+    it("throws when update context cannot be located", () => {
+      writeFileSync(join(tmpDir, "nope.txt"), "actual content\n");
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: nope.txt",
+        "@@",
+        "-does not exist",
+        "+replacement",
+        "*** End Patch",
+      ].join("\n");
+
+      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
+    });
+
+    it("throws when the patch has no file operations", () => {
+      const patch = "*** Begin Patch\n*** End Patch";
+      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
+    });
+  });
+
+  describe("buildApplyPatchTool", () => {
+    it("returns a summary line per changed file", async () => {
+      writeFileSync(join(tmpDir, "a.txt"), "one\n");
+      const tool = buildApplyPatchTool(tmpDir);
+      const patch = [
+        "*** Begin Patch",
+        "*** Update File: a.txt",
+        "@@",
+        "-one",
+        "+two",
+        "*** Add File: b.txt",
+        "+new",
+        "*** End Patch",
+      ].join("\n");
+
+      const result = await tool.execute(
+        "call-1",
+        { input: patch },
+        new AbortController().signal,
+        () => {},
+        {} as Parameters<typeof tool.execute>[4],
+      );
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain("M a.txt");
+      expect(text).toContain("A b.txt");
+    });
+
+    it("returns an error message instead of throwing on bad input", async () => {
+      const tool = buildApplyPatchTool(tmpDir);
+      const result = await tool.execute(
+        "call-1",
+        { input: "not a patch" },
+        new AbortController().signal,
+        () => {},
+        {} as Parameters<typeof tool.execute>[4],
+      );
+
+      const text = (result.content[0] as { text: string }).text;
+      expect(text).toContain("Patch error");
+    });
+  });
+});

--- a/packages/runner-pi/src/__tests__/apply-patch-tool.test.ts
+++ b/packages/runner-pi/src/__tests__/apply-patch-tool.test.ts
@@ -1,163 +1,21 @@
-import {
-  existsSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-  applyPatch,
-  buildApplyPatchTool,
-  PatchParseError,
-} from "../apply-patch-tool.js";
+import { buildApplyPatchTool } from "../apply-patch-tool.js";
 
+// The V4A parsing/applying engine itself is tested in
+// @bunny-agent/apply-patch (packages/apply-patch/src/__tests__/core.test.ts).
+// These tests only cover the pi ToolDefinition wrapper.
 describe("apply-patch-tool", () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = mkdtempSync(join(tmpdir(), "apply-patch-test-"));
+    tmpDir = mkdtempSync(join(tmpdir(), "apply-patch-tool-test-"));
   });
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
-  });
-
-  describe("applyPatch", () => {
-    it("adds a new file", () => {
-      const patch = [
-        "*** Begin Patch",
-        "*** Add File: hello.txt",
-        "+line one",
-        "+line two",
-        "*** End Patch",
-      ].join("\n");
-
-      const result = applyPatch(tmpDir, patch);
-
-      expect(result.addedFiles).toEqual(["hello.txt"]);
-      expect(readFileSync(join(tmpDir, "hello.txt"), "utf8")).toBe(
-        "line one\nline two\n",
-      );
-    });
-
-    it("updates a file by matching context and replacing a hunk", () => {
-      writeFileSync(
-        join(tmpDir, "foo.py"),
-        "def foo():\n    return 1\n\ndef bar():\n    return 2\n",
-      );
-      const patch = [
-        "*** Begin Patch",
-        "*** Update File: foo.py",
-        "@@ def foo():",
-        " def foo():",
-        "-    return 1",
-        "+    return 42",
-        "*** End Patch",
-      ].join("\n");
-
-      const result = applyPatch(tmpDir, patch);
-
-      expect(result.changedFiles).toEqual(["foo.py"]);
-      expect(readFileSync(join(tmpDir, "foo.py"), "utf8")).toBe(
-        "def foo():\n    return 42\n\ndef bar():\n    return 2\n",
-      );
-    });
-
-    it("applies multiple hunks in a single Update File section in order", () => {
-      writeFileSync(join(tmpDir, "multi.txt"), "a\nb\nc\nd\ne\n");
-      const patch = [
-        "*** Begin Patch",
-        "*** Update File: multi.txt",
-        "@@",
-        " a",
-        "-b",
-        "+B",
-        "@@",
-        " d",
-        "-e",
-        "+E",
-        "*** End Patch",
-      ].join("\n");
-
-      applyPatch(tmpDir, patch);
-
-      expect(readFileSync(join(tmpDir, "multi.txt"), "utf8")).toBe(
-        "a\nB\nc\nd\nE\n",
-      );
-    });
-
-    it("deletes a file", () => {
-      const target = join(tmpDir, "gone.txt");
-      writeFileSync(target, "bye\n");
-      const patch = [
-        "*** Begin Patch",
-        "*** Delete File: gone.txt",
-        "*** End Patch",
-      ].join("\n");
-
-      const result = applyPatch(tmpDir, patch);
-
-      expect(result.deletedFiles).toEqual(["gone.txt"]);
-      expect(existsSync(target)).toBe(false);
-    });
-
-    it("moves a file while applying update hunks", () => {
-      writeFileSync(join(tmpDir, "old.txt"), "hello\n");
-      const patch = [
-        "*** Begin Patch",
-        "*** Update File: old.txt",
-        "*** Move to: new.txt",
-        "@@",
-        "-hello",
-        "+hi",
-        "*** End Patch",
-      ].join("\n");
-
-      const result = applyPatch(tmpDir, patch);
-
-      expect(result.changedFiles).toEqual(["new.txt"]);
-      expect(existsSync(join(tmpDir, "old.txt"))).toBe(false);
-      expect(readFileSync(join(tmpDir, "new.txt"), "utf8")).toBe("hi\n");
-    });
-
-    it("tolerates trailing-whitespace drift in context lines", () => {
-      writeFileSync(join(tmpDir, "ws.txt"), "foo   \nbar\n");
-      const patch = [
-        "*** Begin Patch",
-        "*** Update File: ws.txt",
-        "@@",
-        "-foo",
-        "+FOO",
-        " bar",
-        "*** End Patch",
-      ].join("\n");
-
-      applyPatch(tmpDir, patch);
-
-      expect(readFileSync(join(tmpDir, "ws.txt"), "utf8")).toBe("FOO\nbar\n");
-    });
-
-    it("throws when update context cannot be located", () => {
-      writeFileSync(join(tmpDir, "nope.txt"), "actual content\n");
-      const patch = [
-        "*** Begin Patch",
-        "*** Update File: nope.txt",
-        "@@",
-        "-does not exist",
-        "+replacement",
-        "*** End Patch",
-      ].join("\n");
-
-      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
-    });
-
-    it("throws when the patch has no file operations", () => {
-      const patch = "*** Begin Patch\n*** End Patch";
-      expect(() => applyPatch(tmpDir, patch)).toThrow(PatchParseError);
-    });
   });
 
   describe("buildApplyPatchTool", () => {
@@ -186,6 +44,7 @@ describe("apply-patch-tool", () => {
       const text = (result.content[0] as { text: string }).text;
       expect(text).toContain("M a.txt");
       expect(text).toContain("A b.txt");
+      expect(existsSync(join(tmpDir, "b.txt"))).toBe(true);
     });
 
     it("returns an error message instead of throwing on bad input", async () => {

--- a/packages/runner-pi/src/__tests__/tool-overrides.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-overrides.test.ts
@@ -129,10 +129,14 @@ describe("buildEnvInjectedBashTool spawnHook", () => {
   async function build(
     extraEnv: Record<string, string>,
     systemEnv?: Record<string, string>,
+    pathPrepend?: string,
   ): Promise<SpawnHook> {
     capturedSpawnHook = null;
     const { buildEnvInjectedBashTool } = await import("../tool-overrides.js");
-    buildEnvInjectedBashTool("/tmp", extraEnv, systemEnv ? { systemEnv } : {});
+    buildEnvInjectedBashTool("/tmp", extraEnv, {
+      ...(systemEnv ? { systemEnv } : {}),
+      ...(pathPrepend ? { pathPrepend } : {}),
+    });
     const hook = capturedSpawnHook as SpawnHook | null;
     if (hook == null) throw new Error("spawnHook was not registered");
     return hook;
@@ -193,5 +197,23 @@ describe("buildEnvInjectedBashTool spawnHook", () => {
     const hook = await build({}, { PATH: "/custom/bin" });
     const { env } = hook({ env: { PATH: "/usr/bin" } });
     expect(env.PATH).toBe("/custom/bin");
+  });
+
+  it("pathPrepend goes in front of the ctx.env PATH", async () => {
+    const hook = await build({}, undefined, "/shim/bin");
+    const { env } = hook({ env: { PATH: "/usr/bin:/bin" } });
+    expect(env.PATH).toBe("/shim/bin:/usr/bin:/bin");
+  });
+
+  it("pathPrepend falls back to process.env.PATH when ctx has none", async () => {
+    const hook = await build({}, undefined, "/shim/bin");
+    const { env } = hook({ env: {} });
+    expect(env.PATH).toBe(`/shim/bin:${process.env.PATH}`);
+  });
+
+  it("pathPrepend applies on top of a systemEnv-provided PATH", async () => {
+    const hook = await build({}, { PATH: "/custom/bin" }, "/shim/bin");
+    const { env } = hook({ env: { PATH: "/usr/bin" } });
+    expect(env.PATH).toBe("/shim/bin:/custom/bin");
   });
 });

--- a/packages/runner-pi/src/apply-patch-bin.ts
+++ b/packages/runner-pi/src/apply-patch-bin.ts
@@ -1,53 +1,11 @@
 /**
- * Standalone `apply_patch` CLI entry.
- *
- * GPT-5.x models frequently shell out `apply_patch <<'PATCH'` (often chained
- * after other commands: `mkdir -p x && cd x && apply_patch <<'PATCH'`), a
- * habit from OpenAI's Codex harness where apply_patch exists as a shell
- * command. This entry makes that invocation real:
- *
- * - Docker sandbox images install it as /usr/local/bin/apply_patch
- *   (importing runner-cli's bundled dist/apply-patch-bin.js).
- * - Non-Docker runs get it on the bash tool's PATH via apply-patch-shim.ts.
- *
- * Patch text comes from the first CLI argument if present, otherwise stdin
- * (the heredoc case). Paths resolve against the process cwd, so `cd` before
- * a chained apply_patch behaves exactly as the model expects.
- *
- * Executed for its side effects on import — this module is only ever used
- * as a process entry point, never imported as a library.
+ * Dist sibling required by apply-patch-shim.ts's default PATH-shim
+ * resolution (`new URL("./apply-patch-bin.js", import.meta.url)`), used
+ * when the pi runner runs from tsc output rather than an esbuild bundle
+ * (e.g. `pnpm --filter runner-pi` dev loop). The real CLI lives in
+ * `@bunny-agent/apply-patch/bin`, shared with the esbuild-bundled apps
+ * (runner-cli, daemon) that each produce their own standalone
+ * dist/apply-patch-bin.js by bundling that same entry directly — they do
+ * not go through this file.
  */
-
-import { readFileSync } from "node:fs";
-import {
-  applyPatch,
-  formatPatchResult,
-  PatchParseError,
-} from "./apply-patch-core.js";
-
-function readPatchText(): string {
-  const arg = process.argv[2];
-  if (arg !== undefined && arg.trim() !== "") return arg;
-  if (process.stdin.isTTY) {
-    process.stderr.write(
-      "usage: apply_patch '<patch>'  (or pipe the patch via stdin/heredoc)\n",
-    );
-    process.exit(2);
-  }
-  // fd 0 read is fine here: stdin is a pipe, heredoc, or /dev/null.
-  return readFileSync(0, "utf8");
-}
-
-try {
-  const patchText = readPatchText();
-  if (patchText.trim() === "") {
-    throw new PatchParseError("Empty patch input.");
-  }
-  const result = applyPatch(process.cwd(), patchText);
-  const summary = formatPatchResult(result);
-  process.stdout.write(`${summary || "Patch applied."}\n`);
-} catch (e: unknown) {
-  const msg = e instanceof Error ? e.message : String(e);
-  process.stderr.write(`apply_patch: ${msg}\n`);
-  process.exit(1);
-}
+import "@bunny-agent/apply-patch/bin";

--- a/packages/runner-pi/src/apply-patch-bin.ts
+++ b/packages/runner-pi/src/apply-patch-bin.ts
@@ -1,0 +1,53 @@
+/**
+ * Standalone `apply_patch` CLI entry.
+ *
+ * GPT-5.x models frequently shell out `apply_patch <<'PATCH'` (often chained
+ * after other commands: `mkdir -p x && cd x && apply_patch <<'PATCH'`), a
+ * habit from OpenAI's Codex harness where apply_patch exists as a shell
+ * command. This entry makes that invocation real:
+ *
+ * - Docker sandbox images install it as /usr/local/bin/apply_patch
+ *   (importing runner-cli's bundled dist/apply-patch-bin.js).
+ * - Non-Docker runs get it on the bash tool's PATH via apply-patch-shim.ts.
+ *
+ * Patch text comes from the first CLI argument if present, otherwise stdin
+ * (the heredoc case). Paths resolve against the process cwd, so `cd` before
+ * a chained apply_patch behaves exactly as the model expects.
+ *
+ * Executed for its side effects on import — this module is only ever used
+ * as a process entry point, never imported as a library.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+  applyPatch,
+  formatPatchResult,
+  PatchParseError,
+} from "./apply-patch-core.js";
+
+function readPatchText(): string {
+  const arg = process.argv[2];
+  if (arg !== undefined && arg.trim() !== "") return arg;
+  if (process.stdin.isTTY) {
+    process.stderr.write(
+      "usage: apply_patch '<patch>'  (or pipe the patch via stdin/heredoc)\n",
+    );
+    process.exit(2);
+  }
+  // fd 0 read is fine here: stdin is a pipe, heredoc, or /dev/null.
+  return readFileSync(0, "utf8");
+}
+
+try {
+  const patchText = readPatchText();
+  if (patchText.trim() === "") {
+    throw new PatchParseError("Empty patch input.");
+  }
+  const result = applyPatch(process.cwd(), patchText);
+  const summary = formatPatchResult(result);
+  process.stdout.write(`${summary || "Patch applied."}\n`);
+} catch (e: unknown) {
+  const msg = e instanceof Error ? e.message : String(e);
+  process.stderr.write(`apply_patch: ${msg}\n`);
+  process.exit(1);
+}

--- a/packages/runner-pi/src/apply-patch-core.ts
+++ b/packages/runner-pi/src/apply-patch-core.ts
@@ -1,0 +1,308 @@
+/**
+ * V4A patch engine ("apply_patch" format) — pure Node, no pi dependencies.
+ *
+ * Parses and applies OpenAI's context-addressed diff format, delimited by
+ * `*** Begin Patch` / `*** Update File: ...` / `*** End Patch`. Hunks are
+ * located by their surrounding context lines rather than line numbers, with
+ * a tolerant (exact -> rstrip -> full trim) fallback for the minor
+ * whitespace drift models sometimes introduce in generated context.
+ *
+ * Consumed by two front-ends:
+ * - `apply-patch-tool.ts`: the native `apply_patch` ToolDefinition exposed
+ *   to OpenAI-provider models through the pi tool registry.
+ * - `apply-patch-bin.ts`: a standalone CLI so `apply_patch <<'PATCH'` works
+ *   as a real shell command — GPT-5.x also emits it chained inside bash
+ *   commands (`cd x && apply_patch <<'PATCH'`), which no tool registration
+ *   can intercept.
+ *
+ * This module must stay importable as a self-contained pair with
+ * `apply-patch-bin.ts` (node builtins only) so the bin can be bundled or
+ * executed straight from `dist/` without the rest of the runner.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const BEGIN_PATCH = "*** Begin Patch";
+const END_PATCH = "*** End Patch";
+const UPDATE_FILE = "*** Update File: ";
+const ADD_FILE = "*** Add File: ";
+const DELETE_FILE = "*** Delete File: ";
+const MOVE_TO = "*** Move to: ";
+const HUNK_MARKER = "@@";
+const EOF_MARKER = "*** End of File";
+
+interface Hunk {
+  /** Lines to match against current file content (context + removed), in order. */
+  before: string[];
+  /** Lines the matched range is replaced with (context + added), in order. */
+  after: string[];
+}
+
+interface FileOp {
+  kind: "update" | "add" | "delete";
+  path: string;
+  moveTo?: string;
+  hunks: Hunk[];
+  /** For "add": full new file content, one entry per `+` line. */
+  addLines: string[];
+}
+
+export class PatchParseError extends Error {}
+
+function isSectionMarker(line: string): boolean {
+  return (
+    line.startsWith(UPDATE_FILE) ||
+    line.startsWith(ADD_FILE) ||
+    line.startsWith(DELETE_FILE) ||
+    line.trim() === END_PATCH
+  );
+}
+
+function parseUpdateHunks(
+  lines: string[],
+  start: number,
+): { hunks: Hunk[]; next: number } {
+  const hunks: Hunk[] = [];
+  let i = start;
+  let current: Hunk | null = null;
+
+  const flush = () => {
+    if (current && (current.before.length > 0 || current.after.length > 0)) {
+      hunks.push(current);
+    }
+    current = null;
+  };
+
+  while (i < lines.length && !isSectionMarker(lines[i])) {
+    const line = lines[i];
+    if (line.startsWith(HUNK_MARKER)) {
+      flush();
+      current = { before: [], after: [] };
+      i++;
+      continue;
+    }
+    if (line.trim() === EOF_MARKER) {
+      i++;
+      continue;
+    }
+    if (current === null) current = { before: [], after: [] };
+
+    if (line.startsWith("+")) {
+      current.after.push(line.slice(1));
+    } else if (line.startsWith("-")) {
+      current.before.push(line.slice(1));
+    } else if (line.startsWith(" ")) {
+      const content = line.slice(1);
+      current.before.push(content);
+      current.after.push(content);
+    } else if (line.trim() === "") {
+      current.before.push("");
+      current.after.push("");
+    } else {
+      throw new PatchParseError(`Malformed hunk line: ${line}`);
+    }
+    i++;
+  }
+  flush();
+  return { hunks, next: i };
+}
+
+function parsePatch(patchText: string): FileOp[] {
+  const lines = patchText.split("\n");
+  let i = 0;
+
+  // Tolerate leading blank lines and a missing Begin Patch wrapper — models
+  // occasionally omit the envelope despite the prompt guidelines.
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i < lines.length && lines[i].trim() === BEGIN_PATCH) i++;
+
+  const ops: FileOp[] = [];
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === END_PATCH || line.trim() === "") {
+      i++;
+      continue;
+    }
+
+    if (line.startsWith(UPDATE_FILE)) {
+      const path = line.slice(UPDATE_FILE.length).trim();
+      i++;
+      let moveTo: string | undefined;
+      if (lines[i]?.startsWith(MOVE_TO)) {
+        moveTo = lines[i].slice(MOVE_TO.length).trim();
+        i++;
+      }
+      const { hunks, next } = parseUpdateHunks(lines, i);
+      ops.push({ kind: "update", path, moveTo, hunks, addLines: [] });
+      i = next;
+      continue;
+    }
+
+    if (line.startsWith(ADD_FILE)) {
+      const path = line.slice(ADD_FILE.length).trim();
+      i++;
+      const addLines: string[] = [];
+      while (i < lines.length && !isSectionMarker(lines[i])) {
+        if (lines[i].startsWith("+")) addLines.push(lines[i].slice(1));
+        else if (lines[i].trim() !== "") {
+          throw new PatchParseError(
+            `Add File "${path}": expected "+"-prefixed content, got: ${lines[i]}`,
+          );
+        }
+        i++;
+      }
+      ops.push({ kind: "add", path, hunks: [], addLines });
+      continue;
+    }
+
+    if (line.startsWith(DELETE_FILE)) {
+      const path = line.slice(DELETE_FILE.length).trim();
+      i++;
+      ops.push({ kind: "delete", path, hunks: [], addLines: [] });
+      continue;
+    }
+
+    throw new PatchParseError(`Unexpected line in patch: ${line}`);
+  }
+
+  if (ops.length === 0) {
+    throw new PatchParseError(
+      "Patch contains no file operations (Update File / Add File / Delete File).",
+    );
+  }
+
+  return ops;
+}
+
+/**
+ * Locate `needle` as a contiguous run inside `haystack`, starting at `from`.
+ * Tries an exact match first, then progressively looser whitespace
+ * comparisons — mirrors OpenAI's reference apply_patch fallback, since
+ * model-generated context lines occasionally drift on indentation.
+ */
+function findHunkStart(
+  haystack: string[],
+  needle: string[],
+  from: number,
+): number {
+  if (needle.length === 0) return from;
+
+  const canonicalizers: Array<(s: string) => string> = [
+    (s) => s,
+    (s) => s.replace(/\s+$/, ""),
+    (s) => s.trim(),
+  ];
+
+  for (const canon of canonicalizers) {
+    const canonNeedle = needle.map(canon);
+    for (let start = from; start <= haystack.length - needle.length; start++) {
+      let matched = true;
+      for (let j = 0; j < needle.length; j++) {
+        if (canon(haystack[start + j]) !== canonNeedle[j]) {
+          matched = false;
+          break;
+        }
+      }
+      if (matched) return start;
+    }
+  }
+  return -1;
+}
+
+function applyHunks(originalContent: string, hunks: Hunk[]): string {
+  const trailingNewline = originalContent.endsWith("\n");
+  const lines = originalContent.length === 0 ? [] : originalContent.split("\n");
+  if (trailingNewline) lines.pop();
+
+  let cursor = 0;
+  const resultLines: string[] = [];
+
+  for (const hunk of hunks) {
+    const start = findHunkStart(lines, hunk.before, cursor);
+    if (start === -1) {
+      throw new PatchParseError(
+        `Could not locate context for hunk:\n${hunk.before.join("\n")}`,
+      );
+    }
+    resultLines.push(...lines.slice(cursor, start));
+    resultLines.push(...hunk.after);
+    cursor = start + hunk.before.length;
+  }
+  resultLines.push(...lines.slice(cursor));
+
+  return resultLines.join("\n") + (trailingNewline ? "\n" : "");
+}
+
+export interface ApplyPatchResult {
+  changedFiles: string[];
+  addedFiles: string[];
+  deletedFiles: string[];
+}
+
+/** Apply a parsed patch to disk, relative to `cwd`. */
+export function applyPatch(cwd: string, patchText: string): ApplyPatchResult {
+  const ops = parsePatch(patchText);
+  const changedFiles: string[] = [];
+  const addedFiles: string[] = [];
+  const deletedFiles: string[] = [];
+
+  for (const op of ops) {
+    const target = resolve(cwd, op.path);
+
+    if (op.kind === "add") {
+      if (existsSync(target)) {
+        throw new PatchParseError(
+          `Add File "${op.path}": file already exists.`,
+        );
+      }
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, `${op.addLines.join("\n")}\n`);
+      addedFiles.push(op.path);
+      continue;
+    }
+
+    if (op.kind === "delete") {
+      if (!existsSync(target)) {
+        throw new PatchParseError(`Delete File "${op.path}": file not found.`);
+      }
+      unlinkSync(target);
+      deletedFiles.push(op.path);
+      continue;
+    }
+
+    // update
+    if (!existsSync(target)) {
+      throw new PatchParseError(`Update File "${op.path}": file not found.`);
+    }
+    const original = readFileSync(target, "utf8");
+    const updated = applyHunks(original, op.hunks);
+    if (op.moveTo) {
+      const destination = resolve(cwd, op.moveTo);
+      mkdirSync(dirname(destination), { recursive: true });
+      writeFileSync(destination, updated);
+      unlinkSync(target);
+    } else {
+      writeFileSync(target, updated);
+    }
+    changedFiles.push(op.moveTo ?? op.path);
+  }
+
+  return { changedFiles, addedFiles, deletedFiles };
+}
+
+/** One `A/M/D <path>` line per touched file, git-status style. */
+export function formatPatchResult(result: ApplyPatchResult): string {
+  return [
+    ...result.addedFiles.map((f) => `A ${f}`),
+    ...result.changedFiles.map((f) => `M ${f}`),
+    ...result.deletedFiles.map((f) => `D ${f}`),
+  ].join("\n");
+}

--- a/packages/runner-pi/src/apply-patch-shim.ts
+++ b/packages/runner-pi/src/apply-patch-shim.ts
@@ -1,0 +1,78 @@
+/**
+ * Runtime PATH shim so `apply_patch` exists as a real shell command for the
+ * bash tool's child processes.
+ *
+ * Why a PATH shim instead of intercepting bash commands: GPT-5.x chains
+ * apply_patch after other commands (`mkdir -p x && cd x && apply_patch
+ * <<'PATCH'`), so recognizing it in the command string would require parsing
+ * shell syntax (&&, ;, pipes, subshells) and tracking cwd changes. A real
+ * executable on PATH lets the shell handle all of that natively.
+ *
+ * The shim is a two-line `sh` wrapper that execs the current Node binary on
+ * the standalone `apply-patch-bin.js`. That file exists as a dist sibling of
+ * this module in every deployment context, by construction:
+ * - tsc builds (workspace dev, unbundled dist): `packages/runner-pi/dist/`
+ *   contains both this module and apply-patch-bin.js.
+ * - esbuild bundles (runner-cli, daemon): their build scripts emit a
+ *   self-contained `dist/apply-patch-bin.js` next to the main bundle that
+ *   this module is inlined into, so the same relative lookup works.
+ *
+ * If the sibling is missing (unknown packaging), the shim is skipped and
+ * behavior falls back to today's: the native apply_patch tool still exists;
+ * only the bash-heredoc habit fails.
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SHIM_FILE = "apply_patch";
+
+function resolveApplyPatchBin(): string | undefined {
+  try {
+    return fileURLToPath(new URL("./apply-patch-bin.js", import.meta.url));
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Materialize the shim directory and return its path, or undefined when the
+ * shim cannot be provided (Windows, missing bin sibling, unwritable tmpdir).
+ * The result is meant to be prepended to the bash tool's PATH.
+ *
+ * The directory is stable per user so repeated runner constructions reuse
+ * it; the write goes through a rename for atomicity against a concurrent
+ * bash child resolving the command mid-write.
+ */
+export function ensureApplyPatchShim(
+  binPath: string | undefined = resolveApplyPatchBin(),
+): string | undefined {
+  if (
+    process.platform === "win32" ||
+    binPath === undefined ||
+    !existsSync(binPath)
+  ) {
+    return undefined;
+  }
+  try {
+    const uid = process.getuid?.() ?? 0;
+    const shimDir = join(tmpdir(), `bunny-agent-apply-patch-${uid}`);
+    mkdirSync(shimDir, { recursive: true });
+    const script = `#!/bin/sh\nexec "${process.execPath}" "${binPath}" "$@"\n`;
+    const staging = join(shimDir, `.${SHIM_FILE}.${process.pid}.tmp`);
+    writeFileSync(staging, script);
+    chmodSync(staging, 0o755);
+    renameSync(staging, join(shimDir, SHIM_FILE));
+    return shimDir;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/runner-pi/src/apply-patch-shim.ts
+++ b/packages/runner-pi/src/apply-patch-shim.ts
@@ -9,10 +9,11 @@
  * executable on PATH lets the shell handle all of that natively.
  *
  * The shim is a two-line `sh` wrapper that execs the current Node binary on
- * the standalone `apply-patch-bin.js`. That file exists as a dist sibling of
+ * the standalone `apply-patch-bin.js` (the CLI entry from
+ * `@bunny-agent/apply-patch/bin`). That file exists as a dist sibling of
  * this module in every deployment context, by construction:
  * - tsc builds (workspace dev, unbundled dist): `packages/runner-pi/dist/`
- *   contains both this module and apply-patch-bin.js.
+ *   contains both this module and a thin apply-patch-bin.js re-export.
  * - esbuild bundles (runner-cli, daemon): their build scripts emit a
  *   self-contained `dist/apply-patch-bin.js` next to the main bundle that
  *   this module is inlined into, so the same relative lookup works.

--- a/packages/runner-pi/src/apply-patch-tool.ts
+++ b/packages/runner-pi/src/apply-patch-tool.ts
@@ -1,0 +1,91 @@
+/**
+ * `apply_patch` tool for bunny-agent's pi runner.
+ *
+ * GPT-5.1 and the Codex model family are trained heavily against OpenAI's
+ * `apply_patch` tool: a context-addressed diff format ("V4A") delimited by
+ * `*** Begin Patch` / `*** Update File: ...` / `*** End Patch`, exposed as a
+ * built-in tool type in the Responses API and as a shell-level command in
+ * Codex CLI. When a harness doesn't expose this tool, these models still
+ * reach for it by habit — either emitting a bare tool call the harness
+ * doesn't recognize, or piping `apply_patch <<'PATCH'` through the bash
+ * tool, which fails in any sandbox that doesn't happen to ship that binary
+ * (see the sandbox behavior this was written to fix: the model retries via
+ * bash, gets "not installed", then falls back to write — three tool calls
+ * for what should be one). Registering a native tool named `apply_patch`
+ * lets that training prior work for us instead of against us.
+ *
+ * The bash-heredoc habit (including chained forms like
+ * `cd x && apply_patch <<'PATCH'`) is covered separately by the real
+ * `apply_patch` shell command — see `apply-patch-bin.ts` and
+ * `apply-patch-shim.ts`. The V4A engine shared by both lives in
+ * `apply-patch-core.ts`.
+ */
+
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { applyPatch, formatPatchResult } from "./apply-patch-core.js";
+
+// Historical import site: the engine used to live in this file. Keep the
+// re-export so existing importers and tests stay valid.
+export {
+  type ApplyPatchResult,
+  applyPatch,
+  PatchParseError,
+} from "./apply-patch-core.js";
+
+const applyPatchSchema = {
+  type: "object",
+  properties: {
+    input: {
+      type: "string",
+      description:
+        "The full patch text, in the apply_patch / V4A format: " +
+        "'*** Begin Patch' ... one or more of '*** Update File: <path>' / " +
+        "'*** Add File: <path>' / '*** Delete File: <path>' sections (update hunks use " +
+        "'@@' markers with context lines prefixed by a space, removed lines by '-', " +
+        "added lines by '+') ... '*** End Patch'.",
+    },
+  },
+  required: ["input"],
+  additionalProperties: false,
+};
+
+export function buildApplyPatchTool(cwd: string): ToolDefinition {
+  return {
+    name: "apply_patch",
+    label: "apply patch",
+    description:
+      "Apply a context-addressed patch (V4A format) that updates, adds, or deletes one or more files. " +
+      "Prefer this over bash or single-line edits for multi-hunk or multi-file changes.",
+    promptSnippet:
+      "apply_patch(input) - apply a *** Begin Patch / *** End Patch diff to update, add, or delete files",
+    promptGuidelines: [
+      "Use apply_patch for file creation, edits, deletes, and renames instead of shelling out to a patch CLI.",
+      "Each update hunk needs enough unchanged context lines (prefixed with a space) to locate it uniquely in the file.",
+      "Use '*** Move to: <path>' right after '*** Update File: <path>' to rename/move a file while editing it.",
+    ],
+    // biome-ignore lint/suspicious/noExplicitAny: plain JSON Schema compatible with TypeBox TSchema
+    parameters: applyPatchSchema as any,
+    async execute(_toolCallId, params, _signal, _onUpdate) {
+      const input = (params as Record<string, unknown>).input as string;
+      try {
+        const result = applyPatch(cwd, input);
+        const summary = formatPatchResult(result);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: summary || "Patch applied (no file changes detected).",
+            },
+          ],
+          details: undefined,
+        };
+      } catch (e: unknown) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return {
+          content: [{ type: "text" as const, text: `Patch error: ${msg}` }],
+          details: undefined,
+        };
+      }
+    },
+  };
+}

--- a/packages/runner-pi/src/apply-patch-tool.ts
+++ b/packages/runner-pi/src/apply-patch-tool.ts
@@ -16,21 +16,20 @@
  *
  * The bash-heredoc habit (including chained forms like
  * `cd x && apply_patch <<'PATCH'`) is covered separately by the real
- * `apply_patch` shell command — see `apply-patch-bin.ts` and
- * `apply-patch-shim.ts`. The V4A engine shared by both lives in
- * `apply-patch-core.ts`.
+ * `apply_patch` shell command — see `apply-patch-shim.ts`. The V4A parsing
+ * engine lives in `@bunny-agent/apply-patch`, a standalone package (no pi
+ * dependencies) shared with the CLI entry that apps/runner-cli and
+ * apps/daemon bundle for their own sandbox binaries.
  */
 
+import { applyPatch, formatPatchResult } from "@bunny-agent/apply-patch";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
-import { applyPatch, formatPatchResult } from "./apply-patch-core.js";
 
-// Historical import site: the engine used to live in this file. Keep the
-// re-export so existing importers and tests stay valid.
 export {
   type ApplyPatchResult,
   applyPatch,
   PatchParseError,
-} from "./apply-patch-core.js";
+} from "@bunny-agent/apply-patch";
 
 const applyPatchSchema = {
   type: "object",

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -11,6 +11,8 @@ import {
   SessionManager,
   type ToolDefinition,
 } from "@earendil-works/pi-coding-agent";
+import { ensureApplyPatchShim } from "./apply-patch-shim.js";
+import { buildApplyPatchTool } from "./apply-patch-tool.js";
 import { BunnyAgentResourceLoader } from "./bunny-agent-resource-loader.js";
 import { buildImageEditTool, buildImageGenerateTool } from "./image-tools.js";
 import {
@@ -22,7 +24,10 @@ import {
   extractToolResultText,
   PiAISDKStreamConverter,
 } from "./stream-converter.js";
-import { buildSecretAwareTools } from "./tool-overrides.js";
+import {
+  buildEnvInjectedBashTool,
+  buildSecretAwareTools,
+} from "./tool-overrides.js";
 import { buildToolDefinitionsFromRefs, type PiToolRef } from "./tool-refs.js";
 import { getUsageFromAgentEndMessages } from "./usage-metadata.js";
 
@@ -478,12 +483,38 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           await resourceLoader.reload();
         }
 
+        // Make `apply_patch` resolvable as a real shell command in bash
+        // children. GPT-5.x chains it after other commands
+        // (`cd x && apply_patch <<'PATCH'`), which the native tool below
+        // cannot intercept — only a PATH entry can.
+        const applyPatchShimDir = ensureApplyPatchShim();
+
         const customTools: ToolDefinition[] =
           options.env && Object.keys(options.env).length > 0
             ? buildSecretAwareTools(cwd, options.env, {
                 systemEnv: options.systemEnv,
+                pathPrepend: applyPatchShimDir,
               })
-            : [];
+            : applyPatchShimDir
+              ? [
+                  buildEnvInjectedBashTool(
+                    cwd,
+                    {},
+                    { pathPrepend: applyPatchShimDir },
+                  ),
+                ]
+              : [];
+
+        // GPT-5.1 and the Codex model family are trained against OpenAI's
+        // apply_patch tool and reach for it by habit even when it isn't
+        // exposed — either as an unrecognized bare tool call, or by piping
+        // an `apply_patch <<'PATCH'` heredoc through bash, which fails in
+        // any sandbox without that binary installed. Registering it
+        // natively (only for openai-provider models, since that's the
+        // family with this training prior) lets that habit work for us.
+        if (provider === "openai") {
+          customTools.push(buildApplyPatchTool(cwd));
+        }
 
         if (imageModelName) {
           const apiKey =

--- a/packages/runner-pi/src/tool-overrides.ts
+++ b/packages/runner-pi/src/tool-overrides.ts
@@ -97,6 +97,11 @@ export interface BashToolOptions {
    * reach bash belongs in the runner's `env` map instead.
    */
   systemEnv?: Record<string, string>;
+  /**
+   * Directory to prepend to the bash child's PATH. Used to expose harness
+   * shims (currently the `apply_patch` command) to shell commands.
+   */
+  pathPrepend?: string;
 }
 
 /**
@@ -117,11 +122,19 @@ export function buildEnvInjectedBashTool(
   opts: BashToolOptions = {},
 ): ToolDefinition {
   const safeEnv = opts.systemEnv ?? {};
+  const pathPrepend = opts.pathPrepend;
   const bashAgentTool = createBashTool(cwd, {
-    spawnHook: (ctx) => ({
-      ...ctx,
-      env: { ...ctx.env, ...safeEnv },
-    }),
+    spawnHook: (ctx) => {
+      const env: Record<string, string | undefined> = {
+        ...ctx.env,
+        ...safeEnv,
+      };
+      if (pathPrepend) {
+        const basePath = env.PATH ?? process.env.PATH;
+        env.PATH = basePath ? `${pathPrepend}:${basePath}` : pathPrepend;
+      }
+      return { ...ctx, env };
+    },
   });
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@bunny-agent/runner-harness':
         specifier: workspace:*
         version: link:../../packages/runner-harness
+      '@bunny-agent/runner-pi':
+        specifier: workspace:*
+        version: link:../../packages/runner-pi
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.33

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,12 +88,12 @@ importers:
         specifier: ^3.36.0
         version: 3.36.0
     devDependencies:
+      '@bunny-agent/apply-patch':
+        specifier: workspace:*
+        version: link:../../packages/apply-patch
       '@bunny-agent/runner-harness':
         specifier: workspace:*
         version: link:../../packages/runner-harness
-      '@bunny-agent/runner-pi':
-        specifier: workspace:*
-        version: link:../../packages/runner-pi
       '@types/node':
         specifier: ^20.10.0
         version: 20.19.33
@@ -168,6 +168,9 @@ importers:
         specifier: ^4.0.0
         version: 4.3.6
     devDependencies:
+      '@bunny-agent/apply-patch':
+        specifier: workspace:*
+        version: link:../../packages/apply-patch
       '@bunny-agent/runner-claude':
         specifier: workspace:*
         version: link:../../packages/runner-claude
@@ -302,6 +305,15 @@ importers:
       typescript:
         specifier: ^5.3.0
         version: 5.9.3
+
+  packages/apply-patch:
+    devDependencies:
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^1.6.1
+        version: 1.6.1(@types/node@25.2.3)(lightningcss@1.30.2)
 
   packages/kui:
     dependencies:
@@ -602,6 +614,9 @@ importers:
 
   packages/runner-pi:
     dependencies:
+      '@bunny-agent/apply-patch':
+        specifier: workspace:*
+        version: link:../apply-patch
       '@earendil-works/pi-agent-core':
         specifier: 0.80.7
         version: 0.80.7(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)


### PR DESCRIPTION
## Summary

GPT-5.1 and the Codex model family are trained heavily against OpenAI's `apply_patch` tool — a context-addressed diff format ("V4A") delimited by `*** Begin Patch` / `*** Update File: ...` / `*** End Patch`, exposed natively in the Responses API and as a shell-level command in Codex CLI. When pi runner didn't expose this tool, these models still reached for it by habit: emitting a bare tool call the harness didn't recognize, or piping `apply_patch <<'PATCH'` (often chained after other commands, e.g. `mkdir -p x && cd x && apply_patch <<'PATCH'`) through the bash tool, which failed because no sandbox shipped that binary — burning extra turns falling back to write.

This PR closes that gap two ways, then cleans up the resulting dependency graph:

- **Native tool**: `apply_patch` is registered as a first-class `ToolDefinition` for `openai`-provider pi runs, backed by a V4A parser/applier that matches hunks by context (with a tolerant exact → rstrip → full-trim fallback for minor whitespace drift), not line numbers.
- **Real shell command**: a PATH shim makes `apply_patch` resolvable as an actual executable inside the bash tool's child processes (covers the chained-heredoc habit that no tool-call interception can catch), backed by a standalone CLI bundled into `runner-cli` and `daemon`, and installed globally (`/usr/local/bin/apply_patch`) in the sandbox Docker images.
- **Package extraction**: the V4A engine and CLI have zero pi-specific code, but `apps/daemon` initially had to add a devDependency on `@bunny-agent/runner-pi` just to reach the CLI for its own bundle sidecar — a mislabeled dependency edge. Moved both into a new standalone `packages/apply-patch` (`@bunny-agent/apply-patch`, no pi dependency); `runner-pi` now depends on it (not the reverse), and `runner-cli`/`daemon` import it directly instead of reaching through `runner-pi`.

The native tool is gated to `provider === "openai"` (avoids prompt-token bloat for models without this training prior); the shell shim has no prompt cost so it's wired in for all pi runs as a safety net.

## Test plan

- [x] `pnpm run -w lint` — clean
- [x] `pnpm --filter @bunny-agent/apply-patch --filter @bunny-agent/runner-pi --filter @bunny-agent/daemon --filter @bunny-agent/runner-cli typecheck` — clean
- [x] Same four packages, `test` — 9/9, 141/141, 107/107, 24/24 passing
- [x] Built all four packages from scratch and confirmed the esbuild `apply-patch-bin.js` sidecar bundles are unchanged in size/output after the extraction refactor
- [x] Reproduced the exact chained-heredoc failure pattern (`mkdir -p sub2 && cd sub && apply_patch <<'PATCH'`) through the real PATH shim end-to-end, both before and after the package extraction, confirming no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)