### PR TITLE
fix(web-search): require request-scoped provider keys

### DIFF
--- a/.changeset/request-scoped-web-search.md
+++ b/.changeset/request-scoped-web-search.md
@@ -1,0 +1,7 @@
+---
+"@bunny-agent/daemon": patch
+"@bunny-agent/manager": patch
+"@bunny-agent/sandbox-local": patch
+---
+
+Use only explicitly supplied Brave and Tavily credentials for web search runs.

--- a/apps/daemon/src/__tests__/coding-run-env.test.ts
+++ b/apps/daemon/src/__tests__/coding-run-env.test.ts
@@ -68,6 +68,33 @@ describe("prepareCodingRunEnv", () => {
     expect(systemEnv).toBeUndefined();
   });
 
+  it("accepts web search keys only from the request body", () => {
+    const { env } = prepareCodingRunEnv(
+      {
+        PATH: "/usr/bin",
+        BRAVE_API_KEY: "local-brave",
+        TAVILY_API_KEY: "local-tavily",
+      },
+      { env: { TAVILY_API_KEY: "request-tavily" } },
+    );
+    expect(env).toEqual({
+      PATH: "/usr/bin",
+      TAVILY_API_KEY: "request-tavily",
+    });
+  });
+
+  it("omits ambient web search keys when the request does not provide them", () => {
+    const { env } = prepareCodingRunEnv(
+      {
+        PATH: "/usr/bin",
+        BRAVE_API_KEY: "local-brave",
+        TAVILY_API_KEY: "local-tavily",
+      },
+      {},
+    );
+    expect(env).toEqual({ PATH: "/usr/bin" });
+  });
+
   it("sanitizes systemEnv from body", () => {
     const { systemEnv } = prepareCodingRunEnv(
       { PATH: "/usr/bin" },

--- a/apps/daemon/src/coding-run-env.ts
+++ b/apps/daemon/src/coding-run-env.ts
@@ -8,6 +8,8 @@ function isValidEnvKey(key: string): boolean {
   return /^[A-Za-z_][A-Za-z0-9_]*$/.test(key);
 }
 
+const REQUEST_ONLY_ENV_KEYS = new Set(["BRAVE_API_KEY", "TAVILY_API_KEY"]);
+
 /**
  * Normalize `body.env` from JSON (string keys and string values only).
  */
@@ -42,7 +44,7 @@ export interface CodingRunBodyWithEnv {
 }
 
 export interface PreparedCodingRunEnv {
-  /** Full env passed to the runner (daemon env + inline body.env). */
+  /** Full runner env; web search keys are accepted only from inline body.env. */
   env: Record<string, string>;
   /** Sanitized subset of env keys safe to expose to the bash tool. */
   systemEnv: Record<string, string> | undefined;
@@ -50,15 +52,21 @@ export interface PreparedCodingRunEnv {
 
 /**
  * Sanitize and merge env-related fields from a `/api/coding/run` body.
- * Returns the runner env (daemon env + inline `body.env`) and the
- * sanitized `systemEnv` subset, with no body mutation.
+ * Returns the runner env (filtered daemon env + inline `body.env`) and the
+ * sanitized `systemEnv` subset, with no body mutation. Web search credentials
+ * are request-scoped and never inherited from the daemon process.
  */
 export function prepareCodingRunEnv(
   daemonEnv: Record<string, string>,
   body: CodingRunBodyWithEnv,
 ): PreparedCodingRunEnv {
   const inline = sanitizeCodingRunBodyEnv(body.env);
-  const env = inline ? { ...daemonEnv, ...inline } : { ...daemonEnv };
+  const inheritedEnv = Object.fromEntries(
+    Object.entries(daemonEnv).filter(
+      ([key]) => !REQUEST_ONLY_ENV_KEYS.has(key),
+    ),
+  );
+  const env = inline ? { ...inheritedEnv, ...inline } : inheritedEnv;
   const systemEnv = sanitizeCodingRunBodySystemEnv(body.systemEnv);
   return { env, systemEnv };
 }

--- a/apps/web/app/api/ai/route.ts
+++ b/apps/web/app/api/ai/route.ts
@@ -254,13 +254,13 @@ export async function POST(request: Request) {
     OPENAI_BASE_URL,
     GEMINI_API_KEY,
     GEMINI_BASE_URL,
+    BRAVE_API_KEY,
+    TAVILY_API_KEY,
     template,
     useBunnyAgentDaemon,
     env: {
       AGENT_KEY: process.env.AGENT_KEY ?? "",
       BUDA_API_URL: process.env.BUDA_API_URL ?? "",
-      ...(BRAVE_API_KEY ? { BRAVE_API_KEY } : {}),
-      ...(TAVILY_API_KEY ? { TAVILY_API_KEY } : {}),
     },
   };
 

--- a/apps/web/lib/example/create-sandbox.ts
+++ b/apps/web/lib/example/create-sandbox.ts
@@ -93,6 +93,8 @@ export interface CreateSandboxParams {
   OPENAI_BASE_URL?: string;
   GEMINI_API_KEY?: string;
   GEMINI_BASE_URL?: string;
+  BRAVE_API_KEY?: string;
+  TAVILY_API_KEY?: string;
   AWS_REGION?: string;
   template?: string;
   SANDBOX_IMAGE?: string;
@@ -124,6 +126,8 @@ function sandboxCacheKey(params: CreateSandboxParams): string {
     // Only include variables that can influence skill execution.
     AGENT_KEY: env.AGENT_KEY ?? "",
     BUDA_API_URL: env.BUDA_API_URL ?? "",
+    BRAVE_API_KEY: params.BRAVE_API_KEY ?? "",
+    TAVILY_API_KEY: params.TAVILY_API_KEY ?? "",
   };
   const fingerprint = createHash("sha256")
     .update(JSON.stringify(fingerprintSource))
@@ -188,6 +192,8 @@ async function buildSandbox(
     OPENAI_BASE_URL,
     GEMINI_API_KEY,
     GEMINI_BASE_URL,
+    BRAVE_API_KEY,
+    TAVILY_API_KEY,
     template = "default",
     env: extraEnv = {},
   } = params;
@@ -207,6 +213,8 @@ async function buildSandbox(
     OPENAI_BASE_URL,
     GEMINI_API_KEY,
     GEMINI_BASE_URL,
+    BRAVE_API_KEY,
+    TAVILY_API_KEY,
     inherit: extraEnv,
   });
   if (SANDBOX_PROVIDER === "daytona" && DAYTONA_API_KEY) {

--- a/docs/changelog/2026-07-19-request-scoped-web-search-keys.md
+++ b/docs/changelog/2026-07-19-request-scoped-web-search-keys.md
@@ -1,0 +1,17 @@
+# Request-scoped web search credentials
+
+## Summary
+
+Brave and Tavily credentials are now accepted only from the explicit coding-run request environment. Ambient daemon and runner process environments no longer influence web search provider selection.
+
+## Changes
+
+- Removed `process.env` fallback from Pi and harness web search provider resolution.
+- Removed Brave and Tavily fallback and inheritance from `buildRunnerEnv`.
+- Filtered Brave and Tavily keys out of the daemon environment before merging the coding-run request environment.
+- Preserved explicit web search credentials in local sandbox and example web callers through dedicated parameters.
+- Added regression coverage for local credentials being ignored and request credentials being preserved.
+
+## Motivation
+
+A Connector must use the provider credentials selected by Buda for that run. Credentials configured on the user's machine must not silently add or reorder web search providers.

--- a/packages/manager/src/__tests__/env.test.ts
+++ b/packages/manager/src/__tests__/env.test.ts
@@ -18,28 +18,31 @@ describe("buildRunnerEnv", () => {
     expect(env.TAVILY_API_KEY).toBe("tvly-456");
   });
 
-  it("falls back to process.env for BRAVE_API_KEY", () => {
+  it("ignores BRAVE_API_KEY from process.env", () => {
     process.env.BRAVE_API_KEY = "env-brave";
     const env = buildRunnerEnv({});
-    expect(env.BRAVE_API_KEY).toBe("env-brave");
+    expect(env.BRAVE_API_KEY).toBeUndefined();
   });
 
-  it("falls back to process.env for TAVILY_API_KEY", () => {
+  it("ignores TAVILY_API_KEY from process.env", () => {
     process.env.TAVILY_API_KEY = "env-tavily";
     const env = buildRunnerEnv({});
-    expect(env.TAVILY_API_KEY).toBe("env-tavily");
+    expect(env.TAVILY_API_KEY).toBeUndefined();
   });
 
-  it("params override process.env for web search keys", () => {
+  it("uses explicit web search params instead of process.env", () => {
     process.env.BRAVE_API_KEY = "env-brave";
     const env = buildRunnerEnv({ BRAVE_API_KEY: "param-brave" });
     expect(env.BRAVE_API_KEY).toBe("param-brave");
   });
 
-  it("omits web search keys when neither params nor process.env has them", () => {
-    delete process.env.BRAVE_API_KEY;
-    delete process.env.TAVILY_API_KEY;
-    const env = buildRunnerEnv({});
+  it("strips web search keys from the inherited environment", () => {
+    const env = buildRunnerEnv({
+      inherit: {
+        BRAVE_API_KEY: "inherited-brave",
+        TAVILY_API_KEY: "inherited-tavily",
+      },
+    });
     expect(env.BRAVE_API_KEY).toBeUndefined();
     expect(env.TAVILY_API_KEY).toBeUndefined();
   });

--- a/packages/manager/src/env.ts
+++ b/packages/manager/src/env.ts
@@ -40,7 +40,8 @@ export interface RunnerEnvParams {
    * Base env to merge in (lowest priority).
    * Typically `process.env` for local sandbox, or extra vars from the request.
    * Null/undefined values and parent Claude Code keys (CLAUDE_CODE_SSE_PORT
-   * etc.) are automatically stripped.
+   * etc.) are automatically stripped. Web search keys must use their dedicated
+   * parameters and are ignored here.
    */
   inherit?: Record<string, string | undefined | null>;
   /**
@@ -59,6 +60,8 @@ export interface RunnerEnvParams {
 const STRIP_FROM_CHILD = new Set([
   "CLAUDE_CODE_SSE_PORT",
   "CLAUDE_CODE_SSE_SESSION_ID",
+  "BRAVE_API_KEY",
+  "TAVILY_API_KEY",
 ]);
 
 function applyInherit(
@@ -174,9 +177,9 @@ export function buildRunnerEnv(
       break;
   }
 
-  // Web search keys (all runners) — params override process.env
-  const braveKey = params.BRAVE_API_KEY || process.env.BRAVE_API_KEY;
-  const tavilyKey = params.TAVILY_API_KEY || process.env.TAVILY_API_KEY;
+  // Web search keys are request-scoped and must be passed explicitly.
+  const braveKey = params.BRAVE_API_KEY;
+  const tavilyKey = params.TAVILY_API_KEY;
   if (braveKey) env.BRAVE_API_KEY = braveKey;
   if (tavilyKey) env.TAVILY_API_KEY = tavilyKey;
 

--- a/packages/runner-harness/src/tools/web-search.test.ts
+++ b/packages/runner-harness/src/tools/web-search.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { resolveSearchProviders } from "./web-search.js";
+
+describe("resolveSearchProviders", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("uses explicitly provided web search keys", () => {
+    const providers = resolveSearchProviders({
+      BRAVE_API_KEY: "request-brave",
+      TAVILY_API_KEY: "request-tavily",
+    });
+
+    expect(providers.map(({ provider }) => provider.id)).toEqual([
+      "brave",
+      "tavily",
+    ]);
+  });
+
+  it("ignores web search keys from process.env", () => {
+    process.env.BRAVE_API_KEY = "local-brave";
+    process.env.TAVILY_API_KEY = "local-tavily";
+
+    expect(resolveSearchProviders({})).toEqual([]);
+  });
+});

--- a/packages/runner-harness/src/tools/web-search.ts
+++ b/packages/runner-harness/src/tools/web-search.ts
@@ -147,7 +147,7 @@ interface ResolvedProvider {
 }
 
 function getEnv(env: Record<string, string>, key: string): string | undefined {
-  const v = env[key] ?? process.env[key];
+  const v = env[key];
   return v && v.length > 0 ? v : undefined;
 }
 

--- a/packages/runner-pi/src/__tests__/web-tools.test.ts
+++ b/packages/runner-pi/src/__tests__/web-tools.test.ts
@@ -43,23 +43,19 @@ describe("resolveSearchProviders", () => {
     expect(result[1].provider.id).toBe("tavily");
   });
 
-  it("falls back to process.env for BRAVE_API_KEY", () => {
+  it("ignores BRAVE_API_KEY from process.env", () => {
     process.env.BRAVE_API_KEY = "env-brave";
     const result = resolveSearchProviders({});
-    expect(result).toHaveLength(1);
-    expect(result[0].provider.id).toBe("brave");
-    expect(result[0].apiKey).toBe("env-brave");
+    expect(result).toEqual([]);
   });
 
-  it("falls back to process.env for TAVILY_API_KEY", () => {
+  it("ignores TAVILY_API_KEY from process.env", () => {
     process.env.TAVILY_API_KEY = "env-tavily";
     const result = resolveSearchProviders({});
-    expect(result).toHaveLength(1);
-    expect(result[0].provider.id).toBe("tavily");
-    expect(result[0].apiKey).toBe("env-tavily");
+    expect(result).toEqual([]);
   });
 
-  it("env map overrides process.env", () => {
+  it("uses the explicitly provided env map instead of process.env", () => {
     process.env.BRAVE_API_KEY = "env-brave";
     const result = resolveSearchProviders({ BRAVE_API_KEY: "param-brave" });
     expect(result[0].apiKey).toBe("param-brave");

--- a/packages/runner-pi/src/web-tools.ts
+++ b/packages/runner-pi/src/web-tools.ts
@@ -173,7 +173,7 @@ const tavilyProvider: WebSearchProvider = {
 const AUTO_DETECT_ORDER: WebSearchProvider[] = [braveProvider, tavilyProvider];
 
 function getEnv(env: Record<string, string>, key: string): string | undefined {
-  const v = env[key] ?? process.env[key];
+  const v = env[key];
   return v && v.length > 0 ? v : undefined;
 }
 

--- a/packages/sandbox-local/src/local-machine.ts
+++ b/packages/sandbox-local/src/local-machine.ts
@@ -315,8 +315,11 @@ class LocalMachineHandle implements SandboxHandle {
 
     const cwd = opts.cwd ? path.resolve(this.workDir, opts.cwd) : this.workDir;
     const timeout = opts.timeout ?? this.defaultTimeout;
-    const baseInherit = { ...process.env, ...this.env, ...opts.env };
+    const explicitEnv = { ...this.env, ...opts.env };
+    const baseInherit = { ...process.env, ...explicitEnv };
     const env = buildRunnerEnv({
+      BRAVE_API_KEY: explicitEnv.BRAVE_API_KEY,
+      TAVILY_API_KEY: explicitEnv.TAVILY_API_KEY,
       inherit: baseInherit,
     });
 


### PR DESCRIPTION
## Summary

- accept Brave and Tavily credentials only from the explicit coding-run request environment
- prevent daemon, manager, Pi, and harness process environments from changing provider selection
- preserve explicitly supplied credentials in local sandbox and example web callers
- add regression coverage, changelog, and release changeset

## Verification

- 45 focused manager, daemon, harness, and Pi tests passed on the clean PR branch
- 24 local sandbox tests passed in the source worktree
- Biome passed for all changed files
- TypeScript passed for daemon, manager, runner-pi, and sandbox-local

## Context

Connector host environment variables must not silently add or reorder web search providers. Buda should select the available providers for each request.