### PR TITLE
fix(runner-pi): honor question tool allowlist

### DIFF
--- a/docs/changelog/2026-08-13-automation-question-tool-filter.md
+++ b/docs/changelog/2026-08-13-automation-question-tool-filter.md
@@ -1,0 +1,18 @@
+# Automation Question Tool Filter
+
+## Changes
+
+- Made the Pi runner's explicit `allowedTools` list authoritative for the native `ask_user_question` tool.
+- Preserved the interactive default when callers omit `allowedTools`.
+- Prevented unattended automation runs from receiving a tool that requires live user input.
+- Added regression coverage for allowlists that intentionally exclude `ask_user_question`.
+
+## Root Cause
+
+- Buda already marks scheduled automation executions as non-web and omits `ask_user_question` from the runner allowlist.
+- The Pi runner appended its native question tool after applying that allowlist, so automations could still block for the three-minute interactive timeout.
+
+## Validation
+
+- Run the focused Pi runner tests.
+- Run the Pi runner typecheck.

--- a/packages/runner-pi/src/__tests__/pi-runner.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.test.ts
@@ -939,6 +939,11 @@ describe("createPiRunner", () => {
     expect(spy).toHaveBeenCalled();
     const callArgs = spy.mock.calls[0]?.[0];
     expect(callArgs?.tools).toEqual(["read", "bash"]);
+    expect(callArgs?.customTools).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "ask_user_question" }),
+      ]),
+    );
   });
 
   it("registers the snake-case question tool enabled by Buda's allowlist", async () => {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -630,6 +630,9 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           bypassApproval,
           approvalGate,
         );
+        const askUserQuestionEnabled =
+          allowedTools === undefined ||
+          allowedTools.includes(ASK_USER_QUESTION_TOOL_NAME);
 
         const { session } = await createAgentSession({
           cwd,
@@ -643,12 +646,16 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           tools: allowedTools,
           customTools: [
             ...gatedTools,
-            buildAskUserQuestionTool({
-              ...approvalGate,
-              timeoutMs:
-                options.askUserQuestionTimeoutMs ??
-                DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
-            }),
+            ...(askUserQuestionEnabled
+              ? [
+                  buildAskUserQuestionTool({
+                    ...approvalGate,
+                    timeoutMs:
+                      options.askUserQuestionTimeoutMs ??
+                      DEFAULT_ASK_USER_QUESTION_TIMEOUT_MS,
+                  }),
+                ]
+              : []),
           ],
         });
 


### PR DESCRIPTION
## Summary

- Make the Pi runner's explicit `allowedTools` list authoritative for the native `ask_user_question` tool.
- Preserve the interactive default when callers omit `allowedTools`.
- Add regression coverage for unattended runs that exclude `ask_user_question`.

## Root Cause

The Pi runner appended its native question tool after applying the caller's allowlist. As a result, scheduled automation runs could still receive an interactive tool and block until its timeout even when the allowlist intentionally excluded it.

## Impact

Unattended automation runs no longer receive `ask_user_question` unless it is explicitly allowed, while interactive callers without an allowlist keep the existing behavior.

## Validation

- `pnpm --filter @bunny-agent/runner-pi exec vitest run src/__tests__/pi-runner.test.ts` (46 tests passed)
- Lint skipped as requested.
- Typecheck skipped as requested.
