### PR TITLE
fix(runner-pi): fall back on web search network errors

### DIFF
--- a/docs/changelog/2026-07-19-web-search-network-fallback.md
+++ b/docs/changelog/2026-07-19-web-search-network-fallback.md
@@ -1,0 +1,26 @@
+# Web Search Network Fallback
+
+Date: 2026-07-19
+
+## Request
+
+Keep web search available when the preferred provider cannot be reached from a
+user's network.
+
+## Changes
+
+- Treat retryable DNS, connection, timeout, and socket errors as provider
+  fallback conditions.
+- Try the next configured provider after a retryable network failure.
+- Keep authentication and request errors on the selected provider visible
+  without masking them through fallback.
+- Add coverage for Linux DNS failures and Node.js/Undici connection errors.
+
+## Verification
+
+- Focused web tool tests passed, including DNS, connection timeout, and network
+  unreachable fallback cases.
+- All 142 `runner-pi` tests passed on Node.js 24.
+- `runner-pi` typecheck and Biome checks passed.
+- A real local socket disconnect produced `UND_ERR_SOCKET`; the same tool call
+  continued with Tavily and returned a successful search result.

--- a/packages/runner-pi/src/__tests__/web-tools.test.ts
+++ b/packages/runner-pi/src/__tests__/web-tools.test.ts
@@ -224,6 +224,89 @@ describe("buildWebSearchTool", () => {
     );
     expect(result.content[0]?.text).toContain("usage limit exceeded");
   });
+
+  it.each([
+    "EAI_AGAIN",
+    "UND_ERR_CONNECT_TIMEOUT",
+    "ETIMEDOUT",
+    "ENETUNREACH",
+  ])("falls back from Brave to Tavily on %s", async (code) => {
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      if (String(input).startsWith("https://api.search.brave.com/")) {
+        const cause = Object.assign(new Error(`network failure: ${code}`), {
+          code,
+        });
+        throw Object.assign(new TypeError("fetch failed"), { cause });
+      }
+      return {
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({
+          results: [
+            {
+              title: "Fallback result",
+              url: "https://example.com/fallback",
+              content: "Tavily completed the search.",
+            },
+          ],
+        }),
+      } as Response;
+    });
+    globalThis.fetch = fetchMock as typeof fetch;
+    const errorLog = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const tool = buildWebSearchTool({
+      BRAVE_API_KEY: "bsk-test",
+      TAVILY_API_KEY: "tvly-test",
+    });
+    const result = await (
+      tool.execute as (...args: unknown[]) => Promise<{
+        content: Array<{ type: string; text?: string }>;
+        details?: unknown;
+      }>
+    )("call_fallback", { query: "fallback query" }, undefined, undefined, {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.content[0]?.text).toContain("[Tavily] 1 result(s)");
+    expect(result.details).toMatchObject({
+      usage: { raw: { tavily: { requests: 1, fetchedPages: 0 } } },
+    });
+    expect(errorLog).toHaveBeenCalledWith(
+      expect.stringContaining("Brave Search network error, trying Tavily"),
+    );
+  });
+
+  it("does not fall back on provider authentication errors", async () => {
+    const fetchMock = vi.fn(
+      async () =>
+        ({
+          ok: false,
+          status: 401,
+          statusText: "Unauthorized",
+          text: async () => '{"error":"invalid key"}',
+        }) as Response,
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const tool = buildWebSearchTool({
+      BRAVE_API_KEY: "bsk-test",
+      TAVILY_API_KEY: "tvly-test",
+    });
+    const result = await (
+      tool.execute as (...args: unknown[]) => Promise<{
+        content: Array<{ type: string; text?: string }>;
+      }>
+    )("call_auth", { query: "auth query" }, undefined, undefined, {});
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.text).toContain(
+      "Web search error (Brave Search): Brave API 401: Unauthorized",
+    );
+  });
 });
 
 describe("buildWebFetchTool", () => {

--- a/packages/runner-pi/src/web-tools.ts
+++ b/packages/runner-pi/src/web-tools.ts
@@ -224,6 +224,52 @@ function isRateLimitError(err: unknown): boolean {
   );
 }
 
+const RETRYABLE_NETWORK_ERROR_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+
+function hasRetryableNetworkCode(
+  error: unknown,
+  seen = new Set<object>(),
+): boolean {
+  if (error === null || typeof error !== "object" || seen.has(error))
+    return false;
+  seen.add(error);
+
+  const code = getErrorField(error, "code");
+  if (code && RETRYABLE_NETWORK_ERROR_CODES.has(code)) return true;
+
+  const nestedErrors: unknown[] = [];
+  if ("cause" in error) nestedErrors.push(error.cause);
+  if ("errors" in error && Array.isArray(error.errors)) {
+    nestedErrors.push(...error.errors);
+  }
+  return nestedErrors.some((nested) => hasRetryableNetworkCode(nested, seen));
+}
+
+function isRetryableNetworkError(err: unknown): boolean {
+  if (hasRetryableNetworkCode(err)) return true;
+  return err instanceof TypeError && err.message === "fetch failed";
+}
+
+function getFallbackReason(
+  err: unknown,
+): "rate limit" | "network error" | null {
+  if (isRateLimitError(err)) return "rate limit";
+  if (isRetryableNetworkError(err)) return "network error";
+  return null;
+}
+
 function getErrorField(error: object, key: string): string | undefined {
   if (!(key in error)) return undefined;
   const value = (error as Record<string, unknown>)[key];
@@ -457,10 +503,10 @@ export function buildWebSearchTool(
       const freshness = p.freshness as string | undefined;
       const shouldFetchContent = (p.fetch_content as boolean) ?? false;
 
-      // Try each provider in order; fallback on rate-limit errors
+      // Try each provider in order; fallback on rate-limit and network errors.
       let lastError: unknown;
       let lastProviderLabel = "unknown provider";
-      for (const { provider, apiKey } of providers) {
+      for (const [providerIndex, { provider, apiKey }] of providers.entries()) {
         lastProviderLabel = provider.label;
         try {
           const { results } = await provider.search({
@@ -506,13 +552,15 @@ export function buildWebSearchTool(
           console.error(
             `[bunny-agent:pi] ${provider.label} web_search failed: ${diagnostic}`,
           );
-          if (isRateLimitError(e) && providers.length > 1) {
+          const fallbackReason = getFallbackReason(e);
+          const nextProvider = providers[providerIndex + 1];
+          if (fallbackReason && nextProvider) {
             console.error(
-              `[bunny-agent:pi] ${provider.label} rate-limited, trying next provider...`,
+              `[bunny-agent:pi] ${provider.label} ${fallbackReason}, trying ${nextProvider.provider.label}...`,
             );
             continue;
           }
-          // Non-rate-limit error: don't fallback
+          // Authentication and request errors should be surfaced as-is.
           break;
         }
       }


### PR DESCRIPTION
## Problem

When the preferred web search provider cannot be reached because of DNS, connection, or socket failures, `web_search` stops immediately even when another configured provider is available. Users behind unstable DNS or regional network routes repeatedly see `fetch failed` instead of receiving search results.

## Root Cause

The provider loop only treated rate-limit and quota responses as fallback conditions. Node.js and Undici network failures such as `EAI_AGAIN` and `UND_ERR_CONNECT_TIMEOUT` were surfaced immediately without trying the next configured provider.

## Fix

- Treat retryable DNS, connection, timeout, and socket errors as provider fallback conditions.
- Inspect nested `cause` and aggregate error objects for Node.js and Undici error codes.
- Continue from Brave Search to Tavily when a retryable network failure occurs.
- Keep authentication and request errors, including HTTP 401, visible without masking them through fallback.
- Log the fallback reason and the next provider selected.

## Validation

- All 142 `runner-pi` tests passed on Node.js 24.
- Focused web tool tests cover `EAI_AGAIN`, `UND_ERR_CONNECT_TIMEOUT`, `ETIMEDOUT`, and `ENETUNREACH`.
- `runner-pi` typecheck, build, and Biome checks passed.
- A real local socket disconnect produced `UND_ERR_SOCKET`; the same `web_search` call then continued with Tavily and returned a successful result.

## Known Limit

- Fallback requires another configured provider. If only one provider is available, its network error is still returned.

## Files Affected

- `packages/runner-pi/src/web-tools.ts`
- `packages/runner-pi/src/__tests__/web-tools.test.ts`
- `docs/changelog/2026-07-19-web-search-network-fallback.md`
