### PR TITLE
feat: add structured agent input (AgentTurnInputV1)

### DIFF
--- a/apps/daemon/src/__tests__/coding.test.ts
+++ b/apps/daemon/src/__tests__/coding.test.ts
@@ -9,42 +9,44 @@ import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 const createRunnerCalls: Array<Record<string, unknown>> = [];
 
 vi.mock("@bunny-agent/runner-harness", () => ({
-  createRunner: vi.fn((opts: { userInput: string; yolo?: boolean }) => {
-    createRunnerCalls.push(opts);
-    if (opts.userInput === "__THROW__") {
-      // biome-ignore lint/correctness/useYield: throw-only generator simulates immediate runner failure
+  createRunner: vi.fn(
+    (opts: { input?: unknown; userInput?: string; yolo?: boolean }) => {
+      createRunnerCalls.push(opts);
+      if (opts.userInput === "__THROW__") {
+        // biome-ignore lint/correctness/useYield: throw-only generator simulates immediate runner failure
+        return (async function* () {
+          throw new Error("runner exploded");
+        })();
+      }
+      if (opts.userInput === "__SLOW__") {
+        // Simulate a long-running tool execution (e.g. image generation).
+        return (async function* () {
+          yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
+          await new Promise<void>((resolve) => setTimeout(resolve, 40_000));
+          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+          yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
+          yield `data: [DONE]\n\n`;
+        })();
+      }
+      if (opts.userInput === "__SLOW_SHORT__") {
+        // Short delay (100ms) — used with a patched HEARTBEAT_INTERVAL_MS (20ms)
+        // so heartbeats fire multiple times within the pause.
+        return (async function* () {
+          yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
+          await new Promise<void>((resolve) => setTimeout(resolve, 100));
+          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+          yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
+          yield `data: [DONE]\n\n`;
+        })();
+      }
+      // Return an async iterable that yields SSE-style chunks.
       return (async function* () {
-        throw new Error("runner exploded");
-      })();
-    }
-    if (opts.userInput === "__SLOW__") {
-      // Simulate a long-running tool execution (e.g. image generation).
-      return (async function* () {
-        yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
-        await new Promise<void>((resolve) => setTimeout(resolve, 40_000));
-        yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+        yield `data: ${JSON.stringify({ type: "text", text: `echo: ${opts.userInput}` })}\n\n`;
         yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
         yield `data: [DONE]\n\n`;
       })();
-    }
-    if (opts.userInput === "__SLOW_SHORT__") {
-      // Short delay (100ms) — used with a patched HEARTBEAT_INTERVAL_MS (20ms)
-      // so heartbeats fire multiple times within the pause.
-      return (async function* () {
-        yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
-        await new Promise<void>((resolve) => setTimeout(resolve, 100));
-        yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
-        yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
-        yield `data: [DONE]\n\n`;
-      })();
-    }
-    // Return an async iterable that yields SSE-style chunks.
-    return (async function* () {
-      yield `data: ${JSON.stringify({ type: "text", text: `echo: ${opts.userInput}` })}\n\n`;
-      yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
-      yield `data: [DONE]\n\n`;
-    })();
-  }),
+    },
+  ),
 }));
 
 import { createNextHandler } from "../nextjs.js";
@@ -123,6 +125,19 @@ describe("codingRunStream (Web Response)", () => {
     expect(JSON.parse(payloads[0]).text).toBe("echo: test");
     expect(JSON.parse(payloads[1]).type).toBe("finish");
     expect(payloads[payloads.length - 1]).toBe("[DONE]");
+  });
+
+  it("forwards structured input without requiring legacy text", async () => {
+    const input = {
+      version: 1 as const,
+      input: [{ type: "text" as const, text: "structured" }],
+      capabilities: [],
+      execution: {},
+    };
+    const res = codingRunStream({ input }, {});
+    await res.text();
+
+    expect(createRunnerCalls.at(-1)).toMatchObject({ input });
   });
 
   it("forwards request-scoped MCP config to the runner harness", async () => {

--- a/apps/daemon/src/routes/coding.ts
+++ b/apps/daemon/src/routes/coding.ts
@@ -10,7 +10,10 @@ type RunMcpConfig = RunnerCoreOptions["mcpConfig"];
 export interface RunRequest {
   runner?: string;
   model?: string;
-  userInput: string;
+  /** Versioned structured input. Preferred over userInput when present. */
+  input?: RunnerCoreOptions["input"];
+  /** Text-only compatibility fallback for one release. */
+  userInput?: string;
   systemPrompt?: string;
   maxTurns?: number;
   allowedTools?: string[];
@@ -43,6 +46,12 @@ export interface RunRequest {
   /** Reasoning effort / thinking level (e.g. "low", "medium", "high"). */
   effort?: string;
 }
+
+const assertRunRequestInput = (req: RunRequest): void => {
+  if (req.input === undefined && typeof req.userInput !== "string") {
+    throw new Error("Either input or userInput is required");
+  }
+};
 
 /** SSE comment keepalive interval (ms). Prevents idle-timeout disconnects
  *  from reverse proxies or sandbox shell APIs during long tool executions. */
@@ -85,9 +94,11 @@ export async function bunnyAgentRun(
   }, getHeartbeatIntervalMs());
 
   try {
+    assertRunRequestInput(req);
     const stream = createRunner({
       runner: req.runner ?? "claude",
       model: req.model ?? "claude-sonnet-4-20250514",
+      input: req.input,
       userInput: req.userInput,
       systemPrompt: req.systemPrompt,
       maxTurns: req.maxTurns,
@@ -133,6 +144,14 @@ export function codingRunStream(
   req: RunRequest,
   env: Record<string, string>,
 ): Response {
+  try {
+    assertRunRequestInput(req);
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 400 },
+    );
+  }
   const abortController = new AbortController();
 
   const body = new ReadableStream({
@@ -153,6 +172,7 @@ export function codingRunStream(
         const stream = createRunner({
           runner: req.runner ?? "claude",
           model: req.model ?? "claude-sonnet-4-20250514",
+          input: req.input,
           userInput: req.userInput,
           systemPrompt: req.systemPrompt,
           maxTurns: req.maxTurns,

--- a/apps/runner-cli/package.json
+++ b/apps/runner-cli/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@bunny-agent/apply-patch": "workspace:*",
+    "@bunny-agent/manager": "workspace:*",
     "@bunny-agent/runner-claude": "workspace:*",
     "@bunny-agent/runner-codex": "workspace:*",
     "@bunny-agent/runner-copilot": "workspace:*",

--- a/apps/runner-cli/src/__tests__/env-payload.test.ts
+++ b/apps/runner-cli/src/__tests__/env-payload.test.ts
@@ -1,5 +1,31 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { takeMcpConfigFromEnv, takeToolRefsFromEnv } from "../env-payload.js";
+import {
+  takeAgentInputFromEnv,
+  takeMcpConfigFromEnv,
+  takeToolRefsFromEnv,
+} from "../env-payload.js";
+
+describe("takeAgentInputFromEnv", () => {
+  it("validates and deletes the one-shot structured payload", () => {
+    const env = {
+      BUNNY_AGENT_INPUT_JSON: JSON.stringify({
+        version: 1,
+        input: [{ type: "text", text: "hello" }],
+        capabilities: [],
+        execution: {},
+      }),
+    };
+
+    expect(takeAgentInputFromEnv(env)).toMatchObject({ version: 1 });
+    expect(env.BUNNY_AGENT_INPUT_JSON).toBeUndefined();
+  });
+
+  it("deletes malformed payloads before throwing", () => {
+    const env = { BUNNY_AGENT_INPUT_JSON: "not-json" };
+    expect(() => takeAgentInputFromEnv(env)).toThrow();
+    expect(env.BUNNY_AGENT_INPUT_JSON).toBeUndefined();
+  });
+});
 
 describe("takeToolRefsFromEnv", () => {
   beforeEach(() => {

--- a/apps/runner-cli/src/cli.ts
+++ b/apps/runner-cli/src/cli.ts
@@ -19,7 +19,11 @@ config({ path: resolve(process.cwd(), "../../.env") });
 
 import { parseArgs } from "node:util";
 import { buildImage } from "./build-image.js";
-import { takeMcpConfigFromEnv, takeToolRefsFromEnv } from "./env-payload.js";
+import {
+  takeAgentInputFromEnv,
+  takeMcpConfigFromEnv,
+  takeToolRefsFromEnv,
+} from "./env-payload.js";
 import { runAgent } from "./runner.js";
 
 // ---------------------------------------------------------------------------
@@ -314,12 +318,13 @@ async function main(): Promise<void> {
     case "run": {
       const args = parseRunArgs();
       process.chdir(args.cwd);
+      const input = takeAgentInputFromEnv();
       const toolRefs = takeToolRefsFromEnv();
       const mcpConfig = takeMcpConfigFromEnv();
       await runAgent({
         runner: args.runner,
         model: args.model,
-        userInput: args.userInput,
+        ...(input ? { input } : { userInput: args.userInput }),
         systemPrompt: args.systemPrompt,
         maxTurns: args.maxTurns,
         allowedTools: args.allowedTools,

--- a/apps/runner-cli/src/env-payload.ts
+++ b/apps/runner-cli/src/env-payload.ts
@@ -12,12 +12,26 @@
  * is the expected bash environment.
  */
 
+import {
+  type AgentTurnInputV1,
+  parseAgentTurnInputV1,
+} from "@bunny-agent/manager";
 import type { PiRunnerOptions } from "@bunny-agent/runner-pi";
 
 type RunnerToolRefs = NonNullable<PiRunnerOptions["toolRefs"]>;
 export type RunnerToolRefsPayload = { tools: RunnerToolRefs };
 type RunnerMcpConfig = NonNullable<PiRunnerOptions["mcpConfig"]>;
 export type RunnerMcpConfigPayload = { config: RunnerMcpConfig };
+
+export function takeAgentInputFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): AgentTurnInputV1 | null {
+  const raw = env.BUNNY_AGENT_INPUT_JSON;
+  if (raw === undefined) return null;
+  delete env.BUNNY_AGENT_INPUT_JSON;
+  if (raw.length === 0) return null;
+  return parseAgentTurnInputV1(JSON.parse(raw));
+}
 
 /**
  * Take `BUNNY_AGENT_TOOL_REFS_JSON`. Returns null when the var is absent or

--- a/docs/changelog/2026-08-03-structured-agent-input.md
+++ b/docs/changelog/2026-08-03-structured-agent-input.md
@@ -1,0 +1,22 @@
+# Structured Agent Input V1
+
+## Summary
+
+Bunny Agent now accepts a versioned `AgentTurnInputV1` alongside the one-release `userInput` text fallback. The protocol keeps assets, semantic bindings, capabilities, and server-resolved execution context separate.
+
+## Changes
+
+- Added strict parsing and negotiation for typed text, image, skill, integration, reference, capability, and extension inputs.
+- Added secret rejection for execution context, extension payloads, and display snapshots.
+- Added structured daemon and CLI transport with one-shot environment payload cleanup.
+- Added Claude labeled image blocks and Pi `message + images` delivery.
+- Added Vercel AI SDK conversion that freezes `[Image #N]` labels and resolves URL/data-URL images.
+- Unsupported runner/image and extension combinations now fail before execution instead of degrading to text.
+
+## Compatibility
+
+`userInput` remains accepted for one release. Consumers should migrate to `AgentTurnInputV1` before the fallback is removed.
+
+## Verification
+
+Manager, daemon, CLI, SDK, runner harness, Claude, and Pi focused suites cover protocol validation, image order, resume behavior, and unsupported input rejection.

--- a/packages/manager/src/__tests__/agent-input.test.ts
+++ b/packages/manager/src/__tests__/agent-input.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AgentTurnInputV1,
+  compileAgentTurnInput,
+  parseAgentTurnInputV1,
+} from "../agent-input.js";
+
+const createImageTurn = (): AgentTurnInputV1 => ({
+  version: 1,
+  input: [
+    {
+      type: "asset",
+      id: "asset-1",
+      label: "[Image #1]",
+      asset: { mediaType: "image/png", data: "Zmlyc3Q=" },
+    },
+    {
+      type: "asset",
+      id: "asset-2",
+      label: "[Image #2]",
+      asset: { mediaType: "image/jpeg", data: "c2Vjb25k" },
+    },
+    {
+      type: "text",
+      text: "Before [Image #1] between [Image #2] after",
+    },
+  ],
+  capabilities: [],
+  execution: {
+    resolvedBy: "server",
+    skills: [],
+    integrations: [],
+    references: [],
+    capabilityKeys: [],
+    extensionVersions: {},
+  },
+});
+
+describe("AgentTurnInputV1", () => {
+  it("preserves frozen image labels and first appearance order", () => {
+    const compiled = compileAgentTurnInput(createImageTurn());
+    expect(compiled.text).toBe("Before [Image #1] between [Image #2] after");
+    expect(compiled.images.map(({ id, label }) => ({ id, label }))).toEqual([
+      { id: "asset-1", label: "[Image #1]" },
+      { id: "asset-2", label: "[Image #2]" },
+    ]);
+  });
+
+  it("rejects forged skill and capability identifiers", () => {
+    const turn = createImageTurn();
+    turn.input.push({ type: "skill", id: "skill-1", name: "research" });
+    expect(() => parseAgentTurnInputV1(turn)).toThrow(
+      "Unresolved structured agent skill",
+    );
+
+    turn.input.pop();
+    turn.capabilities.push({ key: "web-search", enabled: true });
+    expect(() => parseAgentTurnInputV1(turn)).toThrow(
+      "Unresolved structured agent capability",
+    );
+  });
+
+  it("rejects duplicate assets and secret-bearing execution data", () => {
+    const duplicate = createImageTurn();
+    duplicate.input[1] = {
+      type: "asset",
+      id: "asset-1",
+      label: "[Image #2]",
+      asset: { mediaType: "image/jpeg", data: "c2Vjb25k" },
+    };
+    expect(() => parseAgentTurnInputV1(duplicate)).toThrow(
+      "duplicate asset id",
+    );
+
+    const secret = createImageTurn();
+    Object.assign(secret.execution, { accessToken: "do-not-forward" });
+    expect(() => parseAgentTurnInputV1(secret)).toThrow(
+      "execution must not contain secrets",
+    );
+  });
+
+  it("rejects malformed execution entries and secret-bearing display snapshots", () => {
+    const malformed = createImageTurn();
+    malformed.execution.skills = [null as never];
+    expect(() => parseAgentTurnInputV1(malformed)).toThrow(
+      "execution.skills must be an object array",
+    );
+
+    const snapshot = createImageTurn();
+    snapshot.displaySnapshot = {
+      version: 1,
+      document: { storageRef: "private/file" },
+    };
+    expect(() => parseAgentTurnInputV1(snapshot)).toThrow(
+      "displaySnapshot must be version 1 and secret-free",
+    );
+  });
+
+  it("rejects registered extensions until a runner adapter exists", () => {
+    const turn = createImageTurn();
+    turn.execution.extensionVersions = { "acme/chart": 1 };
+    turn.input.push({
+      type: "extension",
+      id: "extension-1",
+      namespace: "acme",
+      name: "chart",
+      version: 1,
+      payload: { chartId: "chart-1" },
+    });
+    expect(() => compileAgentTurnInput(turn)).toThrow(
+      "Runner adapter does not support extension",
+    );
+  });
+});

--- a/packages/manager/src/agent-input.ts
+++ b/packages/manager/src/agent-input.ts
@@ -1,0 +1,382 @@
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue =
+  | JsonPrimitive
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface ResolvedAsset {
+  mediaType: string;
+  data: string;
+  filename?: string;
+}
+
+export type AgentUserInput =
+  | { type: "text"; text: string }
+  | {
+      type: "asset";
+      id: string;
+      label: string;
+      asset: ResolvedAsset;
+    }
+  | { type: "skill"; id: string; name: string }
+  | { type: "integration"; id: string; providerKey: string }
+  | {
+      type: "reference";
+      id: string;
+      referenceKind: string;
+      targetId: string;
+      label?: string;
+    }
+  | {
+      type: "extension";
+      id: string;
+      namespace: string;
+      name: string;
+      version: number;
+      payload: Record<string, JsonValue>;
+    };
+
+export interface TurnCapabilitySelection {
+  key: string;
+  enabled: boolean;
+  sourceTokenId?: string;
+  configurationRef?: string;
+}
+
+export interface ResolvedExecutionContext {
+  resolvedBy?: "server";
+  skills?: Array<{ id: string; name: string }>;
+  integrations?: Array<{ id: string; providerKey: string }>;
+  references?: Array<{
+    id: string;
+    referenceKind: string;
+    targetId: string;
+  }>;
+  capabilityKeys?: string[];
+  extensionVersions?: Record<string, number>;
+}
+
+export interface SentComposerSnapshotV1 {
+  version: 1;
+  document: JsonValue;
+}
+
+export interface AgentTurnInputV1 {
+  version: 1;
+  input: AgentUserInput[];
+  capabilities: TurnCapabilitySelection[];
+  execution: ResolvedExecutionContext;
+  displaySnapshot?: SentComposerSnapshotV1;
+}
+
+export interface RunnerImageInput {
+  id: string;
+  label: string;
+  mediaType: string;
+  data: string;
+  filename?: string;
+}
+
+export interface CompiledRunnerInput {
+  text: string;
+  images: RunnerImageInput[];
+}
+
+const assertString = (value: unknown, field: string): string => {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Invalid structured agent input: ${field} must be a non-empty string`,
+    );
+  }
+  return value;
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const hasForbiddenSecretKey = (value: unknown): boolean => {
+  if (Array.isArray(value)) return value.some(hasForbiddenSecretKey);
+  if (!isRecord(value)) return false;
+  return Object.entries(value).some(([key, child]) => {
+    const normalized = key.toLowerCase();
+    return (
+      new Set([
+        "apikey",
+        "api_key",
+        "authorization",
+        "cookie",
+        "credential",
+        "credentials",
+        "password",
+        "secret",
+        "token",
+        "accesstoken",
+        "refreshtoken",
+        "signedurl",
+        "storageref",
+      ]).has(normalized) || hasForbiddenSecretKey(child)
+    );
+  });
+};
+
+export const parseAgentTurnInputV1 = (value: unknown): AgentTurnInputV1 => {
+  if (!isRecord(value) || value.version !== 1 || !Array.isArray(value.input)) {
+    throw new Error(
+      "Invalid structured agent input: expected AgentTurnInputV1",
+    );
+  }
+  if (!Array.isArray(value.capabilities) || !isRecord(value.execution)) {
+    throw new Error(
+      "Invalid structured agent input: capabilities and execution are required",
+    );
+  }
+
+  if (hasForbiddenSecretKey(value.execution)) {
+    throw new Error(
+      "Invalid structured agent input: execution must not contain secrets",
+    );
+  }
+  if (value.displaySnapshot !== undefined) {
+    if (
+      !isRecord(value.displaySnapshot) ||
+      value.displaySnapshot.version !== 1 ||
+      !("document" in value.displaySnapshot) ||
+      hasForbiddenSecretKey(value.displaySnapshot)
+    ) {
+      throw new Error(
+        "Invalid structured agent input: displaySnapshot must be version 1 and secret-free",
+      );
+    }
+  }
+
+  const requireRecordArray = (
+    candidate: unknown,
+    field: string,
+  ): Record<string, unknown>[] => {
+    if (candidate === undefined) return [];
+    if (!Array.isArray(candidate) || !candidate.every(isRecord)) {
+      throw new Error(
+        `Invalid structured agent input: execution.${field} must be an object array`,
+      );
+    }
+    return candidate;
+  };
+
+  const resolvedSkills = requireRecordArray(value.execution.skills, "skills");
+  const resolvedIntegrations = requireRecordArray(
+    value.execution.integrations,
+    "integrations",
+  );
+  const resolvedReferences = requireRecordArray(
+    value.execution.references,
+    "references",
+  );
+  const resolvedCapabilityKeys = value.execution.capabilityKeys ?? [];
+  if (
+    !Array.isArray(resolvedCapabilityKeys) ||
+    !resolvedCapabilityKeys.every(
+      (key): key is string => typeof key === "string",
+    )
+  ) {
+    throw new Error(
+      "Invalid structured agent input: execution.capabilityKeys must be a string array",
+    );
+  }
+  const assetIds = new Set<string>();
+
+  for (const [index, item] of value.input.entries()) {
+    if (!isRecord(item)) {
+      throw new Error(
+        `Invalid structured agent input: input[${index}] must be an object`,
+      );
+    }
+    switch (item.type) {
+      case "text":
+        if (typeof item.text !== "string") {
+          throw new Error(
+            `Invalid structured agent input: input[${index}].text must be a string`,
+          );
+        }
+        break;
+      case "asset": {
+        const id = assertString(item.id, `input[${index}].id`);
+        if (assetIds.has(id)) {
+          throw new Error(
+            `Invalid structured agent input: duplicate asset id ${id}`,
+          );
+        }
+        assetIds.add(id);
+        assertString(item.label, `input[${index}].label`);
+        if (!isRecord(item.asset)) {
+          throw new Error(
+            `Invalid structured agent input: input[${index}].asset is required`,
+          );
+        }
+        const mediaType = assertString(
+          item.asset.mediaType,
+          `input[${index}].asset.mediaType`,
+        );
+        assertString(item.asset.data, `input[${index}].asset.data`);
+        if (!mediaType.startsWith("image/")) {
+          throw new Error(
+            `Unsupported structured agent input asset type: ${mediaType}`,
+          );
+        }
+        break;
+      }
+      case "skill": {
+        const id = assertString(item.id, `input[${index}].id`);
+        const name = assertString(item.name, `input[${index}].name`);
+        if (
+          !resolvedSkills.some(
+            (skill) => skill.id === id && skill.name === name,
+          )
+        ) {
+          throw new Error(`Unresolved structured agent skill: ${id}`);
+        }
+        break;
+      }
+      case "integration": {
+        const id = assertString(item.id, `input[${index}].id`);
+        const providerKey = assertString(
+          item.providerKey,
+          `input[${index}].providerKey`,
+        );
+        if (
+          !resolvedIntegrations.some(
+            (integration) =>
+              integration.id === id && integration.providerKey === providerKey,
+          )
+        ) {
+          throw new Error(`Unresolved structured agent integration: ${id}`);
+        }
+        break;
+      }
+      case "reference":
+        if (
+          !resolvedReferences.some(
+            (reference) =>
+              reference.id === assertString(item.id, `input[${index}].id`) &&
+              reference.referenceKind ===
+                assertString(
+                  item.referenceKind,
+                  `input[${index}].referenceKind`,
+                ) &&
+              reference.targetId ===
+                assertString(item.targetId, `input[${index}].targetId`),
+          )
+        ) {
+          throw new Error(
+            `Unresolved structured agent reference: ${String(item.id)}`,
+          );
+        }
+        break;
+      case "extension": {
+        assertString(item.id, `input[${index}].id`);
+        const key = `${assertString(item.namespace, `input[${index}].namespace`)}/${assertString(item.name, `input[${index}].name`)}`;
+        if (!Number.isSafeInteger(item.version) || Number(item.version) < 1) {
+          throw new Error(
+            `Invalid structured agent input: input[${index}].version must be a positive integer`,
+          );
+        }
+        if (!isRecord(item.payload) || hasForbiddenSecretKey(item.payload)) {
+          throw new Error(
+            `Invalid structured agent input: input[${index}].payload must be secret-free JSON`,
+          );
+        }
+        const versions = value.execution.extensionVersions;
+        if (!isRecord(versions) || versions[key] !== item.version) {
+          throw new Error(
+            `Unsupported structured agent input extension: ${key}@${String(item.version)}`,
+          );
+        }
+        break;
+      }
+      default:
+        throw new Error(
+          `Unsupported structured agent input type: ${String(item.type)}`,
+        );
+    }
+  }
+
+  for (const [index, capability] of value.capabilities.entries()) {
+    if (!isRecord(capability)) {
+      throw new Error(
+        `Invalid structured agent input: capabilities[${index}] must be an object`,
+      );
+    }
+    const key = assertString(capability.key, `capabilities[${index}].key`);
+    if (typeof capability.enabled !== "boolean") {
+      throw new Error(
+        `Invalid structured agent input: capabilities[${index}].enabled must be boolean`,
+      );
+    }
+    if (capability.enabled && !resolvedCapabilityKeys.includes(key)) {
+      throw new Error(`Unresolved structured agent capability: ${key}`);
+    }
+  }
+
+  const hasSemanticInput = value.input.some(
+    (item) => isRecord(item) && item.type !== "text",
+  );
+  if (
+    (hasSemanticInput || value.capabilities.length > 0) &&
+    value.execution.resolvedBy !== "server"
+  ) {
+    throw new Error(
+      "Invalid structured agent input: semantic inputs require server-resolved execution",
+    );
+  }
+
+  return value as unknown as AgentTurnInputV1;
+};
+
+export const compileAgentTurnInput = (
+  turn: AgentTurnInputV1,
+): CompiledRunnerInput => {
+  const parsed = parseAgentTurnInputV1(turn);
+  const text: string[] = [];
+  const images: RunnerImageInput[] = [];
+
+  for (const item of parsed.input) {
+    switch (item.type) {
+      case "text":
+        text.push(item.text);
+        break;
+      case "asset":
+        images.push({
+          id: item.id,
+          label: item.label,
+          mediaType: item.asset.mediaType,
+          data: item.asset.data,
+          filename: item.asset.filename,
+        });
+        break;
+      case "skill":
+      case "integration":
+        break;
+      case "reference":
+        text.push(item.label ?? `[${item.referenceKind}: ${item.targetId}]`);
+        break;
+      case "extension":
+        throw new Error(
+          `Runner adapter does not support extension ${item.namespace}/${item.name}@${item.version}`,
+        );
+    }
+  }
+
+  return { text: text.join(""), images };
+};
+
+export const createLegacyAgentTurnInput = (
+  userInput: string,
+): AgentTurnInputV1 => ({
+  version: 1,
+  input: [{ type: "text", text: userInput }],
+  capabilities: [],
+  execution: {},
+});
+
+export const isSemanticAgentTurnInput = (turn: AgentTurnInputV1): boolean =>
+  turn.input.some((item) => item.type !== "text") ||
+  turn.capabilities.length > 0;

--- a/packages/manager/src/bunny-agent.ts
+++ b/packages/manager/src/bunny-agent.ts
@@ -1,3 +1,4 @@
+import { compileAgentTurnInput } from "./agent-input.js";
 import type {
   BunnyAgentOptions,
   Message,
@@ -110,7 +111,9 @@ export class BunnyAgent {
       .filter((m): m is Message & { role: "user" } => m.role === "user")
       .pop();
 
-    if (lastUserMessage) {
+    if (input.input) {
+      cmd.push(compileAgentTurnInput(input.input).text || "[Structured input]");
+    } else if (lastUserMessage) {
       cmd.push(
         typeof lastUserMessage.content === "string"
           ? lastUserMessage.content
@@ -174,6 +177,15 @@ export class BunnyAgent {
     // One-shot payloads are consumed and deleted by runner-cli before runner
     // startup so tokens and headers cannot leak into bash child processes.
     const runnerPayloadEnv: Record<string, string> = {};
+    if (input.input) {
+      const payload = JSON.stringify(input.input);
+      if (Buffer.byteLength(payload, "utf8") > 20 * 1024 * 1024) {
+        throw new Error(
+          "Structured agent input payload exceeds the 20 MiB limit",
+        );
+      }
+      runnerPayloadEnv.BUNNY_AGENT_INPUT_JSON = payload;
+    }
     if (input.toolRefs && input.toolRefs.length > 0) {
       runnerPayloadEnv.BUNNY_AGENT_TOOL_REFS_JSON = JSON.stringify({
         tools: input.toolRefs,

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./agent-input.js";
 export { BunnyAgent } from "./bunny-agent.js";
 export type { DaemonCodingRunExecParams } from "./coding-run.js";
 export {

--- a/packages/manager/src/types.ts
+++ b/packages/manager/src/types.ts
@@ -1,3 +1,5 @@
+import type { AgentTurnInputV1 } from "./agent-input.js";
+
 /**
  * Volume info (for backends that support persistent volumes)
  */
@@ -117,7 +119,10 @@ export interface McpConfig {
 export interface BunnyAgentCodingRunBody {
   runner?: string;
   model?: string;
-  userInput: string;
+  /** Versioned structured input. Preferred over userInput when present. */
+  input?: AgentTurnInputV1;
+  /** Text-only compatibility fallback for older clients. */
+  userInput?: string;
   systemPrompt?: string;
   maxTurns?: number;
   allowedTools?: string[];
@@ -342,6 +347,8 @@ export interface Message {
 export interface StreamInput {
   /** Messages to send to the agent */
   messages: Message[];
+  /** Versioned structured input for the current turn. */
+  input?: AgentTurnInputV1;
   /** Workspace configuration */
   workspace?: {
     /** Path to the workspace directory */

--- a/packages/runner-claude/package.json
+++ b/packages/runner-claude/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.3.215",
     "@anthropic-ai/sdk": "0.112.3",
+    "@bunny-agent/manager": "workspace:*",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -22,6 +22,10 @@ import type {
   SDKUserMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import {
+  type AgentTurnInputV1,
+  compileAgentTurnInput,
+} from "@bunny-agent/manager";
+import {
   convertUsageToAISDK,
   formatDataStream,
   generateId,
@@ -78,31 +82,13 @@ export interface ClaudeRunnerOptions extends BaseRunnerOptions {
 /**
  * Build a regular user message (not a tool result)
  */
-export function buildUserMessage(userInput: string): SDKUserMessage {
-  // If userInput is a serialized JSON array (from BunnyAgent manager for multi-part messages)
-  // Claude Agent SDK allows content to be string or array of blocks.
-  // Let's decode it safely.
-  let parsedContent: string | Array<Record<string, unknown>> = userInput;
-  try {
-    if (userInput.startsWith("[") && userInput.endsWith("]")) {
-      const parsed = JSON.parse(userInput);
-      if (Array.isArray(parsed)) {
-        // Claude SDK UserMessage allows arrays of ContentBlock
-        // Convert to Claude's format if it contains images
-        parsedContent = parsed.map((p) => {
-          if (p.type === "text") return { type: "text", text: p.text };
-          if (p.type === "image")
-            return {
-              type: "image",
-              source: { type: "base64", media_type: p.mimeType, data: p.data },
-            };
-          return { type: "text", text: JSON.stringify(p) };
-        });
-      }
-    }
-  } catch (_e) {
-    // Fallback to string
-  }
+export function buildUserMessage(
+  userInput: string | AgentTurnInputV1,
+): SDKUserMessage {
+  const parsedContent =
+    typeof userInput === "string"
+      ? userInput
+      : buildStructuredClaudeContent(userInput);
 
   return {
     type: "user",
@@ -113,11 +99,33 @@ export function buildUserMessage(userInput: string): SDKUserMessage {
   } as SDKUserMessage;
 }
 
+function buildStructuredClaudeContent(
+  input: AgentTurnInputV1,
+): Array<Record<string, unknown>> {
+  const compiled = compileAgentTurnInput(input);
+  const content: Array<Record<string, unknown>> = [];
+  for (const image of compiled.images) {
+    content.push({ type: "text", text: image.label });
+    content.push({
+      type: "image",
+      source: {
+        type: "base64",
+        media_type: image.mediaType,
+        data: image.data,
+      },
+    });
+  }
+  if (compiled.text.length > 0) {
+    content.push({ type: "text", text: compiled.text });
+  }
+  return content;
+}
+
 /**
  * Build an AsyncIterable<SDKUserMessage> from options
  */
 export async function* buildSDKUserMessageIterable(
-  userInput: string,
+  userInput: string | AgentTurnInputV1,
 ): AsyncIterable<SDKUserMessage> {
   yield buildUserMessage(userInput);
 }
@@ -132,7 +140,7 @@ export interface ClaudeRunner {
    * @param signal - Optional AbortSignal for cancelling the operation
    * @returns An async iterable of AI SDK UI message chunks
    */
-  run(userInput: string): AsyncIterable<string>;
+  run(userInput: string | AgentTurnInputV1): AsyncIterable<string>;
 }
 
 /**
@@ -306,7 +314,7 @@ export function hasClaudeAuth(): boolean {
  */
 export function createClaudeRunner(options: ClaudeRunnerOptions): ClaudeRunner {
   return {
-    async *run(userInput: string): AsyncIterable<string> {
+    async *run(userInput: string | AgentTurnInputV1): AsyncIterable<string> {
       // Check for API key or Bedrock proxy config
       if (!hasClaudeAuth()) {
         console.error(
@@ -319,7 +327,9 @@ export function createClaudeRunner(options: ClaudeRunnerOptions): ClaudeRunner {
 
         yield* runMockAgent(
           options,
-          userInput,
+          typeof userInput === "string"
+            ? userInput
+            : compileAgentTurnInput(userInput).text,
           options.abortController?.signal,
         );
         return;
@@ -330,7 +340,13 @@ export function createClaudeRunner(options: ClaudeRunnerOptions): ClaudeRunner {
 
       if (sdk) {
         // Use the real Claude Agent SDK
-        yield* runWithClaudeAgentSDK(sdk, options, userInput);
+        yield* runWithClaudeAgentSDK(
+          sdk,
+          options,
+          typeof userInput === "string"
+            ? userInput
+            : buildSDKUserMessageIterable(userInput),
+        );
       } else {
         // Fallback to mock implementation
         console.error(
@@ -339,7 +355,9 @@ export function createClaudeRunner(options: ClaudeRunnerOptions): ClaudeRunner {
         );
         yield* runMockAgent(
           options,
-          userInput,
+          typeof userInput === "string"
+            ? userInput
+            : compileAgentTurnInput(userInput).text,
           options.abortController?.signal,
         );
       }

--- a/packages/runner-claude/src/structured-input.test.ts
+++ b/packages/runner-claude/src/structured-input.test.ts
@@ -1,0 +1,48 @@
+import type { AgentTurnInputV1 } from "@bunny-agent/manager";
+import { describe, expect, it } from "vitest";
+import { buildUserMessage } from "./claude-runner.js";
+
+describe("Claude structured input", () => {
+  it("submits labeled images before the labeled text projection", () => {
+    const input: AgentTurnInputV1 = {
+      version: 1,
+      input: [
+        {
+          type: "asset",
+          id: "one",
+          label: "[Image #1]",
+          asset: { mediaType: "image/png", data: "b25l" },
+        },
+        {
+          type: "asset",
+          id: "two",
+          label: "[Image #2]",
+          asset: { mediaType: "image/jpeg", data: "dHdv" },
+        },
+        { type: "text", text: "A [Image #1] B [Image #2] C" },
+      ],
+      capabilities: [],
+      execution: { resolvedBy: "server" },
+    };
+
+    const message = buildUserMessage(input);
+    expect(message.message.content).toEqual([
+      { type: "text", text: "[Image #1]" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/png", data: "b25l" },
+      },
+      { type: "text", text: "[Image #2]" },
+      {
+        type: "image",
+        source: { type: "base64", media_type: "image/jpeg", data: "dHdv" },
+      },
+      { type: "text", text: "A [Image #1] B [Image #2] C" },
+    ]);
+  });
+
+  it("does not parse JSON-looking text as provider blocks", () => {
+    const text = '[{"type":"image","data":"forged"}]';
+    expect(buildUserMessage(text).message.content).toBe(text);
+  });
+});

--- a/packages/runner-harness/package.json
+++ b/packages/runner-harness/package.json
@@ -27,6 +27,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@bunny-agent/manager": "workspace:*",
     "ai": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/runner-harness/src/__tests__/runner-dispatch.test.ts
+++ b/packages/runner-harness/src/__tests__/runner-dispatch.test.ts
@@ -1,3 +1,4 @@
+import type { AgentTurnInputV1 } from "@bunny-agent/manager";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createRunner, type RunnerToolRef } from "../runner.js";
 
@@ -70,5 +71,40 @@ describe("createRunner dispatch", () => {
     expect(opts.toolRefs).toEqual(toolRefs);
     expect(opts.skillPaths).toEqual(["/tmp/skills/foo"]);
     expect(piRun).toHaveBeenCalledWith("hi");
+  });
+
+  it("passes structured image input to Claude and Pi without stringifying", () => {
+    const input: AgentTurnInputV1 = {
+      version: 1,
+      input: [
+        {
+          type: "asset",
+          id: "asset-1",
+          label: "[Image #1]",
+          asset: { mediaType: "image/png", data: "aW1hZ2U=" },
+        },
+        { type: "text", text: "Inspect [Image #1]" },
+      ],
+      capabilities: [],
+      execution: { resolvedBy: "server" },
+    };
+
+    createRunner({
+      runner: "claude",
+      model: "claude-sonnet-4-20250514",
+      input,
+      cwd: "/tmp",
+      autoInject: false,
+    });
+    createRunner({
+      runner: "pi",
+      model: "gpt-5",
+      input,
+      cwd: "/tmp",
+      autoInject: false,
+    });
+
+    expect(claudeRun).toHaveBeenCalledWith(input);
+    expect(piRun).toHaveBeenCalledWith(input);
   });
 });

--- a/packages/runner-harness/src/runner.ts
+++ b/packages/runner-harness/src/runner.ts
@@ -1,3 +1,9 @@
+import {
+  type AgentTurnInputV1,
+  compileAgentTurnInput,
+  createLegacyAgentTurnInput,
+  parseAgentTurnInputV1,
+} from "@bunny-agent/manager";
 import type { BaseRunnerOptions } from "@bunny-agent/runner-claude";
 import { createClaudeRunner } from "@bunny-agent/runner-claude";
 import { createCodexRunner } from "@bunny-agent/runner-codex";
@@ -24,7 +30,10 @@ export interface RunnerToolRef {
 
 export interface RunnerCoreOptions extends BaseRunnerOptions {
   runner: string;
-  userInput: string;
+  /** Versioned structured input. Preferred over userInput when present. */
+  input?: AgentTurnInputV1;
+  /** Text-only compatibility input. */
+  userInput?: string;
   skillPaths?: string[];
   cwd?: string;
   env?: Record<string, string>;
@@ -99,7 +108,10 @@ export function createRunner(
     abortController,
   };
 
-  const rawStream = dispatchRunner(options.runner, base, cwd, options);
+  const input = options.input
+    ? parseAgentTurnInputV1(options.input)
+    : createLegacyAgentTurnInput(options.userInput ?? "");
+  const rawStream = dispatchRunner(options.runner, base, cwd, options, input);
   return autoInject ? captureSessionId(rawStream, cwd) : rawStream;
 }
 
@@ -111,8 +123,11 @@ function dispatchRunner(
   },
   cwd: string,
   options: RunnerCoreOptions,
+  input: AgentTurnInputV1,
 ): AsyncIterable<string> {
   const _env = base.env;
+  const compiled = compileAgentTurnInput(input);
+  const hasStructuredInput = options.input !== undefined;
   switch (runner) {
     case "claude":
       return createClaudeRunner({
@@ -121,11 +136,14 @@ function dispatchRunner(
         forkFrom: options.forkFrom,
         skillPaths: options.skillPaths ?? discoverSkillPaths(cwd),
         toolRefs: options.toolRefs,
-      }).run(options.userInput);
+      }).run(hasStructuredInput ? input : compiled.text);
     case "codex": {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { outputFormat: _of, ...codexBase } = base;
       const codexEfforts = ["minimal", "low", "medium", "high", "xhigh"];
+      if (compiled.images.length > 0) {
+        throw new Error("Runner codex does not support structured image input");
+      }
       return createCodexRunner({
         ...codexBase,
         cwd,
@@ -135,9 +153,14 @@ function dispatchRunner(
                 options.effort as import("@bunny-agent/runner-codex").CodexRunnerOptions["modelReasoningEffort"],
             }
           : {}),
-      }).run(options.userInput);
+      }).run(compiled.text);
     }
     case "gemini":
+      if (compiled.images.length > 0) {
+        throw new Error(
+          "Runner gemini does not support structured image input",
+        );
+      }
       return createGeminiRunner({
         model: options.model,
         cwd,
@@ -146,7 +169,7 @@ function dispatchRunner(
         systemPrompt: base.systemPrompt,
         resume: base.resume,
         yolo: base.yolo,
-      }).run(options.userInput);
+      }).run(compiled.text);
     case "pi": {
       return createPiRunner({
         ...base,
@@ -158,9 +181,14 @@ function dispatchRunner(
         mcpConfig: options.mcpConfig,
         effort: options.effort,
         systemEnv: options.systemEnv,
-      }).run(options.userInput);
+      }).run(hasStructuredInput ? input : compiled.text);
     }
     case "opencode":
+      if (compiled.images.length > 0) {
+        throw new Error(
+          "Runner opencode does not support structured image input",
+        );
+      }
       return createOpenCodeRunner({
         model: options.model,
         cwd,
@@ -169,9 +197,14 @@ function dispatchRunner(
         systemPrompt: base.systemPrompt,
         resume: base.resume,
         yolo: base.yolo,
-      }).run(options.userInput);
+      }).run(compiled.text);
     case "copilot": {
       const reasoningEfforts = ["low", "medium", "high", "xhigh"];
+      if (compiled.images.length > 0) {
+        throw new Error(
+          "Runner copilot does not support structured image input",
+        );
+      }
       return createCopilotRunner({
         model: options.model,
         systemPrompt: base.systemPrompt,
@@ -187,7 +220,7 @@ function dispatchRunner(
                 options.effort as import("@bunny-agent/runner-copilot").CopilotReasoningEffort,
             }
           : {}),
-      }).run(options.userInput);
+      }).run(compiled.text);
     }
     default:
       throw new Error(`Unknown runner: ${runner}`);

--- a/packages/runner-pi/package.json
+++ b/packages/runner-pi/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@bunny-agent/apply-patch": "workspace:*",
+    "@bunny-agent/manager": "workspace:*",
     "@earendil-works/pi-agent-core": "0.80.10",
     "@earendil-works/pi-ai": "0.80.10",
     "@earendil-works/pi-coding-agent": "0.80.10",

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -1,3 +1,4 @@
+import type { AgentTurnInputV1 } from "@bunny-agent/manager";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // ── Mock session that drives the event loop ──────────────────────────
@@ -9,6 +10,8 @@ class MockSession {
   sessionId = "mock-session-id";
   extensionRunner = { emit: vi.fn().mockResolvedValue(undefined) };
   hasExtensionHandlers = vi.fn().mockReturnValue(false);
+  lastPrompt: string | undefined;
+  lastPromptOptions: unknown;
   private listeners: Listener[] = [];
   private behavior:
     | "normal"
@@ -37,7 +40,9 @@ class MockSession {
     this.behavior = behavior;
   }
 
-  async prompt(_userInput: string): Promise<void> {
+  async prompt(userInput: string, options?: unknown): Promise<void> {
+    this.lastPrompt = userInput;
+    this.lastPromptOptions = options;
     if (this.behavior === "pending") {
       return new Promise(() => {
         // Keep pending forever so the abort test can fire.
@@ -472,6 +477,33 @@ describe("createPiRunner", () => {
     ).toBe(true);
     expect(chunks.some((c) => c.includes('"type":"finish"'))).toBe(true);
     expect(chunks.some((c) => c.includes("[DONE]"))).toBe(true);
+  });
+
+  it("passes labeled image data through Pi prompt options", async () => {
+    const input: AgentTurnInputV1 = {
+      version: 1,
+      input: [
+        {
+          type: "asset",
+          id: "asset-1",
+          label: "[Image #1]",
+          asset: { mediaType: "image/png", data: "aW1hZ2U=" },
+        },
+        { type: "text", text: "Before [Image #1] after" },
+      ],
+      capabilities: [],
+      execution: { resolvedBy: "server" },
+    };
+    const runner = createPiRunner({ model: "google:gemini-2.5-pro" });
+
+    for await (const _chunk of runner.run(input)) {
+      // Drain the stream so the prompt completes.
+    }
+
+    expect(createdSessions[0].lastPrompt).toBe("Before [Image #1] after");
+    expect(createdSessions[0].lastPromptOptions).toEqual({
+      images: [{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" }],
+    });
   });
 
   it("emits web_search billing metadata on tool output and finish", async () => {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -1,7 +1,11 @@
 import { appendFileSync, existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
+import {
+  type AgentTurnInputV1,
+  compileAgentTurnInput,
+} from "@bunny-agent/manager";
 import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, ImageContent, Model } from "@earendil-works/pi-ai";
 import { getBuiltinModel } from "@earendil-works/pi-ai/providers/all";
 import {
   type AgentSession,
@@ -113,7 +117,7 @@ export interface PiRunnerOptions {
 }
 
 export interface PiRunner {
-  run(userInput: string): AsyncIterable<string>;
+  run(userInput: string | AgentTurnInputV1): AsyncIterable<string>;
 }
 
 export async function disposePiSession(
@@ -388,7 +392,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
     : undefined;
 
   return {
-    async *run(userInput: string): AsyncIterable<string> {
+    async *run(userInput: string | AgentTurnInputV1): AsyncIterable<string> {
       const modelRuntime = await ModelRuntime.create({
         modelsPath: null,
         allowModelNetwork: false,
@@ -659,8 +663,18 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
         try {
           traceRawMessage(cwd, null, true, options.env);
 
-          const promptText = userInput;
-          const promptPromise = session.prompt(promptText);
+          const compiled =
+            typeof userInput === "string"
+              ? { text: userInput, images: [] }
+              : compileAgentTurnInput(userInput);
+          const images: ImageContent[] = compiled.images.map((image) => ({
+            type: "image",
+            data: image.data,
+            mimeType: image.mediaType,
+          }));
+          const promptPromise = session.prompt(compiled.text, {
+            images: images.length > 0 ? images : undefined,
+          });
           void promptPromise.then(
             () => {
               promptSettled = true;

--- a/packages/sdk/src/__tests__/structured-agent-input.test.ts
+++ b/packages/sdk/src/__tests__/structured-agent-input.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { compileMessagesToAgentInput } from "../provider/bunny-agent-language-model";
+
+describe("AI SDK structured agent input", () => {
+  it("keeps prose and two image labels associated in source order", async () => {
+    const turn = await compileMessagesToAgentInput(
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "before " },
+            {
+              type: "image",
+              mimeType: "image/png",
+              data: "data:image/png;base64,b25l",
+            },
+            { type: "text", text: " between " },
+            {
+              type: "image",
+              mimeType: "image/jpeg",
+              data: "data:image/jpeg;base64,dHdv",
+            },
+            { type: "text", text: " after" },
+          ],
+        },
+      ],
+      false,
+    );
+
+    expect(turn.input).toEqual([
+      {
+        type: "asset",
+        id: "image-1",
+        label: "[Image #1]",
+        asset: { mediaType: "image/png", data: "b25l" },
+      },
+      {
+        type: "asset",
+        id: "image-2",
+        label: "[Image #2]",
+        asset: { mediaType: "image/jpeg", data: "dHdv" },
+      },
+      {
+        type: "text",
+        text: "before [Image #1] between [Image #2] after",
+      },
+    ]);
+  });
+
+  it("retains prior text and images only for fresh sessions", async () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          { type: "image" as const, mimeType: "image/png", data: "b2xk" },
+          { type: "text" as const, text: " old" },
+        ],
+      },
+      { role: "assistant" as const, content: "answer" },
+      { role: "user" as const, content: "new" },
+    ];
+
+    const fresh = await compileMessagesToAgentInput(messages, true);
+    const resumed = await compileMessagesToAgentInput(messages, false);
+    expect(fresh.input.some((part) => part.type === "asset")).toBe(true);
+    expect(resumed.input).toEqual([{ type: "text", text: "new" }]);
+  });
+
+  it("does not duplicate a composer-provided frozen image label", async () => {
+    const turn = await compileMessagesToAgentInput(
+      [
+        {
+          role: "user",
+          content: [
+            { type: "text", text: "before [Image #1]" },
+            { type: "image", mimeType: "image/png", data: "b25l" },
+            { type: "text", text: " after" },
+          ],
+        },
+      ],
+      false,
+    );
+
+    expect(turn.input.at(-1)).toEqual({
+      type: "text",
+      text: "before [Image #1] after",
+    });
+  });
+});

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -13,6 +13,7 @@ import type {
   SharedV3Warning,
 } from "@ai-sdk/provider";
 import {
+  type AgentTurnInputV1,
   BunnyAgent,
   type BunnyAgentCodingRunBody,
   type Message,
@@ -98,83 +99,108 @@ function mergeToolRefs(
   return merged.length > 0 ? merged : undefined;
 }
 
-function extractTextContent(content: Message["content"]): string {
-  if (typeof content === "string") return content;
-  return content
-    .filter((p): p is { type: "text"; text: string } => p.type === "text")
-    .map((p) => p.text)
-    .join("\n");
+function getCurrentTurnStart(messages: Message[]): number {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role !== "user") return i + 1;
+  }
+  return 0;
 }
 
-function getLastUserTextFromMessages(messages: Message[]): string {
-  // Collect all trailing user messages (handles batched/queued messages)
-  const trailingUserMessages: Message[] = [];
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
-      trailingUserMessages.unshift(messages[i]);
-    } else {
-      break;
-    }
+async function resolveImageData(
+  data: string,
+  declaredMediaType: string,
+): Promise<{ data: string; mediaType: string }> {
+  if (!declaredMediaType.startsWith("image/")) {
+    throw new Error(
+      `Unsupported BunnyAgent file media type: ${declaredMediaType}`,
+    );
   }
-  if (trailingUserMessages.length === 0) return "";
-  return trailingUserMessages
-    .map((msg) => extractTextContent(msg.content))
-    .join("\n\n");
+  const dataUrl = /^data:([^;,]+);base64,(.+)$/s.exec(data);
+  if (dataUrl) {
+    if (!dataUrl[1].startsWith("image/")) {
+      throw new Error(
+        `Unsupported BunnyAgent data URL media type: ${dataUrl[1]}`,
+      );
+    }
+    return { mediaType: dataUrl[1], data: dataUrl[2] };
+  }
+  if (/^https?:\/\//i.test(data)) {
+    const response = await fetch(data, { redirect: "follow" });
+    if (!response.ok) {
+      throw new Error(
+        `Unable to fetch BunnyAgent image: HTTP ${response.status}`,
+      );
+    }
+    const contentLength = Number(response.headers.get("content-length") ?? 0);
+    if (contentLength > 20 * 1024 * 1024) {
+      throw new Error("BunnyAgent image exceeds the 20 MiB limit");
+    }
+    const mediaType =
+      response.headers.get("content-type")?.split(";")[0] ?? declaredMediaType;
+    if (!mediaType.startsWith("image/")) {
+      throw new Error(`Fetched BunnyAgent asset is not an image: ${mediaType}`);
+    }
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    if (bytes.byteLength > 20 * 1024 * 1024) {
+      throw new Error("BunnyAgent image exceeds the 20 MiB limit");
+    }
+    return { mediaType, data: Buffer.from(bytes).toString("base64") };
+  }
+  return { mediaType: declaredMediaType, data };
 }
 
-/**
- * Serialize the full transcript into a single userInput string.
- *
- * Used when the runtime has no session context to hydrate from — i.e. neither
- * `resume` (existing runner session id) nor `forkFrom` (parent session to
- * snapshot-clone) is set. In that case the runner starts a brand-new session
- * whose only visible input is the `userInput` payload; if we passed only the
- * last user turn the runner would lose all prior conversation, which is what
- * happened when share-continued fallback sessions arrived at pi with just
- * the current question instead of the copied `agent_messages` history.
- *
- * Format: prior turns labeled by role, then the current user message under
- * a "Current message" header so the runner treats it as the actual prompt.
- */
-function serializeMessagesToUserInput(messages: Message[]): string {
-  // Split trailing consecutive user messages (the "current" turn) from history.
-  let currentStart = messages.length;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "user") {
-      currentStart = i;
-    } else {
-      break;
+export async function compileMessagesToAgentInput(
+  messages: Message[],
+  includeHistory: boolean,
+): Promise<AgentTurnInputV1> {
+  const selected = includeHistory
+    ? messages
+    : messages.slice(getCurrentTurnStart(messages));
+  const text: string[] = [];
+  const assets: AgentTurnInputV1["input"] = [];
+  let imageNumber = 0;
+
+  for (const message of selected) {
+    if (includeHistory) {
+      const role = message.role[0].toUpperCase() + message.role.slice(1);
+      text.push(`${role}: `);
     }
+    const parts =
+      typeof message.content === "string"
+        ? [{ type: "text" as const, text: message.content }]
+        : message.content;
+    for (const part of parts) {
+      if (part.type === "text") {
+        text.push(part.text);
+        continue;
+      }
+      imageNumber += 1;
+      const label = `[Image #${imageNumber}]`;
+      const resolved = await resolveImageData(part.data, part.mimeType);
+      if (!text.join("").endsWith(label)) text.push(label);
+      assets.push({
+        type: "asset",
+        id: `image-${imageNumber}`,
+        label,
+        asset: resolved,
+      });
+    }
+    text.push("\n\n");
   }
 
-  const history = messages.slice(0, currentStart);
-  const current = messages.slice(currentStart);
-
-  const currentText = current
-    .map((msg) => extractTextContent(msg.content))
-    .filter((t) => t.length > 0)
-    .join("\n\n");
-
-  if (history.length === 0) return currentText;
-
-  const historyLines: string[] = [];
-  for (const msg of history) {
-    const text = extractTextContent(msg.content);
-    if (text.length === 0) continue;
-    const label =
-      msg.role === "user"
-        ? "User"
-        : msg.role === "assistant"
-          ? "Assistant"
-          : "System";
-    historyLines.push(`${label}: ${text}`);
-  }
-
-  if (historyLines.length === 0) return currentText;
-
-  const historyBlock = `Previous conversation:\n\n${historyLines.join("\n\n")}`;
-  if (currentText.length === 0) return historyBlock;
-  return `${historyBlock}\n\nCurrent message:\n\n${currentText}`;
+  return {
+    version: 1,
+    input: [...assets, { type: "text", text: text.join("").trimEnd() }],
+    capabilities: [],
+    execution: {
+      resolvedBy: "server",
+      skills: [],
+      integrations: [],
+      references: [],
+      capabilityKeys: [],
+      extensionVersions: {},
+    },
+  };
 }
 
 function createEmptyUsage(): LanguageModelV3Usage {
@@ -415,7 +441,11 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
       const sandboxEnv = sandbox.getEnv?.() ?? {};
       const runnerEnv = { ...sandboxEnv, ...this.options.env };
       const body: BunnyAgentCodingRunBody = {
-        ...this.buildCodingRunBody(messages, handle.getWorkdir(), toolRefs),
+        ...(await this.buildCodingRunBody(
+          messages,
+          handle.getWorkdir(),
+          toolRefs,
+        )),
         ...(Object.keys(runnerEnv).length > 0 ? { env: runnerEnv } : {}),
         ...(this.options.systemEnv &&
         Object.keys(this.options.systemEnv).length > 0
@@ -456,8 +486,13 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
     });
 
     try {
+      const input = await compileMessagesToAgentInput(
+        messages,
+        !(this.options.resume ?? this.options.forkFrom),
+      );
       const bytesStream = await agent.stream({
         messages,
+        input,
         workspace: {
           path: sandboxWorkdir,
         },
@@ -514,30 +549,26 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
     ];
   }
 
-  private buildCodingRunBody(
+  private async buildCodingRunBody(
     messages: Message[],
     cwdFallback: string,
     toolRefs: ToolRef[] | undefined,
-  ): BunnyAgentCodingRunBody {
+  ): Promise<BunnyAgentCodingRunBody> {
     const runner = this.options.runner;
     const cwd = this.options.cwd ?? cwdFallback;
 
-    // When the runner has session context to hydrate from (resume points at
-    // an existing runner session, or forkFrom snapshot-clones a parent), send
-    // only the last user turn — history lives in the runner's session file.
-    // Otherwise it's a fresh session with no server-side history, so serialize
-    // the full transcript into userInput so the runner sees prior turns.
     const hasRuntimeHistory = Boolean(
       this.options.resume ?? this.options.forkFrom,
     );
-    const userInput = hasRuntimeHistory
-      ? getLastUserTextFromMessages(messages)
-      : serializeMessagesToUserInput(messages);
+    const input = await compileMessagesToAgentInput(
+      messages,
+      !hasRuntimeHistory,
+    );
 
     return {
       runner: runner.runnerType ?? "claude",
       model: this.modelId,
-      userInput,
+      input,
       cwd,
       resume: this.options.resume,
       forkFrom: this.options.forkFrom,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       '@bunny-agent/apply-patch':
         specifier: workspace:*
         version: link:../../packages/apply-patch
+      '@bunny-agent/manager':
+        specifier: workspace:*
+        version: link:../../packages/manager
       '@bunny-agent/runner-claude':
         specifier: workspace:*
         version: link:../../packages/runner-claude
@@ -577,6 +580,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: 0.112.3
         version: 0.112.3(zod@4.3.6)
+      '@bunny-agent/manager':
+        specifier: workspace:*
+        version: link:../manager
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -641,6 +647,9 @@ importers:
 
   packages/runner-harness:
     dependencies:
+      '@bunny-agent/manager':
+        specifier: workspace:*
+        version: link:../manager
       '@bunny-agent/runner-claude':
         specifier: workspace:*
         version: link:../runner-claude
@@ -694,6 +703,9 @@ importers:
       '@bunny-agent/apply-patch':
         specifier: workspace:*
         version: link:../apply-patch
+      '@bunny-agent/manager':
+        specifier: workspace:*
+        version: link:../manager
       '@earendil-works/pi-agent-core':
         specifier: 0.80.10
         version: 0.80.10(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.19.0)(zod@4.3.6)


### PR DESCRIPTION
## Summary

- Introduce versioned `AgentTurnInputV1` protocol alongside legacy `userInput` text fallback
- Add strict parsing and negotiation for typed text, image, skill, integration, reference, capability, and extension inputs
- Add secret rejection for execution context, extension payloads, and display snapshots
- Add Claude labeled image blocks and Pi `message + images` delivery
- Add Vercel AI SDK conversion with `[Image #N]` label freezing and URL/data-URL image resolution
- Unsupported runner/image and extension combinations now fail before execution instead of silently degrading

## Compatibility

`userInput` remains accepted for one release. Consumers should migrate to `AgentTurnInputV1` before the fallback is removed.

## Test plan

- [ ] Manager: protocol validation, image order, resume behavior
- [ ] Daemon & CLI: structured transport, one-shot env payload cleanup
- [ ] Runner harness: unsupported input rejection
- [ ] Claude runner: labeled image blocks
- [ ] Pi runner: message + images delivery
- [ ] SDK: Vercel AI SDK conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)