### PR TITLE
fix: prevent interactive questions from blocking indefinitely

### DIFF
--- a/apps/daemon/src/__tests__/coding.test.ts
+++ b/apps/daemon/src/__tests__/coding.test.ts
@@ -163,6 +163,23 @@ describe("codingRunStream (Web Response)", () => {
       mcpConfig,
     });
   });
+
+  it("forwards the interactive question timeout to the runner harness", async () => {
+    const res = codingRunStream(
+      {
+        userInput: "ask a question",
+        runner: "pi",
+        askUserQuestionTimeoutMs: 1_500,
+      },
+      {},
+    );
+
+    await res.text();
+
+    expect(createRunnerCalls.at(-1)).toMatchObject({
+      askUserQuestionTimeoutMs: 1_500,
+    });
+  });
 });
 
 describe("createNextHandler", () => {

--- a/apps/daemon/src/routes/coding.ts
+++ b/apps/daemon/src/routes/coding.ts
@@ -45,6 +45,11 @@ export interface RunRequest {
   mcpConfig?: RunMcpConfig;
   /** Reasoning effort / thinking level (e.g. "low", "medium", "high"). */
   effort?: string;
+  /**
+   * Maximum time to wait for an interactive question answer before returning
+   * a timeout result to the model so the conversation can continue.
+   */
+  askUserQuestionTimeoutMs?: number;
 }
 
 const assertRunRequestInput = (req: RunRequest): void => {
@@ -114,6 +119,7 @@ export async function bunnyAgentRun(
       toolRefs: req.toolRefs,
       mcpConfig: req.mcpConfig,
       effort: req.effort,
+      askUserQuestionTimeoutMs: req.askUserQuestionTimeoutMs,
       // API: caller owns resume/session; do not read/write cwd/.bunny-agent or auto-load CLAUDE.md.
       autoInject: false,
     });
@@ -188,6 +194,7 @@ export function codingRunStream(
           toolRefs: req.toolRefs,
           mcpConfig: req.mcpConfig,
           effort: req.effort,
+          askUserQuestionTimeoutMs: req.askUserQuestionTimeoutMs,
           autoInject: false,
         });
         for await (const chunk of stream) {

--- a/apps/web/content/docs/tools/ask-user-question.mdx
+++ b/apps/web/content/docs/tools/ask-user-question.mdx
@@ -3,14 +3,16 @@ title: AskUserQuestion
 description: Let the agent ask interactive questions during a run
 ---
 
-`AskUserQuestion` is a dynamic tool that lets the agent ask the user questions during execution. Your UI renders the questions and submits answers to an answer API. The runner waits for an approval file in the sandbox, then continues.
+`AskUserQuestion` is a dynamic tool that lets the agent ask the user questions during execution. Your UI renders the questions and submits answers to an answer API. The runner waits up to 60 seconds by default, then continues with either the submitted answers or a model-visible timeout result.
 
 ## Architecture
 
 ```
 Runner (inside sandbox)
+  - Creates the pending approval file
   - Polls approval file every 500ms
   - Continues when status == "completed"
+  - Continues with a timeout result after 60s by default
         ↕
 Answer API (server)
   - Receives { toolCallId, questions, answers }
@@ -22,9 +24,10 @@ UI
 ```
 
 Key points:
-- The runner only reads/polls the file — it does not create it
+- The runner creates the pending file and then reads/polls it
 - The answer API overwrites the file on every update
-- If timeout occurs, the runner may continue with partial answers
+- If a timeout occurs, the runner continues with any partial answers plus an explicit timeout marker
+- Set `askUserQuestionTimeoutMs` in runner options to override the 60-second default
 
 ## 1. Answer API
 
@@ -77,7 +80,8 @@ function AskUserQuestionUI({ part }: { part: DynamicToolUIPart }) {
 1. Agent emits `AskUserQuestion` tool call
 2. UI renders the tool and submits answers
 3. Answer API writes approval file via `submitAnswer`
-4. Runner reads the file, continues, and the tool becomes completed
+4. Runner reads the file and continues when the answer is completed
+5. If no completed answer arrives before the timeout, the runner returns a timeout result to the model so it can keep chatting
 
 ## Data Structures
 

--- a/docs/changelog/2026-08-11-ask-user-question-timeout.md
+++ b/docs/changelog/2026-08-11-ask-user-question-timeout.md
@@ -1,0 +1,26 @@
+# AskUserQuestion Timeout
+
+## Changes
+
+- Added a 60-second default timeout for interactive `AskUserQuestion` calls in the Pi and Claude runners.
+- Converted unanswered question timeouts into model-visible tool results so the agent continues the conversation instead of remaining blocked.
+- Preserved partial answers and included an explicit timeout marker for the model.
+- Kept ordinary tool approvals waiting indefinitely unless they are aborted.
+- Added a per-run `askUserQuestionTimeoutMs` override through the runner harness.
+- Added focused timeout coverage for both runner implementations.
+- Verified that the runner harness forwards the timeout override to Claude and Pi.
+- Updated the AskUserQuestion documentation with the default timeout and continuation behavior.
+- Updated the daemon build to rebuild its workspace runner dependencies before bundling, preventing stale runner code from being served locally.
+- Added daemon API forwarding for `askUserQuestionTimeoutMs` and regression coverage for the request contract.
+- Added a per-run timeout latch so repeated AskUserQuestion calls return immediately after the first timeout instead of opening another blocking wait.
+
+## Local Runtime Diagnosis
+
+- Reproduced the reported task at `http://localhost:3000/agents/agt_mk_social/tskZkNYaRqKHgTmzANo`.
+- Confirmed the task reached the outer five-minute command timeout because the daemon bundle still contained the previous indefinite AskUserQuestion wait implementation.
+- Confirmed the first rebuilt timeout released after 60 seconds, then found and fixed a follow-up model retry that opened a second question card.
+
+## Research
+
+- Reviewed the repository lifecycle with DeepWiki and verified the current implementation directly because the indexed timeout behavior was stale.
+- Compared human-in-the-loop timeout and rejection patterns from agent frameworks found through Exa, favoring a model-visible result over a suspended promise or terminal run failure.

--- a/packages/manager/src/__tests__/approval-file.test.ts
+++ b/packages/manager/src/__tests__/approval-file.test.ts
@@ -3,7 +3,9 @@ import { approvalFileName } from "../approval-file.js";
 
 describe("approvalFileName", () => {
   it("preserves legacy filenames for normal tool call IDs", () => {
-    expect(approvalFileName("tool-call_123.abc")).toBe("tool-call_123.abc.json");
+    expect(approvalFileName("tool-call_123.abc")).toBe(
+      "tool-call_123.abc.json",
+    );
   });
 
   it("hashes path-unsafe and oversized tool call IDs deterministically", () => {

--- a/packages/manager/src/__tests__/approval-file.test.ts
+++ b/packages/manager/src/__tests__/approval-file.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { approvalFileName } from "../approval-file.js";
+
+describe("approvalFileName", () => {
+  it("preserves legacy filenames for normal tool call IDs", () => {
+    expect(approvalFileName("tool-call_123.abc")).toBe("tool-call_123.abc.json");
+  });
+
+  it("hashes path-unsafe and oversized tool call IDs deterministically", () => {
+    const toolCallId = `thought/${"opaque+payload".repeat(80)}`;
+    const filename = approvalFileName(toolCallId);
+
+    expect(filename).toMatch(/^hashed-[a-f0-9]{64}\.json$/);
+    expect(filename).toBe(approvalFileName(toolCallId));
+    expect(Buffer.byteLength(filename, "utf8")).toBeLessThan(255);
+  });
+});

--- a/packages/manager/src/approval-file.ts
+++ b/packages/manager/src/approval-file.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+
+const LEGACY_APPROVAL_FILE_STEM_MAX_BYTES = 200;
+const SAFE_APPROVAL_FILE_STEM = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * Return the shared approval filename for a tool call.
+ *
+ * Normal tool call IDs keep their legacy filenames. IDs containing path
+ * separators, unsafe characters, or unusually long byte sequences use a
+ * deterministic SHA-256 filename so every runner and SDK client resolves the
+ * same file without exceeding filesystem component limits.
+ */
+export function approvalFileName(toolCallId: string): string {
+  const useLegacyName =
+    SAFE_APPROVAL_FILE_STEM.test(toolCallId) &&
+    Buffer.byteLength(toolCallId, "utf8") <= LEGACY_APPROVAL_FILE_STEM_MAX_BYTES;
+
+  const stem = useLegacyName
+    ? toolCallId
+    : `hashed-${createHash("sha256").update(toolCallId).digest("hex")}`;
+
+  return `${stem}.json`;
+}

--- a/packages/manager/src/approval-file.ts
+++ b/packages/manager/src/approval-file.ts
@@ -14,7 +14,8 @@ const SAFE_APPROVAL_FILE_STEM = /^[A-Za-z0-9._-]+$/;
 export function approvalFileName(toolCallId: string): string {
   const useLegacyName =
     SAFE_APPROVAL_FILE_STEM.test(toolCallId) &&
-    Buffer.byteLength(toolCallId, "utf8") <= LEGACY_APPROVAL_FILE_STEM_MAX_BYTES;
+    Buffer.byteLength(toolCallId, "utf8") <=
+      LEGACY_APPROVAL_FILE_STEM_MAX_BYTES;
 
   const stem = useLegacyName
     ? toolCallId

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./agent-input.js";
+export { approvalFileName } from "./approval-file.js";
 export { BunnyAgent } from "./bunny-agent.js";
 export type { DaemonCodingRunExecParams } from "./coding-run.js";
 export {

--- a/packages/runner-claude/src/__tests__/claude-runner.test.ts
+++ b/packages/runner-claude/src/__tests__/claude-runner.test.ts
@@ -1,6 +1,12 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+  ASK_USER_QUESTION_TIMEOUT_MESSAGE,
   type ClaudeRunnerOptions,
+  createCanUseToolCallback,
   createClaudeRunner,
 } from "../claude-runner.js";
 
@@ -189,6 +195,68 @@ describe("ClaudeRunnerOptions", () => {
 
     const runner = createClaudeRunner(options);
     expect(runner).toBeDefined();
+  });
+});
+
+describe("createCanUseToolCallback", () => {
+  it("returns a model-visible timeout result for unanswered questions", async () => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "claude-approval-"));
+    try {
+      const callback = createCanUseToolCallback({
+        model: "claude-sonnet-4-20250514",
+        cwd,
+        askUserQuestionTimeoutMs: 20,
+      });
+      const questions = [{ question: "Continue?" }];
+      const result = await callback(
+        "AskUserQuestion",
+        { questions },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "ask-timeout",
+          requestId: "request-timeout",
+        },
+      );
+
+      expect(result).toEqual({
+        behavior: "allow",
+        updatedInput: {
+          questions,
+          answers: {
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
+        },
+      });
+      expect(
+        fs.existsSync(
+          path.join(cwd, ".bunny-agent", "approvals", "ask-timeout.json"),
+        ),
+      ).toBe(false);
+
+      const secondStartedAt = Date.now();
+      const secondResult = await callback(
+        "AskUserQuestion",
+        { questions: [{ question: "Another question?" }] },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "ask-timeout-2",
+          requestId: "request-timeout-2",
+        },
+      );
+      expect(Date.now() - secondStartedAt).toBeLessThan(25);
+      expect(secondResult).toMatchObject({
+        behavior: "allow",
+        updatedInput: {
+          answers: {
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
+        },
+      });
+    } finally {
+      fs.rmSync(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -23,6 +23,7 @@ import type {
 } from "@anthropic-ai/claude-agent-sdk";
 import {
   type AgentTurnInputV1,
+  approvalFileName,
   compileAgentTurnInput,
 } from "@bunny-agent/manager";
 import {
@@ -44,7 +45,7 @@ import type { BaseRunnerOptions } from "./types";
 export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 60_000;
 export const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
 export const ASK_USER_QUESTION_TIMEOUT_MESSAGE =
-  "The user did not answer before the interactive question timed out. Continue the original task without waiting, using reasonable assumptions when safe, and provide a user-visible response.";
+  "The user did not answer before the interactive question timed out. Continue the original task without waiting, using reasonable assumptions when safe, and provide a user-visible response. Do not call AskUserQuestion again during this turn.";
 
 /**
  * Options for creating a Claude runner
@@ -175,6 +176,8 @@ interface ClaudeAgentSDKModule {
 export function createCanUseToolCallback(
   claudeOptions: ClaudeRunnerOptions,
 ): CanUseTool {
+  let questionTimedOut = false;
+
   return async (
     toolName: string,
     input: unknown,
@@ -188,6 +191,19 @@ export function createCanUseToolCallback(
     },
   ) => {
     const { toolUseID } = options;
+
+    if (toolName === "AskUserQuestion" && questionTimedOut) {
+      return {
+        behavior: "allow",
+        updatedInput: {
+          questions: (input as Record<string, unknown>)?.questions,
+          answers: {
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
+        },
+      };
+    }
 
     // If yolo mode, only intercept AskUserQuestion (skip approval for all other tools)
     if (claudeOptions.yolo && toolName !== "AskUserQuestion") {
@@ -205,7 +221,7 @@ export function createCanUseToolCallback(
       const path = await import("node:path");
 
       const approvalDir = path.join(cwd, ".bunny-agent", "approvals");
-      const approvalFile = path.join(approvalDir, `${toolUseID}.json`);
+      const approvalFile = path.join(approvalDir, approvalFileName(toolUseID));
 
       // Write pending file so frontend knows a tool is waiting for approval
       fs.mkdirSync(approvalDir, { recursive: true });
@@ -286,6 +302,7 @@ export function createCanUseToolCallback(
         // Ignore cleanup errors
       }
 
+      questionTimedOut = true;
       return {
         behavior: "allow",
         updatedInput: {

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -41,6 +41,11 @@ import {
 } from "./tool-refs.js";
 import type { BaseRunnerOptions } from "./types";
 
+export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 60_000;
+export const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
+export const ASK_USER_QUESTION_TIMEOUT_MESSAGE =
+  "The user did not answer before the interactive question timed out. Continue the original task without waiting, using reasonable assumptions when safe, and provide a user-visible response.";
+
 /**
  * Options for creating a Claude runner
  * Extends BaseRunnerOptions with internal runtime options
@@ -54,6 +59,11 @@ export interface ClaudeRunnerOptions extends BaseRunnerOptions {
   includePartialMessages?: boolean;
   /** AbortController for cancelling operations */
   abortController?: AbortController;
+  /**
+   * Maximum time to wait for an AskUserQuestion answer before returning a
+   * timeout result to Claude so the conversation can continue.
+   */
+  askUserQuestionTimeoutMs?: number;
   /**
    * Fork a new session from this session ID instead of continuing it.
    * The forked session gets a new ID; the source session is left untouched.
@@ -162,7 +172,7 @@ interface ClaudeAgentSDKModule {
  * @param claudeOptions - Claude runner options
  * @returns canUseTool callback function
  */
-function createCanUseToolCallback(
+export function createCanUseToolCallback(
   claudeOptions: ClaudeRunnerOptions,
 ): CanUseTool {
   return async (
@@ -215,10 +225,19 @@ function createCanUseToolCallback(
         );
       }
 
-      // Poll for answers indefinitely — wait until the web layer writes
-      // `status: "completed"` or the tool's abort signal fires. There is no
-      // timeout: a human may take arbitrarily long to answer.
-      while (true) {
+      const timeoutMs =
+        toolName === "AskUserQuestion"
+          ? (claudeOptions.askUserQuestionTimeoutMs ??
+            DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS)
+          : Number.POSITIVE_INFINITY;
+      const deadline = Date.now() + Math.max(0, timeoutMs);
+      let lastApproval: {
+        questions: unknown;
+        answers: Record<string, unknown>;
+        status: string;
+      } | null = null;
+
+      while (Date.now() < deadline) {
         if (options.signal?.aborted) {
           try {
             fs.unlinkSync(approvalFile);
@@ -238,6 +257,7 @@ function createCanUseToolCallback(
             answers: Record<string, unknown>;
             status: string;
           };
+          lastApproval = approval;
 
           if (approval.status === "completed") {
             try {
@@ -259,6 +279,26 @@ function createCanUseToolCallback(
 
         await new Promise((resolve) => setTimeout(resolve, 500));
       }
+
+      try {
+        fs.unlinkSync(approvalFile);
+      } catch {
+        // Ignore cleanup errors
+      }
+
+      return {
+        behavior: "allow",
+        updatedInput: {
+          questions:
+            lastApproval?.questions ??
+            (input as Record<string, unknown>)?.questions,
+          answers: {
+            ...(lastApproval?.answers ?? {}),
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
+        },
+      };
     } catch (error) {
       console.error("Failed to handle approval flow:", error);
       return {

--- a/packages/runner-claude/src/index.ts
+++ b/packages/runner-claude/src/index.ts
@@ -1,8 +1,12 @@
 export {
+  ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+  ASK_USER_QUESTION_TIMEOUT_MESSAGE,
   buildUserMessage,
   type ClaudeRunner,
   type ClaudeRunnerOptions,
+  createCanUseToolCallback,
   createClaudeRunner,
+  DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   hasClaudeAuth,
 } from "./claude-runner.js";
 export {

--- a/packages/runner-harness/src/__tests__/runner-dispatch.test.ts
+++ b/packages/runner-harness/src/__tests__/runner-dispatch.test.ts
@@ -73,6 +73,26 @@ describe("createRunner dispatch", () => {
     expect(piRun).toHaveBeenCalledWith("hi");
   });
 
+  it("passes the interactive question timeout to supported runners", () => {
+    const commonOptions = {
+      model: "test-model",
+      userInput: "hello",
+      cwd: "/tmp",
+      autoInject: false,
+      askUserQuestionTimeoutMs: 1_500,
+    };
+
+    createRunner({ runner: "claude", ...commonOptions });
+    createRunner({ runner: "pi", ...commonOptions });
+
+    expect(createClaudeRunner.mock.calls[0][0].askUserQuestionTimeoutMs).toBe(
+      1_500,
+    );
+    expect(createPiRunner.mock.calls[0][0].askUserQuestionTimeoutMs).toBe(
+      1_500,
+    );
+  });
+
   it("passes structured image input to Claude and Pi without stringifying", () => {
     const input: AgentTurnInputV1 = {
       version: 1,

--- a/packages/runner-harness/src/runner.ts
+++ b/packages/runner-harness/src/runner.ts
@@ -70,6 +70,11 @@ export interface RunnerCoreOptions extends BaseRunnerOptions {
    */
   effort?: string;
   /**
+   * Maximum time to wait for an interactive user answer before allowing the
+   * supported runner to continue with a model-visible timeout result.
+   */
+  askUserQuestionTimeoutMs?: number;
+  /**
    * Source session ID to fork from before running the current turn. When set,
    * the runner snapshot-clones the source session into a fresh session with a
    * new id and continues chat on top of that copied history. Mutually
@@ -106,6 +111,7 @@ export function createRunner(
     yolo: options.yolo,
     env,
     abortController,
+    askUserQuestionTimeoutMs: options.askUserQuestionTimeoutMs,
   };
 
   const input = options.input
@@ -120,6 +126,7 @@ function dispatchRunner(
   base: BaseRunnerOptions & {
     env: Record<string, string>;
     abortController: AbortController;
+    askUserQuestionTimeoutMs?: number;
   },
   cwd: string,
   options: RunnerCoreOptions,

--- a/packages/runner-pi/src/__tests__/stream-converter.test.ts
+++ b/packages/runner-pi/src/__tests__/stream-converter.test.ts
@@ -47,6 +47,13 @@ function deltasOf(chunks: string[]): string[] {
     .map((e) => e.delta ?? "");
 }
 
+function eventsOf(chunks: string[]): Array<Record<string, unknown>> {
+  return chunks
+    .map((chunk) => chunk.replace(/^data: /, "").replace(/\n\n$/, ""))
+    .filter((line) => line && line !== "[DONE]")
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
 describe("PiAISDKStreamConverter text-delta passthrough", () => {
   it("preserves leading/trailing newlines in a single delta", () => {
     const conv = makeConverter();
@@ -67,5 +74,64 @@ describe("PiAISDKStreamConverter text-delta passthrough", () => {
       deltas.push(...deltasOf(chunks));
     }
     expect(deltas.join("")).toBe("。\n\n---\n\n## 先说");
+  });
+});
+
+describe("PiAISDKStreamConverter tool output", () => {
+  it("emits structured answers for ask-user-question results", () => {
+    const conv = makeConverter();
+    const chunks = conv.handleEvent(
+      {
+        type: "tool_execution_end",
+        toolCallId: "tool-1",
+        toolName: "ask_user_question",
+        result: {
+          content: [{ type: "text", text: "The user answered." }],
+          details: {
+            questions: [{ question: "What would you like to create?" }],
+            answers: { "What would you like to create?": "Make a video" },
+          },
+        },
+        isError: false,
+      } as AgentSessionEvent,
+      false,
+    );
+
+    expect(eventsOf(chunks)).toContainEqual(
+      expect.objectContaining({
+        type: "tool-output-available",
+        toolCallId: "tool-1",
+        output: {
+          answers: { "What would you like to create?": "Make a video" },
+        },
+      }),
+    );
+  });
+
+  it("does not persist the internal timeout marker as a user answer", () => {
+    const conv = makeConverter();
+    const chunks = conv.handleEvent(
+      {
+        type: "tool_execution_end",
+        toolCallId: "tool-2",
+        toolName: "AskUserQuestion",
+        result: {
+          details: {
+            answers: {
+              "Known question": "Known answer",
+              __bunny_agent_timeout__: "Timed out",
+            },
+          },
+        },
+        isError: false,
+      } as AgentSessionEvent,
+      false,
+    );
+
+    expect(eventsOf(chunks)).toContainEqual(
+      expect.objectContaining({
+        output: { answers: { "Known question": "Known answer" } },
+      }),
+    );
   });
 });

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -3,6 +3,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+  ASK_USER_QUESTION_TIMEOUT_MESSAGE,
   ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
   LEGACY_ASK_USER_QUESTION_TOOL_NAME,
@@ -60,7 +62,16 @@ describe("waitForApproval", () => {
     });
 
     const decision = await promise;
-    expect(decision.behavior).toBe("deny");
+    expect(decision).toEqual({
+      behavior: "allow",
+      updatedInput: {
+        questions: input.questions,
+        answers: {
+          [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+            ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+        },
+      },
+    });
   });
 
   it("omits questions for regular tools", async () => {
@@ -141,7 +152,7 @@ describe("waitForApproval", () => {
     expect(fs.existsSync(approvalFile("call-4"))).toBe(false);
   });
 
-  it("returns partial answers on timeout, like runner-claude", async () => {
+  it("returns partial answers with a timeout marker", async () => {
     const questions = [{ question: "A?" }, { question: "B?" }];
     const promise = waitForApproval({
       cwd,
@@ -164,7 +175,14 @@ describe("waitForApproval", () => {
     const decision = await promise;
     expect(decision).toEqual({
       behavior: "allow",
-      updatedInput: { questions, answers: { "A?": "yes" } },
+      updatedInput: {
+        questions,
+        answers: {
+          "A?": "yes",
+          [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+            ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+        },
+      },
     });
   });
 
@@ -229,22 +247,55 @@ describe("buildAskUserQuestionTool", () => {
     });
   });
 
-  it("throws on timeout so the tool call fails", async () => {
+  it("returns a timeout result so the model can continue", async () => {
     const tool = buildAskUserQuestionTool({
       cwd,
       pollIntervalMs: 10,
       timeoutMs: 50,
     });
-    await expect(
-      tool.execute(
-        "ask-2",
-        { questions: [{ question: "Q?" }] },
-        undefined,
-        undefined,
-        // biome-ignore lint/suspicious/noExplicitAny: ExtensionContext unused in execute
-        undefined as any,
-      ),
-    ).rejects.toThrow("Timeout waiting for user input");
+    const questions = [{ question: "Q?" }];
+    const result = await tool.execute(
+      "ask-2",
+      { questions },
+      undefined,
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: ExtensionContext unused in execute
+      undefined as any,
+    );
+    expect(result.content).toEqual([
+      {
+        type: "text",
+        text: [
+          ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          "Available answers: {}",
+          "Continue the original task without waiting. Use any available answers, make reasonable assumptions when safe, and provide a user-visible response. Do not call ask_user_question again during this turn.",
+        ].join("\n"),
+      },
+    ]);
+    expect(result.details).toEqual({
+      questions,
+      answers: {
+        [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+          ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+      },
+    });
+
+    const secondStartedAt = Date.now();
+    const secondResult = await tool.execute(
+      "ask-3",
+      { questions: [{ question: "Another question?" }] },
+      undefined,
+      undefined,
+      // biome-ignore lint/suspicious/noExplicitAny: ExtensionContext unused in execute
+      undefined as any,
+    );
+    expect(Date.now() - secondStartedAt).toBeLessThan(25);
+    expect(secondResult.details).toMatchObject({
+      answers: {
+        [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+          ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+      },
+    });
   });
 });
 

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -16,7 +16,12 @@ import {
 let cwd: string;
 
 function approvalFile(toolCallId: string): string {
-  return path.join(cwd, ".bunny-agent", "approvals", approvalFileName(toolCallId));
+  return path.join(
+    cwd,
+    ".bunny-agent",
+    "approvals",
+    approvalFileName(toolCallId),
+  );
 }
 
 function completeApproval(

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { approvalFileName } from "@bunny-agent/manager";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
@@ -15,7 +16,7 @@ import {
 let cwd: string;
 
 function approvalFile(toolCallId: string): string {
-  return path.join(cwd, ".bunny-agent", "approvals", `${toolCallId}.json`);
+  return path.join(cwd, ".bunny-agent", "approvals", approvalFileName(toolCallId));
 }
 
 function completeApproval(
@@ -39,6 +40,28 @@ afterEach(() => {
 });
 
 describe("waitForApproval", () => {
+  it("supports opaque tool call IDs that are unsafe as filenames", async () => {
+    const toolCallId = `thought/${"opaque+payload".repeat(80)}`;
+    const questions = [{ question: "Format?" }];
+    const promise = waitForApproval({
+      cwd,
+      toolCallId,
+      toolName: ASK_USER_QUESTION_TOOL_NAME,
+      input: { questions },
+      pollIntervalMs: 10,
+      timeoutMs: 5_000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(fs.existsSync(approvalFile(toolCallId))).toBe(true);
+    completeApproval(toolCallId, questions, { "Format?": "Video" });
+
+    await expect(promise).resolves.toEqual({
+      behavior: "allow",
+      updatedInput: { questions, answers: { "Format?": "Video" } },
+    });
+  });
+
   it("writes a pending approval file with the claude-compatible shape", async () => {
     const input = { questions: [{ question: "Pick one?" }] };
     const promise = waitForApproval({

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -21,8 +21,11 @@ export {
 export {
   type ApprovalDecision,
   type ApprovalGateOptions,
+  ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+  ASK_USER_QUESTION_TIMEOUT_MESSAGE,
   ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
+  DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   gateToolsForApproval,
   type WaitForApprovalOptions,
   waitForApproval,

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -38,6 +38,7 @@ import {
   type ApprovalGateOptions,
   ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
+  DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   gateToolsForApproval,
   LEGACY_ASK_USER_QUESTION_TOOL_NAME,
 } from "./tool-approval.js";
@@ -116,6 +117,11 @@ export interface PiRunnerOptions {
    * Mapped to pi-mono's ThinkingLevel and passed to createAgentSession.
    */
   effort?: string;
+  /**
+   * Maximum time to wait for an interactive question answer before returning
+   * a timeout result to the model so the conversation can continue.
+   */
+  askUserQuestionTimeoutMs?: number;
 }
 
 export interface PiRunner {
@@ -635,7 +641,15 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
             ? (options.effort as ThinkingLevel)
             : undefined,
           tools: allowedTools,
-          customTools: [...gatedTools, buildAskUserQuestionTool(approvalGate)],
+          customTools: [
+            ...gatedTools,
+            buildAskUserQuestionTool({
+              ...approvalGate,
+              timeoutMs:
+                options.askUserQuestionTimeoutMs ??
+                DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
+            }),
+          ],
         });
 
         try {

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -23,6 +23,12 @@ interface PiAISDKStreamConverterOptions {
   ) => string | undefined;
 }
 
+const ASK_USER_QUESTION_TOOL_NAMES = new Set([
+  "AskUserQuestion",
+  "ask_user_question",
+]);
+const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
+
 function emitStreamError(errorText: string): string[] {
   const errorLine =
     "data: " + JSON.stringify({ type: "error", errorText }) + "\n\n";
@@ -51,6 +57,32 @@ export function extractToolResultText(result: unknown): string {
   } catch {
     return String(result);
   }
+}
+
+function extractAskUserQuestionOutput(
+  toolName: string,
+  result: unknown,
+): { answers: Record<string, unknown> } | undefined {
+  if (!ASK_USER_QUESTION_TOOL_NAMES.has(toolName)) return undefined;
+  if (result === null || typeof result !== "object") return undefined;
+
+  const details = (result as { details?: unknown }).details;
+  if (details === null || typeof details !== "object" || Array.isArray(details)) {
+    return undefined;
+  }
+
+  const answers = (details as { answers?: unknown }).answers;
+  if (answers === null || typeof answers !== "object" || Array.isArray(answers)) {
+    return undefined;
+  }
+
+  return {
+    answers: Object.fromEntries(
+      Object.entries(answers as Record<string, unknown>).filter(
+        ([key]) => key !== ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+      ),
+    ),
+  };
 }
 
 function sseData(obj: Record<string, unknown>): string {
@@ -124,7 +156,7 @@ export class PiAISDKStreamConverter {
     }
 
     if (event.type === "tool_execution_end") {
-      const output = this.options.normalizeToolOutput(event.result);
+      const textOutput = this.options.normalizeToolOutput(event.result);
       const raw = (event.result as { details?: ToolDetailsWithUsage })?.details
         ?.usage?.raw;
       if (raw != null) accumulateToolUsage(this.toolUsageTally, raw);
@@ -133,12 +165,14 @@ export class PiAISDKStreamConverter {
           sseData({
             type: "tool-output-error",
             toolCallId: event.toolCallId,
-            errorText: output,
+            errorText: textOutput,
             dynamic: true,
             providerExecuted: true,
           }),
         );
       } else {
+        const output =
+          extractAskUserQuestionOutput(event.toolName, event.result) ?? textOutput;
         chunks.push(
           sseData({
             type: "tool-output-available",

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -67,12 +67,20 @@ function extractAskUserQuestionOutput(
   if (result === null || typeof result !== "object") return undefined;
 
   const details = (result as { details?: unknown }).details;
-  if (details === null || typeof details !== "object" || Array.isArray(details)) {
+  if (
+    details === null ||
+    typeof details !== "object" ||
+    Array.isArray(details)
+  ) {
     return undefined;
   }
 
   const answers = (details as { answers?: unknown }).answers;
-  if (answers === null || typeof answers !== "object" || Array.isArray(answers)) {
+  if (
+    answers === null ||
+    typeof answers !== "object" ||
+    Array.isArray(answers)
+  ) {
     return undefined;
   }
 
@@ -172,7 +180,8 @@ export class PiAISDKStreamConverter {
         );
       } else {
         const output =
-          extractAskUserQuestionOutput(event.toolName, event.result) ?? textOutput;
+          extractAskUserQuestionOutput(event.toolName, event.result) ??
+          textOutput;
         chunks.push(
           sseData({
             type: "tool-output-available",

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -15,6 +15,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { approvalFileName } from "@bunny-agent/manager";
 import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "@sinclair/typebox";
 
@@ -59,7 +60,7 @@ export interface WaitForApprovalOptions {
 }
 
 function approvalFilePath(cwd: string, toolCallId: string): string {
-  return path.join(cwd, ".bunny-agent", "approvals", `${toolCallId}.json`);
+  return path.join(cwd, ".bunny-agent", "approvals", approvalFileName(toolCallId));
 }
 
 /**

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -60,7 +60,12 @@ export interface WaitForApprovalOptions {
 }
 
 function approvalFilePath(cwd: string, toolCallId: string): string {
-  return path.join(cwd, ".bunny-agent", "approvals", approvalFileName(toolCallId));
+  return path.join(
+    cwd,
+    ".bunny-agent",
+    "approvals",
+    approvalFileName(toolCallId),
+  );
 }
 
 /**

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -7,11 +7,10 @@
  *   shape claude writes ({ status, toolName, input, questions?, answers }),
  *   so the SDK's question-processor / AskUserQuestion web UI works unchanged.
  * - Polls the file every 500ms waiting for the web layer to overwrite it with
- *   `status: "completed"` (see packages/sdk submitAnswer). By default it waits
- *   indefinitely, matching runner-claude — only aborting the session signal
- *   stops polling and denies. An optional `timeoutMs` bound exists for tests.
- * - On completion returns `{ questions, answers }`; if a finite `timeoutMs`
- *   elapses with partial answers it returns those, otherwise denies.
+ *   `status: "completed"` (see packages/sdk submitAnswer).
+ * - AskUserQuestion uses a 60-second default timeout and returns a model-visible
+ *   timeout answer so the conversation continues. Regular approvals remain
+ *   unbounded unless a caller explicitly supplies `timeoutMs`.
  */
 
 import * as fs from "node:fs";
@@ -21,6 +20,10 @@ import { Type } from "@sinclair/typebox";
 
 export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 export const LEGACY_ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
+export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 60_000;
+export const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
+export const ASK_USER_QUESTION_TIMEOUT_MESSAGE =
+  "The user did not answer before the interactive question timed out. Do not call ask_user_question again during this turn.";
 
 export function isAskUserQuestionToolName(toolName: string): boolean {
   return (
@@ -49,9 +52,8 @@ export interface WaitForApprovalOptions {
   signal?: AbortSignal;
   pollIntervalMs?: number;
   /**
-   * Optional upper bound on how long to wait. Omitted (the default) waits
-   * indefinitely for the user's answer, matching runner-claude; only the abort
-   * signal ends the wait. Primarily useful for tests.
+   * Optional upper bound on how long to wait. Omitted waits indefinitely at
+   * this low-level bridge; AskUserQuestion supplies its production default.
    */
   timeoutMs?: number;
 }
@@ -153,13 +155,18 @@ export async function waitForApproval(
 
     cleanup();
 
-    if (lastApproval && Object.keys(lastApproval.answers ?? {}).length > 0) {
-      // Return partial answers on timeout, like runner-claude.
+    if (isAskUserQuestionToolName(toolName)) {
       return {
         behavior: "allow",
         updatedInput: {
-          questions: lastApproval.questions,
-          answers: lastApproval.answers,
+          questions:
+            lastApproval?.questions ??
+            (input as Record<string, unknown>)?.questions,
+          answers: {
+            ...(lastApproval?.answers ?? {}),
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
         },
       };
     }
@@ -226,6 +233,19 @@ function formatAskUserQuestionResult(updatedInput: {
   questions: unknown;
   answers: Record<string, unknown>;
 }): string {
+  if (ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY in updatedInput.answers) {
+    const availableAnswers = Object.fromEntries(
+      Object.entries(updatedInput.answers).filter(
+        ([key]) => key !== ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY,
+      ),
+    );
+    return [
+      ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+      `Available answers: ${JSON.stringify(availableAnswers)}`,
+      "Continue the original task without waiting. Use any available answers, make reasonable assumptions when safe, and provide a user-visible response. Do not call ask_user_question again during this turn.",
+    ].join("\n");
+  }
+
   return [
     "The user answered the interactive questions.",
     `Answers: ${JSON.stringify(updatedInput.answers)}`,
@@ -241,6 +261,8 @@ function formatAskUserQuestionResult(updatedInput: {
 export function buildAskUserQuestionTool(
   options: ApprovalGateOptions,
 ): ToolDefinition {
+  let questionTimedOut = false;
+
   return {
     name: ASK_USER_QUESTION_TOOL_NAME,
     label: "Ask User Question",
@@ -250,6 +272,25 @@ export function buildAskUserQuestionTool(
       "missing information required to continue the task.",
     parameters: askUserQuestionParameters,
     async execute(toolCallId, params, signal) {
+      if (questionTimedOut) {
+        const updatedInput = {
+          questions: (params as Record<string, unknown>)?.questions,
+          answers: {
+            [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
+              ASK_USER_QUESTION_TIMEOUT_MESSAGE,
+          },
+        };
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: formatAskUserQuestionResult(updatedInput),
+            },
+          ],
+          details: updatedInput,
+        };
+      }
+
       const decision = await waitForApproval({
         cwd: options.cwd,
         toolCallId,
@@ -257,11 +298,13 @@ export function buildAskUserQuestionTool(
         input: params,
         signal: signal ?? options.fallbackSignal,
         pollIntervalMs: options.pollIntervalMs,
-        timeoutMs: options.timeoutMs,
+        timeoutMs: options.timeoutMs ?? DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
       });
       if (decision.behavior === "deny") {
         throw new Error(decision.message);
       }
+      questionTimedOut =
+        ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY in decision.updatedInput.answers;
       return {
         content: [
           {

--- a/packages/sdk/src/__tests__/question-processor.test.ts
+++ b/packages/sdk/src/__tests__/question-processor.test.ts
@@ -87,4 +87,22 @@ describe("submitAnswer", () => {
     const payload = JSON.parse(String(files[0].content));
     expect(payload.status).toBe("pending");
   });
+
+  it("uploads unsafe opaque tool call IDs using the shared hashed filename", async () => {
+    const handle = createHandle();
+    const sandbox = {
+      getHandle: () => handle,
+      attach: vi.fn(),
+    } as unknown as SandboxAdapter;
+    const toolCallId = `thought/${"opaque+payload".repeat(80)}`;
+
+    await submitAnswer(sandbox, {
+      toolCallId,
+      questions: [{ question: "Format?" }],
+      answers: { "Format?": "Video" },
+    });
+
+    const [files] = (handle.upload as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(files[0].path).toMatch(/^hashed-[a-f0-9]{64}\.json$/);
+  });
 });

--- a/packages/sdk/src/provider/question-processor.ts
+++ b/packages/sdk/src/provider/question-processor.ts
@@ -1,4 +1,4 @@
-import type { SandboxAdapter } from "@bunny-agent/manager";
+import { approvalFileName, type SandboxAdapter } from "@bunny-agent/manager";
 import type { SubmitAnswerParams } from "./types";
 
 /**
@@ -46,7 +46,7 @@ export async function submitAnswer(
     timestamp: new Date().toISOString(),
   };
 
-  const filename = `${toolCallId}.json`;
+  const filename = approvalFileName(toolCallId);
   const handle = sandbox.getHandle() ?? (await sandbox.attach());
   // Absolute path so remote sandboxes (Sandock) write to the same path the runner reads (/workspace/.bunny-agent/approvals).
   const workdir = handle.getWorkdir();


### PR DESCRIPTION
## Summary

This PR adds a bounded timeout for interactive `AskUserQuestion` calls in the Pi and Claude runners.

Previously, an unanswered interactive question could leave a run blocked indefinitely. The runners now wait up to 60 seconds by default, then return a model-visible timeout result so the conversation can continue gracefully.

The timeout is configurable per run through `askUserQuestionTimeoutMs`.

## Changes

- Add a 60-second default timeout for `AskUserQuestion` in the Pi and Claude runners.
- Preserve any partial answers received before the timeout.
- Return an explicit timeout marker to the model instead of failing or leaving the run suspended.
- Prevent repeated `AskUserQuestion` calls from opening another blocking wait after a timeout in the same turn.
- Keep ordinary tool approvals unchanged and indefinitely waitable unless a caller provides an explicit timeout.
- Forward `askUserQuestionTimeoutMs` through the runner harness and daemon coding API.
- Add shared approval-file naming for opaque, path-unsafe, or oversized tool call IDs.
- Preserve legacy approval filenames for safe tool call IDs.
- Hash unsafe or oversized IDs deterministically using SHA-256 while keeping filenames within filesystem limits.
- Emit structured `AskUserQuestion` answers through the Pi stream converter.
- Exclude the internal timeout marker from user-visible answer payloads.
- Update the `AskUserQuestion` documentation and add a changelog entry.

## Behavior

When a question is answered within the timeout window, the existing flow is preserved.

When the timeout expires, the runner returns:

- Any answers already provided by the user.
- An explicit timeout result visible to the model.
- Instructions to continue the original task without waiting.
- A guard preventing another interactive question from blocking the same turn.

The default can be overridden with:

```ts
{
 askUserQuestionTimeoutMs: 120_000,
}
