### PR TITLE
chore: remove request-scoped web search changeset

### DIFF
--- a/.changeset/request-scoped-web-search.md
+++ b/.changeset/request-scoped-web-search.md
@@ -1,7 +1,0 @@
----
-"@bunny-agent/daemon": patch
-"@bunny-agent/manager": patch
-"@bunny-agent/sandbox-local": patch
----
-
-Use only explicitly supplied Brave and Tavily credentials for web search runs.


### PR DESCRIPTION
Remove the changeset added by #376 because this internal credential-routing change does not require a package release entry.