### PR TITLE
fix(runner-pi): align ask user question tool name

### DIFF
--- a/docs/changelog/2026-08-06-ask-user-question-tool-name.md
+++ b/docs/changelog/2026-08-06-ask-user-question-tool-name.md
@@ -7,11 +7,15 @@ Date: 2026-08-06
 - Registered Pi's interactive question tool with the canonical `ask_user_question` name used by product allowlists and prompts.
 - Normalized the legacy `AskUserQuestion` allowlist name for backward compatibility.
 - Preserved legacy approval-file recognition so historical CamelCase tool calls still expose their questions.
+- Returned the submitted answers with an explicit instruction to continue the original task and produce a visible response instead of ending on an empty assistant message.
+- Kept the structured questions and answers in the tool-result details for runtime consumers.
 - Added focused regression coverage for canonical registration and legacy compatibility.
 
 ## Why
 
 Pi activates custom tools by exact allowlist name. Products such as Buda allowed `ask_user_question`, while the Pi runner registered `AskUserQuestion`, so the tool was registered but inactive and the model reported that it was unavailable.
+
+After the name mismatch was fixed, some providers consumed the answer but ended the resumed turn with an empty assistant message. The tool result now makes the continuation contract explicit while preserving the structured answer payload.
 
 ## Verification
 

--- a/docs/changelog/2026-08-06-ask-user-question-tool-name.md
+++ b/docs/changelog/2026-08-06-ask-user-question-tool-name.md
@@ -1,0 +1,19 @@
+# Ask User Question Tool Name Alignment
+
+Date: 2026-08-06
+
+## What Changed
+
+- Registered Pi's interactive question tool with the canonical `ask_user_question` name used by product allowlists and prompts.
+- Normalized the legacy `AskUserQuestion` allowlist name for backward compatibility.
+- Preserved legacy approval-file recognition so historical CamelCase tool calls still expose their questions.
+- Added focused regression coverage for canonical registration and legacy compatibility.
+
+## Why
+
+Pi activates custom tools by exact allowlist name. Products such as Buda allowed `ask_user_question`, while the Pi runner registered `AskUserQuestion`, so the tool was registered but inactive and the model reported that it was unavailable.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/runner-pi exec vitest run src/__tests__/pi-runner.test.ts src/__tests__/tool-approval.test.ts` passed with 58 tests.
+- Linting and typechecking were intentionally skipped for PR publication at the user's request.

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -941,6 +941,55 @@ describe("createPiRunner", () => {
     expect(callArgs?.tools).toEqual(["read", "bash"]);
   });
 
+  it("registers the snake-case question tool enabled by Buda's allowlist", async () => {
+    const { createAgentSession: mockCreateAgentSession } = await import(
+      "@earendil-works/pi-coding-agent"
+    );
+    const spy = vi.mocked(mockCreateAgentSession);
+    spy.mockClear();
+
+    const runner = createPiRunner({
+      model: "google:gemini-2.5-pro",
+      allowedTools: ["read", "ask_user_question"],
+    });
+
+    for await (const _ of runner.run("ask for clarification")) {
+      break;
+    }
+
+    const callArgs = spy.mock.calls[0]?.[0];
+    expect(callArgs?.tools).toEqual(["read", "ask_user_question"]);
+    expect(callArgs?.customTools).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "ask_user_question" }),
+      ]),
+    );
+    expect(callArgs?.customTools).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "AskUserQuestion" }),
+      ]),
+    );
+  });
+
+  it("normalizes the legacy question-tool allowlist name", async () => {
+    const { createAgentSession: mockCreateAgentSession } = await import(
+      "@earendil-works/pi-coding-agent"
+    );
+    const spy = vi.mocked(mockCreateAgentSession);
+    spy.mockClear();
+
+    const runner = createPiRunner({
+      model: "google:gemini-2.5-pro",
+      allowedTools: ["AskUserQuestion"],
+    });
+
+    for await (const _ of runner.run("ask for clarification")) {
+      break;
+    }
+
+    expect(spy.mock.calls[0]?.[0]?.tools).toEqual(["ask_user_question"]);
+  });
+
   it("does not mutate process.env when injecting runner env", async () => {
     const key = "__PI_RUNNER_ENV_LEAK_TEST__";
     delete process.env[key];

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
+  LEGACY_ASK_USER_QUESTION_TOOL_NAME,
   waitForApproval,
   wrapToolWithApproval,
 } from "../tool-approval.js";
@@ -76,6 +77,25 @@ describe("waitForApproval", () => {
     expect(raw.toolName).toBe("bash");
     expect(raw.input).toEqual({ command: "ls" });
     expect(raw.questions).toBeUndefined();
+    await promise;
+  });
+
+  it("preserves questions for legacy AskUserQuestion approval files", async () => {
+    const input = { questions: [{ question: "Continue?" }] };
+    const promise = waitForApproval({
+      cwd,
+      toolCallId: "call-legacy",
+      toolName: LEGACY_ASK_USER_QUESTION_TOOL_NAME,
+      input,
+      pollIntervalMs: 10,
+      timeoutMs: 100,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const raw = JSON.parse(
+      fs.readFileSync(approvalFile("call-legacy"), "utf-8"),
+    );
+    expect(raw.questions).toEqual(input.questions);
     await promise;
   });
 

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -216,9 +216,17 @@ describe("buildAskUserQuestionTool", () => {
     expect(result.content).toEqual([
       {
         type: "text",
-        text: JSON.stringify({ questions, answers: { "Deploy?": "Yes" } }),
+        text: [
+          "The user answered the interactive questions.",
+          'Answers: {"Deploy?":"Yes"}',
+          "Continue the original task using these answers and provide a user-visible response. Do not end the turn with an empty response.",
+        ].join("\n"),
       },
     ]);
+    expect(result.details).toEqual({
+      questions,
+      answers: { "Deploy?": "Yes" },
+    });
   });
 
   it("throws on timeout so the tool call fails", async () => {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -36,8 +36,10 @@ import {
 } from "./stream-converter.js";
 import {
   type ApprovalGateOptions,
+  ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
   gateToolsForApproval,
+  LEGACY_ASK_USER_QUESTION_TOOL_NAME,
 } from "./tool-approval.js";
 import {
   buildEnvInjectedBashTool,
@@ -145,6 +147,21 @@ function applyAllowedTools(
   if (!allowedTools) return tools;
   const allowed = new Set(allowedTools);
   return tools.filter((tool) => allowed.has(tool.name));
+}
+
+function normalizeAllowedTools(
+  allowedTools: string[] | undefined,
+): string[] | undefined {
+  if (!allowedTools) return undefined;
+  return [
+    ...new Set(
+      allowedTools.map((toolName) =>
+        toolName === LEGACY_ASK_USER_QUESTION_TOOL_NAME
+          ? ASK_USER_QUESTION_TOOL_NAME
+          : toolName,
+      ),
+    ),
+  ];
 }
 
 export function shouldStripLLMThoughtSignaturesForModel(model: {
@@ -572,6 +589,9 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           );
         }
 
+        console.log('all',options.allowedTools);
+        const allowedTools = normalizeAllowedTools(options.allowedTools);
+        console.log('all',allowedTools);
         const toolRefDefinitions =
           options.toolRefs && options.toolRefs.length > 0
             ? buildToolDefinitionsFromRefs(options.toolRefs)
@@ -588,7 +608,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           fallbackSignal: options.abortController?.signal,
         };
         let regularTools: ToolDefinition[] = [
-          ...applyAllowedTools(customTools, options.allowedTools),
+          ...applyAllowedTools(customTools, allowedTools),
           ...toolRefDefinitions,
         ];
         if (!bypassApproval) {
@@ -597,7 +617,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           );
           const builtinTools = applyAllowedTools(
             createCodingTools(cwd) as unknown as ToolDefinition[],
-            options.allowedTools,
+            allowedTools,
           ).filter((tool) => !overriddenNames.has(tool.name));
           regularTools = [...regularTools, ...builtinTools];
         }
@@ -616,7 +636,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           thinkingLevel: options.effort
             ? (options.effort as ThinkingLevel)
             : undefined,
-          tools: options.allowedTools,
+          tools: allowedTools,
           customTools: [...gatedTools, buildAskUserQuestionTool(approvalGate)],
         });
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -589,9 +589,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           );
         }
 
-        console.log('all',options.allowedTools);
         const allowedTools = normalizeAllowedTools(options.allowedTools);
-        console.log('all',allowedTools);
         const toolRefDefinitions =
           options.toolRefs && options.toolRefs.length > 0
             ? buildToolDefinitionsFromRefs(options.toolRefs)

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -19,7 +19,15 @@ import * as path from "node:path";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
-export const ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
+export const LEGACY_ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+
+export function isAskUserQuestionToolName(toolName: string): boolean {
+  return (
+    toolName === ASK_USER_QUESTION_TOOL_NAME ||
+    toolName === LEGACY_ASK_USER_QUESTION_TOOL_NAME
+  );
+}
 
 /** Same poll cadence as runner-claude's approval bridge. */
 export const DEFAULT_POLL_INTERVAL_MS = 500;
@@ -90,10 +98,9 @@ export async function waitForApproval(
           status: "pending",
           toolName,
           input,
-          questions:
-            toolName === ASK_USER_QUESTION_TOOL_NAME
-              ? (input as Record<string, unknown>)?.questions
-              : undefined,
+          questions: isAskUserQuestionToolName(toolName)
+            ? (input as Record<string, unknown>)?.questions
+            : undefined,
           answers: {},
         }),
       );

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -222,6 +222,17 @@ export interface ApprovalGateOptions {
   timeoutMs?: number;
 }
 
+function formatAskUserQuestionResult(updatedInput: {
+  questions: unknown;
+  answers: Record<string, unknown>;
+}): string {
+  return [
+    "The user answered the interactive questions.",
+    `Answers: ${JSON.stringify(updatedInput.answers)}`,
+    "Continue the original task using these answers and provide a user-visible response. Do not end the turn with an empty response.",
+  ].join("\n");
+}
+
 /**
  * Build the AskUserQuestion custom tool. Its execute() blocks on the approval
  * file bridge and returns the user's answers as the tool result. This tool is
@@ -255,10 +266,10 @@ export function buildAskUserQuestionTool(
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(decision.updatedInput),
+            text: formatAskUserQuestionResult(decision.updatedInput),
           },
         ],
-        details: undefined,
+        details: decision.updatedInput,
       };
     },
   };


### PR DESCRIPTION
## Summary

- register Pi's interactive question tool with the canonical `ask_user_question` name
- normalize the legacy `AskUserQuestion` allowlist entry for backward compatibility
- preserve legacy approval-file question extraction
- add regression coverage for canonical registration and legacy compatibility

## Why

Pi activates custom tools by exact allowlist name. Product allowlists use `ask_user_question`, while the runner registered `AskUserQuestion`, leaving the tool inactive even though it was available to the runner.

## Impact

Products can enable the Pi interactive question tool with the canonical snake-case name, while existing CamelCase configurations and approval files remain compatible.

## Validation

- `pnpm --filter @bunny-agent/runner-pi exec vitest run src/__tests__/pi-runner.test.ts src/__tests__/tool-approval.test.ts` (58 tests passed)
- linting intentionally skipped at user request
- typechecking intentionally skipped at user request
