### PR TITLE
fix(runner-pi): expose tool transport error causes

### DIFF
--- a/packages/runner-pi/src/__tests__/tool-refs.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-refs.test.ts
@@ -4,7 +4,7 @@ import type { AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildToolDefinitionsFromRefs, type PiToolRef } from "../tool-refs.js";
 
 interface CapturedCall {
@@ -84,6 +84,7 @@ describe("buildToolDefinitionsFromRefs", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await server.close();
   });
 
@@ -173,6 +174,33 @@ describe("buildToolDefinitionsFromRefs", () => {
     ).rejects.toMatchObject({
       name: "PiToolRefError",
       message: expect.stringMatching(/transport error.*abort/i),
+    });
+  });
+
+  it("includes the underlying fetch cause in transport errors", async () => {
+    const socketError = Object.assign(new Error("other side closed"), {
+      code: "UND_ERR_SOCKET",
+    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(
+      Object.assign(new TypeError("fetch failed"), { cause: socketError }),
+    );
+
+    const [tool] = buildToolDefinitionsFromRefs([
+      { ...sampleSpec, runtime: { type: "http", url: server.url } },
+    ]);
+
+    await expect(
+      tool.execute(
+        "tc_transport",
+        {},
+        undefined,
+        undefined,
+        undefined as never,
+      ),
+    ).rejects.toMatchObject({
+      name: "PiToolRefError",
+      message:
+        'Tool "get_current_time" transport error: fetch failed (cause: UND_ERR_SOCKET: other side closed)',
     });
   });
 

--- a/packages/runner-pi/src/tool-refs.ts
+++ b/packages/runner-pi/src/tool-refs.ts
@@ -70,7 +70,7 @@ function buildOne(spec: PiToolRef): ToolDefinition {
       try {
         response = await executeToolRef(spec, params, signal);
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = formatTransportError(error);
         throw new PiToolRefError(
           `Tool "${spec.name}" transport error: ${message}`,
           { toolName: spec.name },
@@ -86,6 +86,35 @@ function buildOne(spec: PiToolRef): ToolDefinition {
       return okResult(response.body);
     },
   };
+}
+
+function formatTransportError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  if (typeof error !== "object" || error === null || !("cause" in error)) {
+    return message;
+  }
+
+  const cause = error.cause;
+  if (cause === undefined || cause === null) return message;
+
+  const causeMessage = cause instanceof Error ? cause.message : String(cause);
+  const causeCode =
+    typeof cause === "object" &&
+    cause !== null &&
+    "code" in cause &&
+    typeof cause.code === "string"
+      ? cause.code
+      : undefined;
+  const details = [causeCode, causeMessage]
+    .filter(
+      (part, index, parts): part is string =>
+        !!part && parts.indexOf(part) === index,
+    )
+    .join(": ");
+
+  return details && details !== message
+    ? `${message} (cause: ${details})`
+    : message;
 }
 
 function formatToolRuntimeErrorMessage(response: RuntimeResponse): string {


### PR DESCRIPTION
## Summary
- include the underlying fetch cause code and message in HTTP tool transport errors
- preserve the existing top-level error message and avoid logging request headers or credentials
- cover the Undici socket-close failure shape with a focused test

## Context
Node fetch often reports only `fetch failed` at the top level while the actionable reason, such as `UND_ERR_SOCKET`, `ECONNRESET`, `ETIMEDOUT`, or `ENOTFOUND`, is stored in `error.cause`. This makes production image-tool failures impossible to distinguish from the current Agent output.

## Verification
- runner-pi tool-refs tests: 5 passed
- runner-pi TypeScript check: passed
- Biome check: passed
- git diff --check: passed