### PR TITLE
fix(sdk): ignore SSE heartbeat comments

### DIFF
--- a/docs/changelog/2026-08-06-sdk-sse-heartbeat-comments.md
+++ b/docs/changelog/2026-08-06-sdk-sse-heartbeat-comments.md
@@ -1,0 +1,21 @@
+# Ignore SSE Heartbeat Comments in the SDK
+
+Date: 2026-08-06
+
+## What Changed
+
+- Updated both SDK stream parsing paths to ignore blank lines and SSE comment lines before JSON parsing.
+- Added regression coverage for heartbeat comments between normal Pi data events and in the trailing EOF buffer.
+- Verified that normal text, `finish`, and `[DONE]` events remain consumable without unparsed-line logs.
+
+## Why
+
+The daemon sends `: heartbeat` SSE comments during long-running operations. The SDK previously treated every non-empty line that did not start with `data: ` as JSON, causing each heartbeat to produce an `Unparsed stream line` debug message for Pi and every other runner using daemon transport.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/manager build`
+- `pnpm --filter @bunny-agent/sdk test` passed with 40 tests.
+- `pnpm --filter @bunny-agent/sdk typecheck`
+- `pnpm --filter @bunny-agent/sdk build`
+- `pnpm exec biome check packages/sdk/src/provider/bunny-agent-language-model.ts packages/sdk/src/__tests__/sse-comments.test.ts docs/changelog/2026-08-06-sdk-sse-heartbeat-comments.md`

--- a/packages/sdk/src/__tests__/sse-comments.test.ts
+++ b/packages/sdk/src/__tests__/sse-comments.test.ts
@@ -1,0 +1,95 @@
+import type {
+  BunnyAgentCodingRunBody,
+  ExecOptions,
+  SandboxAdapter,
+  SandboxHandle,
+} from "@bunny-agent/manager";
+import { streamText } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { createBunnyAgent } from "../provider/bunny-agent-provider";
+import type { Logger } from "../provider/types";
+
+describe("Bunny provider SSE comments", () => {
+  it("ignores heartbeat comments between data events", async () => {
+    const logger = createLogger();
+    const bunnyAgent = createBunnyAgent({
+      sandbox: createStreamingSandbox([
+        ": heartbeat\n\n",
+        'data: {"type":"text","text":"hello"}\n\n  : heartbeat\n\n',
+        'data: {"type":"finish","finishReason":"stop"}\n\ndata: [DONE]\n\n',
+      ]),
+      daemonUrl: "http://127.0.0.1:3080",
+      logger,
+    });
+
+    const result = streamText({
+      model: bunnyAgent("google:gemini-2.5-pro", { runnerType: "pi" }),
+      prompt: "test",
+    });
+
+    await expect(result.text).resolves.toBe("hello");
+    expectUnparsedStreamLineNotLogged(logger);
+  });
+
+  it("ignores a trailing heartbeat comment when the stream ends", async () => {
+    const logger = createLogger();
+    const bunnyAgent = createBunnyAgent({
+      sandbox: createStreamingSandbox([
+        'data: {"type":"finish","finishReason":"stop"}\n\n: heartbeat',
+      ]),
+      daemonUrl: "http://127.0.0.1:3080",
+      logger,
+    });
+
+    const result = streamText({
+      model: bunnyAgent("google:gemini-2.5-pro", { runnerType: "pi" }),
+      prompt: "test",
+    });
+
+    await result.consumeStream();
+    expectUnparsedStreamLineNotLogged(logger);
+  });
+});
+
+function createLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function expectUnparsedStreamLineNotLogged(logger: Logger): void {
+  for (const method of [logger.debug, logger.info, logger.warn, logger.error]) {
+    expect(method).not.toHaveBeenCalledWith(
+      expect.stringContaining("Unparsed stream line"),
+    );
+  }
+}
+
+function createStreamingSandbox(chunks: string[]): SandboxAdapter {
+  const handle: SandboxHandle = {
+    getSandboxId: () => null,
+    getVolumes: () => null,
+    getWorkdir: () => "/workspace",
+    exec: async function* () {},
+    upload: async () => {},
+    readFile: async () => "",
+    destroy: async () => {},
+    streamCodingRun: async function* (
+      _body: BunnyAgentCodingRunBody,
+      _opts?: ExecOptions,
+    ) {
+      for (const chunk of chunks) {
+        yield new TextEncoder().encode(chunk);
+      }
+    },
+  };
+
+  return {
+    attach: async () => handle,
+    getHandle: () => handle,
+    getWorkdir: () => "/workspace",
+  };
+}

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -638,10 +638,11 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
 
             let foundDone = false;
             for (const line of lines) {
+              const trimmedLine = line.trim();
+              if (!trimmedLine || trimmedLine.startsWith(":")) continue;
               const candidate = line.startsWith("data: ")
                 ? line.slice(6)
-                : line.trim();
-              if (!candidate) continue;
+                : trimmedLine;
               if (candidate === "[DONE]") {
                 foundDone = true;
                 continue;
@@ -714,8 +715,10 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
     const lines = buffer.split("\n");
 
     for (const line of lines) {
-      const candidate = line.startsWith("data: ") ? line.slice(6) : line.trim();
-      if (!candidate || candidate === "[DONE]") continue;
+      const trimmedLine = line.trim();
+      if (!trimmedLine || trimmedLine.startsWith(":")) continue;
+      const candidate = line.startsWith("data: ") ? line.slice(6) : trimmedLine;
+      if (candidate === "[DONE]") continue;
       try {
         const parsedParts = this.parseSSEData(candidate);
         parts.push(...parsedParts);


### PR DESCRIPTION
## Summary

- ignore blank lines and standard SSE comment lines before JSON parsing
- apply the same behavior to live stream chunks and the trailing EOF buffer
- add Pi daemon transport coverage for heartbeat comments, normal data events, `finish`, and `[DONE]`
- verify heartbeat comments do not produce `Unparsed stream line` logs

## Testing

- `pnpm --filter @bunny-agent/manager build`
- `pnpm --filter @bunny-agent/sdk test` (40 tests passed)
- `pnpm --filter @bunny-agent/sdk typecheck`
- `pnpm --filter @bunny-agent/sdk build`
- `pnpm exec biome check packages/sdk/src/provider/bunny-agent-language-model.ts packages/sdk/src/__tests__/sse-comments.test.ts`
- `git diff --check`

## Environment note

The local Node.js version was 20.11.1, below the repository engine requirement of >=20.19.0. The commands above completed successfully with an engine warning.