### PR TITLE
fix: bound interactive question surveys

### DIFF
--- a/docs/changelog/2026-08-12-ask-user-question-limits.md
+++ b/docs/changelog/2026-08-12-ask-user-question-limits.md
@@ -1,0 +1,15 @@
+# AskUserQuestion Limits
+
+## Changes
+
+- Increased the default interactive question timeout from 60 seconds to 3 minutes in the Claude and Pi runners.
+- Limited Pi `ask_user_question` surveys to a maximum of 8 questions in the tool schema.
+- Added defensive runtime validation in both runners so oversized surveys never reach the approval bridge or frontend.
+- Exported the shared maximum-question constants for integrations and tests.
+- Added focused regression coverage for the timeout defaults, Pi schema, and oversized survey rejection.
+
+## Compatibility
+
+- Per-run `askUserQuestionTimeoutMs` overrides continue to take precedence over the default.
+- Claude Agent SDK currently limits its built-in `AskUserQuestion` tool to 4 questions, which remains within Bunny Agent's maximum of 8.
+- Ordinary tool approvals remain unbounded unless callers explicitly configure a timeout.

--- a/packages/runner-claude/src/__tests__/claude-runner.test.ts
+++ b/packages/runner-claude/src/__tests__/claude-runner.test.ts
@@ -8,6 +8,8 @@ import {
   type ClaudeRunnerOptions,
   createCanUseToolCallback,
   createClaudeRunner,
+  DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
+  MAX_ASK_USER_QUESTIONS,
 } from "../claude-runner.js";
 
 // Mock the Claude Agent SDK so tests always use mock mode
@@ -199,6 +201,33 @@ describe("ClaudeRunnerOptions", () => {
 });
 
 describe("createCanUseToolCallback", () => {
+  it("uses a three-minute default timeout and rejects surveys over eight questions", async () => {
+    expect(DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS).toBe(180_000);
+    expect(MAX_ASK_USER_QUESTIONS).toBe(8);
+
+    const callback = createCanUseToolCallback({
+      model: "claude-sonnet-4-20250514",
+    });
+    const questions = Array.from({ length: 9 }, (_, index) => ({
+      question: `Question ${index + 1}?`,
+    }));
+
+    await expect(
+      callback(
+        "AskUserQuestion",
+        { questions },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "ask-too-many",
+          requestId: "request-too-many",
+        },
+      ),
+    ).resolves.toEqual({
+      behavior: "deny",
+      message: "AskUserQuestion supports at most 8 questions per survey.",
+    });
+  });
+
   it("returns a model-visible timeout result for unanswered questions", async () => {
     const cwd = fs.mkdtempSync(path.join(os.tmpdir(), "claude-approval-"));
     try {

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -245,8 +245,7 @@ export function createCanUseToolCallback(
             status: "pending",
             toolName,
             input,
-            questions:
-              toolName === "AskUserQuestion" ? questions : undefined,
+            questions: toolName === "AskUserQuestion" ? questions : undefined,
             answers: {},
           }),
         );

--- a/packages/runner-claude/src/claude-runner.ts
+++ b/packages/runner-claude/src/claude-runner.ts
@@ -42,7 +42,8 @@ import {
 } from "./tool-refs.js";
 import type { BaseRunnerOptions } from "./types";
 
-export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 60_000;
+export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 180_000;
+export const MAX_ASK_USER_QUESTIONS = 8;
 export const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
 export const ASK_USER_QUESTION_TIMEOUT_MESSAGE =
   "The user did not answer before the interactive question timed out. Continue the original task without waiting, using reasonable assumptions when safe, and provide a user-visible response. Do not call AskUserQuestion again during this turn.";
@@ -191,12 +192,24 @@ export function createCanUseToolCallback(
     },
   ) => {
     const { toolUseID } = options;
+    const questions = (input as Record<string, unknown>)?.questions;
+
+    if (
+      toolName === "AskUserQuestion" &&
+      Array.isArray(questions) &&
+      questions.length > MAX_ASK_USER_QUESTIONS
+    ) {
+      return {
+        behavior: "deny",
+        message: `AskUserQuestion supports at most ${MAX_ASK_USER_QUESTIONS} questions per survey.`,
+      };
+    }
 
     if (toolName === "AskUserQuestion" && questionTimedOut) {
       return {
         behavior: "allow",
         updatedInput: {
-          questions: (input as Record<string, unknown>)?.questions,
+          questions,
           answers: {
             [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
               ASK_USER_QUESTION_TIMEOUT_MESSAGE,
@@ -233,9 +246,7 @@ export function createCanUseToolCallback(
             toolName,
             input,
             questions:
-              toolName === "AskUserQuestion"
-                ? (input as Record<string, unknown>)?.questions
-                : undefined,
+              toolName === "AskUserQuestion" ? questions : undefined,
             answers: {},
           }),
         );

--- a/packages/runner-claude/src/index.ts
+++ b/packages/runner-claude/src/index.ts
@@ -8,6 +8,7 @@ export {
   createClaudeRunner,
   DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   hasClaudeAuth,
+  MAX_ASK_USER_QUESTIONS,
 } from "./claude-runner.js";
 export {
   buildMcpToolDefinitionsFromRefs,

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -8,7 +8,9 @@ import {
   ASK_USER_QUESTION_TIMEOUT_MESSAGE,
   ASK_USER_QUESTION_TOOL_NAME,
   buildAskUserQuestionTool,
+  DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   LEGACY_ASK_USER_QUESTION_TOOL_NAME,
+  MAX_ASK_USER_QUESTIONS,
   waitForApproval,
   wrapToolWithApproval,
 } from "../tool-approval.js";
@@ -238,6 +240,35 @@ describe("waitForApproval", () => {
 });
 
 describe("buildAskUserQuestionTool", () => {
+  it("uses a three-minute default timeout and caps surveys at eight questions", () => {
+    const tool = buildAskUserQuestionTool({ cwd });
+    const parameters = tool.parameters as {
+      properties: { questions: { maxItems?: number } };
+    };
+
+    expect(DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS).toBe(180_000);
+    expect(MAX_ASK_USER_QUESTIONS).toBe(8);
+    expect(parameters.properties.questions.maxItems).toBe(8);
+  });
+
+  it("rejects oversized surveys when execution bypasses schema validation", async () => {
+    const tool = buildAskUserQuestionTool({ cwd });
+    const questions = Array.from({ length: 9 }, (_, index) => ({
+      question: `Question ${index + 1}?`,
+    }));
+
+    await expect(
+      tool.execute(
+        "ask-too-many",
+        { questions },
+        undefined,
+        undefined,
+        // biome-ignore lint/suspicious/noExplicitAny: ExtensionContext unused in execute
+        undefined as any,
+      ),
+    ).rejects.toThrow("at most 8 questions");
+  });
+
   it("returns the user's answers as the tool result on completion", async () => {
     const tool = buildAskUserQuestionTool({
       cwd,

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -27,6 +27,7 @@ export {
   buildAskUserQuestionTool,
   DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
   gateToolsForApproval,
+  MAX_ASK_USER_QUESTIONS,
   type WaitForApprovalOptions,
   waitForApproval,
   wrapToolWithApproval,

--- a/packages/runner-pi/src/tool-approval.ts
+++ b/packages/runner-pi/src/tool-approval.ts
@@ -8,7 +8,7 @@
  *   so the SDK's question-processor / AskUserQuestion web UI works unchanged.
  * - Polls the file every 500ms waiting for the web layer to overwrite it with
  *   `status: "completed"` (see packages/sdk submitAnswer).
- * - AskUserQuestion uses a 60-second default timeout and returns a model-visible
+ * - AskUserQuestion uses a 3-minute default timeout and returns a model-visible
  *   timeout answer so the conversation continues. Regular approvals remain
  *   unbounded unless a caller explicitly supplies `timeoutMs`.
  */
@@ -21,7 +21,8 @@ import { Type } from "@sinclair/typebox";
 
 export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
 export const LEGACY_ASK_USER_QUESTION_TOOL_NAME = "AskUserQuestion";
-export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 60_000;
+export const DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS = 180_000;
+export const MAX_ASK_USER_QUESTIONS = 8;
 export const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
 export const ASK_USER_QUESTION_TIMEOUT_MESSAGE =
   "The user did not answer before the interactive question timed out. Do not call ask_user_question again during this turn.";
@@ -223,7 +224,10 @@ const askUserQuestionParameters = Type.Object({
         }),
       ),
     }),
-    { description: "Questions to present to the user." },
+    {
+      description: `Questions to present to the user (maximum ${MAX_ASK_USER_QUESTIONS}).`,
+      maxItems: MAX_ASK_USER_QUESTIONS,
+    },
   ),
 });
 
@@ -278,9 +282,19 @@ export function buildAskUserQuestionTool(
       "missing information required to continue the task.",
     parameters: askUserQuestionParameters,
     async execute(toolCallId, params, signal) {
+      const questions = (params as Record<string, unknown>)?.questions;
+      if (
+        Array.isArray(questions) &&
+        questions.length > MAX_ASK_USER_QUESTIONS
+      ) {
+        throw new Error(
+          `ask_user_question supports at most ${MAX_ASK_USER_QUESTIONS} questions per survey.`,
+        );
+      }
+
       if (questionTimedOut) {
         const updatedInput = {
-          questions: (params as Record<string, unknown>)?.questions,
+          questions,
           answers: {
             [ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY]:
               ASK_USER_QUESTION_TIMEOUT_MESSAGE,


### PR DESCRIPTION
## Summary

- increase the default AskUserQuestion timeout from 60 seconds to 3 minutes in the Claude and Pi runners
- cap interactive surveys at 8 questions with schema and runtime enforcement
- export the shared limit constants and add focused regression coverage
- document the behavior and compatibility details in the session changelog

## Why

Interactive surveys could time out too quickly, while oversized question sets could reach the approval bridge without a consistent Bunny Agent limit. This change gives users more time to answer and enforces a bounded survey contract across both runner implementations.

## Validation

Not run per request:

- lint
- typecheck
- tests
