### PR TITLE
fix(server-acp): stop leaking runners on disconnect; report bad runner names as invalidParams

### DIFF
--- a/.changeset/acp-agent-server.md
+++ b/.changeset/acp-agent-server.md
@@ -1,0 +1,21 @@
+---
+"@bunny-agent/daemon": minor
+"@bunny-agent/manager": minor
+"@bunny-agent/runner-cli": minor
+"@bunny-agent/sandbox-e2b": minor
+"@bunny-agent/sandbox-local": minor
+"@bunny-agent/sandbox-sandock": minor
+"@bunny-agent/sandbox-srt": minor
+"@bunny-agent/sandbox-daytona": minor
+"@bunny-agent/sdk": minor
+---
+
+Serve runners over the Agent Client Protocol (ACP) alongside the existing AI SDK UI stream, so ACP clients (Zed, JetBrains, and the Neovim/Emacs/VS Code plugins) can drive any BunnyAgent runner.
+
+- `POST /api/coding/acp` on the daemon — ACP over Streamable HTTP, mounted next to the unchanged `/api/coding/run`.
+- `bunny-agent acp` on the CLI — a long-lived ACP agent over stdio, the transport editors use when they spawn an agent binary. Separate from the one-shot `bunny-agent run`.
+- Runner/model selection uses ACP's protocol-defined `_meta` extension namespaced under `"bunny-agent"`, falling back to the server's configured defaults.
+
+Both protocols are backed by dedicated internal packages (`server-acp`, `server-ai-sdk`) implementing a shared `CodingRunServer` contract, both consuming the same `RunnerChunk` stream — so every runner is available on both. `/api/coding/run`'s wire contract is unchanged.
+
+Also fixes `bunny-agent run` writing dotenv's startup tips to stdout, which carries the protocol stream.

--- a/apps/runner-cli/src/__tests__/runner-cli.integration.test.ts
+++ b/apps/runner-cli/src/__tests__/runner-cli.integration.test.ts
@@ -172,6 +172,50 @@ describe("runner-cli Integration Tests", () => {
     },
     TIMEOUT,
   );
+
+  it(
+    "reports an unknown runner from _meta as invalid params, not an internal error",
+    async () => {
+      // Fully unmocked, and credential-free: dispatch rejects the runner name
+      // before any agent SDK is constructed.
+      const result = await runAcpHandshake([
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: 1, clientCapabilities: {} },
+        },
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "session/new",
+          params: {
+            cwd: process.cwd(),
+            mcpServers: [],
+            _meta: { "bunny-agent": { runner: "claude-code" } },
+          },
+        },
+        (prior) => ({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "session/prompt",
+          params: {
+            sessionId: prior[1].result.sessionId,
+            prompt: [{ type: "text", text: "hi" }],
+          },
+        }),
+      ]);
+
+      const promptResponse = result.responses[2];
+      expect(promptResponse.error).toBeDefined();
+      // -32602 invalid params, not -32603 internal error.
+      expect(promptResponse.error?.code).toBe(-32602);
+      expect(promptResponse.error?.message).toMatch(
+        /Unknown runner: claude-code/,
+      );
+    },
+    TIMEOUT,
+  );
 });
 
 /**
@@ -227,17 +271,21 @@ interface AcpRpcResponse {
   jsonrpc: "2.0";
   id: number;
   // biome-ignore lint/suspicious/noExplicitAny: test-only, response shape varies by method
-  result: any;
+  result?: any;
+  error?: { code: number; message: string; data?: unknown };
 }
 
+/** A request, or one built from the responses received so far. */
+type AcpRpcStep = AcpRpcRequest | ((prior: AcpRpcResponse[]) => AcpRpcRequest);
+
 /**
- * Drives `bunny-agent acp` as a real subprocess: writes newline-delimited
- * JSON-RPC requests to its stdin, collects matching responses from stdout by
- * id, then closes stdin (how a disconnecting editor looks on the wire) and
- * waits for the process to exit cleanly.
+ * Drives `bunny-agent acp` as a real subprocess over its actual stdin/stdout:
+ * sends each step, waits for the matching response before sending the next
+ * (so a step can depend on an earlier `sessionId`), then closes stdin — how a
+ * disconnecting editor looks on the wire — and waits for a clean exit.
  */
 function runAcpHandshake(
-  requests: AcpRpcRequest[],
+  steps: AcpRpcStep[],
 ): Promise<{ responses: AcpRpcResponse[]; exitCode: number }> {
   return new Promise((resolve, reject) => {
     const proc = spawn("node", [CLI_PATH, "acp", "--runner", "claude"], {
@@ -245,10 +293,22 @@ function runAcpHandshake(
       stdio: "pipe",
     });
 
-    const pendingIds = new Set(requests.map((r) => r.id));
     const responses: AcpRpcResponse[] = [];
     let buffer = "";
     let stderr = "";
+    let stepIndex = 0;
+    let awaitingId: number | null = null;
+
+    const sendNext = () => {
+      if (stepIndex >= steps.length) {
+        proc.stdin?.end();
+        return;
+      }
+      const step = steps[stepIndex++];
+      const req = typeof step === "function" ? step(responses) : step;
+      awaitingId = req.id;
+      proc.stdin?.write(`${JSON.stringify(req)}\n`);
+    };
 
     proc.stdout?.on("data", (chunk) => {
       buffer += chunk.toString();
@@ -267,13 +327,11 @@ function runAcpHandshake(
           );
           return;
         }
-        if (typeof msg.id === "number" && pendingIds.has(msg.id)) {
+        if (msg.id === awaitingId) {
           responses.push(msg);
-          pendingIds.delete(msg.id);
+          awaitingId = null;
+          sendNext();
         }
-      }
-      if (pendingIds.size === 0) {
-        proc.stdin?.end();
       }
     });
 
@@ -282,10 +340,10 @@ function runAcpHandshake(
     });
 
     proc.on("close", (code) => {
-      if (pendingIds.size > 0) {
+      if (responses.length < steps.length) {
         reject(
           new Error(
-            `acp process exited before answering all requests (missing ids: ${[...pendingIds].join(",")}). stderr: ${stderr}`,
+            `acp process exited after ${responses.length}/${steps.length} responses. stderr: ${stderr}`,
           ),
         );
         return;
@@ -295,9 +353,7 @@ function runAcpHandshake(
 
     proc.on("error", reject);
 
-    for (const req of requests) {
-      proc.stdin?.write(`${JSON.stringify(req)}\n`);
-    }
+    sendNext();
 
     setTimeout(() => {
       proc.kill();

--- a/packages/runner-pi/src/__tests__/tool-approval.test.ts
+++ b/packages/runner-pi/src/__tests__/tool-approval.test.ts
@@ -80,8 +80,9 @@ describe("waitForApproval", () => {
       timeoutMs: 100,
     });
 
-    // Give the synchronous write a tick, then inspect the file.
-    await new Promise((r) => setTimeout(r, 20));
+    // waitForApproval writes the pending file synchronously, before its first
+    // await, so it is readable the moment the call returns. Sleeping first
+    // would race the timeout, whose cleanup deletes this file.
     const raw = JSON.parse(fs.readFileSync(approvalFile("call-1"), "utf-8"));
     expect(raw).toEqual({
       status: "pending",
@@ -113,7 +114,6 @@ describe("waitForApproval", () => {
       pollIntervalMs: 10,
       timeoutMs: 100,
     });
-    await new Promise((r) => setTimeout(r, 20));
     const raw = JSON.parse(fs.readFileSync(approvalFile("call-2"), "utf-8"));
     expect(raw.toolName).toBe("bash");
     expect(raw.input).toEqual({ command: "ls" });
@@ -132,7 +132,6 @@ describe("waitForApproval", () => {
       timeoutMs: 100,
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 20));
     const raw = JSON.parse(
       fs.readFileSync(approvalFile("call-legacy"), "utf-8"),
     );

--- a/packages/server-acp/src/__tests__/acp-agent.test.ts
+++ b/packages/server-acp/src/__tests__/acp-agent.test.ts
@@ -7,6 +7,8 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const createRunnerCalls: Array<Record<string, unknown>> = [];
+/** userInput of every runner whose abort signal fired. */
+const abortedRunners: string[] = [];
 
 vi.mock("@bunny-agent/runner-harness", async () => {
   const actual = await vi.importActual<
@@ -32,6 +34,9 @@ vi.mock("@bunny-agent/runner-harness", async () => {
       }
       const userInput = opts.userInput as string;
       const abort = opts.abortController as AbortController | undefined;
+      abort?.signal.addEventListener("abort", () => {
+        abortedRunners.push(userInput);
+      });
       return (async function* () {
         if (userInput === "__THROW__") {
           yield `data: ${JSON.stringify({ type: "error", errorText: "runner exploded" })}\n\n`;
@@ -71,6 +76,7 @@ import { createBunnyAgentAcpApp } from "../acp-agent.js";
 describe("BunnyAgent ACP agent", () => {
   beforeEach(() => {
     createRunnerCalls.length = 0;
+    abortedRunners.length = 0;
   });
 
   it("negotiates the protocol version on initialize", async () => {
@@ -315,6 +321,38 @@ describe("BunnyAgent ACP agent", () => {
     } finally {
       connection.close();
     }
+  });
+
+  it("aborts the runner when the client disconnects mid-prompt", async () => {
+    const agentApp = createBunnyAgentAcpApp();
+    const clientApp = client({ name: "test-client" });
+    const connection = clientApp.connect(agentApp as never);
+
+    await connection.agent.request(methods.agent.initialize, {
+      protocolVersion: PROTOCOL_VERSION,
+      clientCapabilities: {},
+    });
+    const session = await connection.agent.request(methods.agent.session.new, {
+      cwd: "/workspace",
+      mcpServers: [],
+    });
+
+    connection.agent
+      .request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "__HANG__" }],
+      })
+      .catch(() => undefined);
+
+    // Let the turn reach the runner, then drop the connection without any
+    // session/cancel — an editor being closed, or a network drop.
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(createRunnerCalls).toHaveLength(1);
+    connection.close();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Without this the runner would keep running on a long-lived daemon.
+    expect(abortedRunners).toContain("__HANG__");
   });
 
   it("keeps runner selection isolated between concurrent sessions", async () => {

--- a/packages/server-acp/src/__tests__/acp-agent.test.ts
+++ b/packages/server-acp/src/__tests__/acp-agent.test.ts
@@ -16,6 +16,20 @@ vi.mock("@bunny-agent/runner-harness", async () => {
     ...actual,
     createRunner: vi.fn((opts: Record<string, unknown>) => {
       createRunnerCalls.push(opts);
+      // Mirror dispatchRunner's contract: an unrecognised runner throws
+      // synchronously (runner-harness/src/runner.ts), rather than failing
+      // somewhere inside the stream.
+      const KNOWN_RUNNERS = [
+        "claude",
+        "codex",
+        "gemini",
+        "opencode",
+        "copilot",
+        "pi",
+      ];
+      if (!KNOWN_RUNNERS.includes(opts.runner as string)) {
+        throw new Error(`Unknown runner: ${opts.runner}`);
+      }
       const userInput = opts.userInput as string;
       const abort = opts.abortController as AbortController | undefined;
       return (async function* () {
@@ -425,6 +439,96 @@ describe("BunnyAgent ACP agent", () => {
           prompt: [{ type: "text", text: "hi" }],
         }),
       ).rejects.toThrow(/Unknown session/);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("surfaces an unknown runner from _meta as invalidParams, not a bare internal error", async () => {
+    const agentApp = createBunnyAgentAcpApp();
+    const clientApp = client({ name: "test-client" });
+    const connection = clientApp.connect(agentApp as never);
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await connection.agent.request(
+        methods.agent.session.new,
+        {
+          cwd: "/workspace",
+          mcpServers: [],
+          // A plausible client-side typo — must not read as "Internal error".
+          _meta: { "bunny-agent": { runner: "claude-code" } },
+        },
+      );
+
+      const error = await connection.agent
+        .request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hi" }],
+        })
+        .then(
+          () => undefined,
+          (e) => e as { code?: number; message?: string; data?: unknown },
+        );
+
+      expect(error).toBeDefined();
+      // -32602 invalid params, not -32603 internal error.
+      expect(error?.code).toBe(-32602);
+      // The real reason must reach the client, not just "Invalid params".
+      expect(error?.message).toMatch(/Unknown runner: claude-code/);
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("clears the abort handle when runner setup fails", async () => {
+    const agentApp = createBunnyAgentAcpApp();
+    const clientApp = client({ name: "test-client" });
+    const connection = clientApp.connect(agentApp as never);
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await connection.agent.request(
+        methods.agent.session.new,
+        {
+          cwd: "/workspace",
+          mcpServers: [],
+          _meta: { "bunny-agent": { runner: "nope" } },
+        },
+      );
+
+      await connection.agent
+        .request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hi" }],
+        })
+        .catch(() => undefined);
+
+      // A cancel after a failed setup must be inert, not act on a stale
+      // controller left behind by the failure.
+      await expect(
+        connection.agent.notify(methods.agent.session.cancel, {
+          sessionId: session.sessionId,
+        }),
+      ).resolves.toBeUndefined();
+
+      // The session is still usable afterwards.
+      createRunnerCalls.length = 0;
+      const result = await connection.agent
+        .request(methods.agent.session.prompt, {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "hi" }],
+        })
+        .catch((e) => e);
+      // Still the same invalidParams (the bad runner is session state), but the
+      // point is the server stayed responsive rather than wedging.
+      expect(result).toBeDefined();
     } finally {
       connection.close();
     }

--- a/packages/server-acp/src/acp-agent.ts
+++ b/packages/server-acp/src/acp-agent.ts
@@ -108,22 +108,35 @@ export function createBunnyAgentAcpApp(
       session.abort = abort;
       const serializer = new AcpSessionUpdateSerializer();
 
-      const chunks = parseRunnerStream(
-        createRunner({
-          runner: session.runner ?? options.defaultRunner ?? "claude",
-          model: session.model ?? options.defaultModel ?? DEFAULT_MODEL,
-          userInput: promptToText(params.prompt),
-          systemPrompt: session.systemPrompt,
-          cwd: session.cwd,
-          yolo: session.yolo ?? options.yolo,
-          env: options.env,
-          abortController: abort,
-          // Caller owns session/resume; don't touch cwd/.bunny-agent state.
-          autoInject: false,
-        }),
-      );
-
       try {
+        let chunks: ReturnType<typeof parseRunnerStream>;
+        try {
+          // createRunner dispatches synchronously, so setup failures (an
+          // unknown runner from `_meta`, malformed input) land here rather than
+          // in the stream. Surfacing them as invalidParams keeps the real
+          // reason visible; letting them escape would reach the client as a
+          // bare JSON-RPC "Internal error".
+          chunks = parseRunnerStream(
+            createRunner({
+              runner: session.runner ?? options.defaultRunner ?? "claude",
+              model: session.model ?? options.defaultModel ?? DEFAULT_MODEL,
+              userInput: promptToText(params.prompt),
+              systemPrompt: session.systemPrompt,
+              cwd: session.cwd,
+              yolo: session.yolo ?? options.yolo,
+              env: options.env,
+              abortController: abort,
+              // Caller owns session/resume; don't touch cwd/.bunny-agent state.
+              autoInject: false,
+            }),
+          );
+        } catch (error) {
+          throw RequestError.invalidParams(
+            undefined,
+            error instanceof Error ? error.message : String(error),
+          );
+        }
+
         for await (const update of serializer.serialize(chunks)) {
           await client.notify(methods.client.session.update, {
             sessionId: params.sessionId,

--- a/packages/server-acp/src/acp-agent.ts
+++ b/packages/server-acp/src/acp-agent.ts
@@ -95,60 +95,70 @@ export function createBunnyAgentAcpApp(
       return { sessionId };
     })
 
-    .onRequest(methods.agent.session.prompt, async ({ params, client }) => {
-      const session = sessions.get(params.sessionId);
-      if (!session) {
-        throw RequestError.invalidParams(
-          undefined,
-          `Unknown session: ${params.sessionId}`,
-        );
-      }
-
-      const abort = new AbortController();
-      session.abort = abort;
-      const serializer = new AcpSessionUpdateSerializer();
-
-      try {
-        let chunks: ReturnType<typeof parseRunnerStream>;
-        try {
-          // createRunner dispatches synchronously, so setup failures (an
-          // unknown runner from `_meta`, malformed input) land here rather than
-          // in the stream. Surfacing them as invalidParams keeps the real
-          // reason visible; letting them escape would reach the client as a
-          // bare JSON-RPC "Internal error".
-          chunks = parseRunnerStream(
-            createRunner({
-              runner: session.runner ?? options.defaultRunner ?? "claude",
-              model: session.model ?? options.defaultModel ?? DEFAULT_MODEL,
-              userInput: promptToText(params.prompt),
-              systemPrompt: session.systemPrompt,
-              cwd: session.cwd,
-              yolo: session.yolo ?? options.yolo,
-              env: options.env,
-              abortController: abort,
-              // Caller owns session/resume; don't touch cwd/.bunny-agent state.
-              autoInject: false,
-            }),
-          );
-        } catch (error) {
+    .onRequest(
+      methods.agent.session.prompt,
+      async ({ params, client, signal }) => {
+        const session = sessions.get(params.sessionId);
+        if (!session) {
           throw RequestError.invalidParams(
             undefined,
-            error instanceof Error ? error.message : String(error),
+            `Unknown session: ${params.sessionId}`,
           );
         }
 
-        for await (const update of serializer.serialize(chunks)) {
-          await client.notify(methods.client.session.update, {
-            sessionId: params.sessionId,
-            update,
-          });
-        }
-      } finally {
-        session.abort = undefined;
-      }
+        const abort = new AbortController();
+        session.abort = abort;
+        // Transport-level cancellation — the client disconnecting, or the
+        // request being cancelled — must stop the runner too. Without this a
+        // dropped editor connection leaves it running on a long-lived daemon.
+        const onTransportAbort = () => abort.abort();
+        if (signal.aborted) abort.abort();
+        else signal.addEventListener("abort", onTransportAbort, { once: true });
+        const serializer = new AcpSessionUpdateSerializer();
 
-      return { stopReason: serializer.stopReason };
-    })
+        try {
+          let chunks: ReturnType<typeof parseRunnerStream>;
+          try {
+            // createRunner dispatches synchronously, so setup failures (an
+            // unknown runner from `_meta`, malformed input) land here rather
+            // than in the stream. Surfacing them as invalidParams keeps the
+            // real reason visible; letting them escape would reach the client
+            // as a bare JSON-RPC "Internal error".
+            chunks = parseRunnerStream(
+              createRunner({
+                runner: session.runner ?? options.defaultRunner ?? "claude",
+                model: session.model ?? options.defaultModel ?? DEFAULT_MODEL,
+                userInput: promptToText(params.prompt),
+                systemPrompt: session.systemPrompt,
+                cwd: session.cwd,
+                yolo: session.yolo ?? options.yolo,
+                env: options.env,
+                abortController: abort,
+                // Caller owns session/resume; don't touch cwd/.bunny-agent.
+                autoInject: false,
+              }),
+            );
+          } catch (error) {
+            throw RequestError.invalidParams(
+              undefined,
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+
+          for await (const update of serializer.serialize(chunks)) {
+            await client.notify(methods.client.session.update, {
+              sessionId: params.sessionId,
+              update,
+            });
+          }
+        } finally {
+          signal.removeEventListener("abort", onTransportAbort);
+          session.abort = undefined;
+        }
+
+        return { stopReason: serializer.stopReason };
+      },
+    )
 
     .onNotification(methods.agent.session.cancel, ({ params }) => {
       sessions.get(params.sessionId)?.abort?.abort();


### PR DESCRIPTION
Follow-up to #405. Those commits landed on the branch after #405 was merged, so they never made it into `main` — this carries them over, rebased onto current `main`.

## Two bugs in the ACP agent

Both were found by probing the merged surface, root-caused, and covered by tests that fail when the fix is reverted (verified against `main`'s version of the file).

**A dropped ACP connection leaked a running runner.** Only `session/cancel` stopped a turn. An editor closing mid-prompt — or a network drop — left the runner going on a long-lived daemon, still burning tokens and CPU with nothing to send its output to. The stdio/CLI case hid this, since the process exits anyway.

The ACP SDK already hands request handlers an `AbortSignal` covering exactly this ("AbortSignal for the current request, or the connection signal"); `session/prompt` just wasn't using it. It now forwards that signal to the runner's `AbortController` and drops the listener in `finally`, so a long-lived connection signal doesn't accumulate one listener per turn.

**An unknown runner in `_meta` came back as `-32603 Internal error`.** A typo, or targeting a runner built into a different image, produced a code that means *the server broke*, with the real reason buried in `data.details`. `createRunner()` dispatches synchronously, so the throw escaped the handler's `try` entirely. It's now `-32602` with the reason in the message, and `session.abort` is no longer left pointing at a stale controller after a failed setup.

The `server-acp` mock accepted any runner name, so it could not have caught the second one — it now mirrors `dispatchRunner`'s contract.

## Flaky test fix

Three `runner-pi` tool-approval tests start `waitForApproval` with a 100 ms deadline, then sleep 20 ms before reading the pending file — but the deadline path *deletes* that file, so under load the read hits ENOENT. One failed during this branch's runs.

`waitForApproval` writes that file synchronously, before its first `await`, so it's readable the moment the call returns. Dropping the sleep removes the race outright and preserves the timeout semantics these tests assert (including the timeout-marker answers from #401), rather than widening the window. The remaining short deadlines in that file *want* the timeout to fire and don't race a read against it, so they're unchanged.

## Release

Includes the changeset #405 was missing: `minor` for the publishable packages (daemon gained `/api/coding/acp`, runner-cli gained `bunny-agent acp`); the rest of the `fixed` group moves with them. `server-acp`/`server-ai-sdk` are `private` and bundled at build time, so changesets picks them up as dependents rather than publishing them — verified with `changeset status`.

## Verification

- `pnpm run -w lint`, `pnpm -r build`, `pnpm -r typecheck` clean.
- `pnpm -r test` green across all 22 packages, run twice; `runner-pi` passes 6/6 in isolation.
- Both ACP fixes verified to fail against `main`'s `acp-agent.ts` (`expected [] to include '__HANG__'`, `expected -32603 to be -32602`) and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)