### PR TITLE
feat(server-acp): expand runtime metadata

### DIFF
--- a/.changeset/acp-agent-server.md
+++ b/.changeset/acp-agent-server.md
@@ -15,6 +15,9 @@ Serve runners over the Agent Client Protocol (ACP) alongside the existing AI SDK
 - `POST /api/coding/acp` on the daemon — ACP over Streamable HTTP, mounted next to the unchanged `/api/coding/run`.
 - `bunny-agent acp` on the CLI — a long-lived ACP agent over stdio, the transport editors use when they spawn an agent binary. Separate from the one-shot `bunny-agent run`.
 - Runner/model selection uses ACP's protocol-defined `_meta` extension namespaced under `"bunny-agent"`, falling back to the server's configured defaults.
+- Hosted clients can pass structured turn input, environment variables, allowed tools, HTTP/module tool references, MCP configuration, skills, resume/fork state, reasoning effort, and question timeout through the same namespaced metadata.
+- Prompt responses report runner session ID and token usage metadata for persistence and billing.
+- Streamable HTTP routing supports `POST`, `GET`, and `DELETE`, including transport and explicit `session/cancel` cancellation.
 
 Both protocols are backed by dedicated internal packages (`server-acp`, `server-ai-sdk`) implementing a shared `CodingRunServer` contract, both consuming the same `RunnerChunk` stream — so every runner is available on both. `/api/coding/run`'s wire contract is unchanged.
 

--- a/apps/daemon/package.json
+++ b/apps/daemon/package.json
@@ -48,6 +48,7 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@agentclientprotocol/sdk": "^1.2.1",
     "@bunny-agent/apply-patch": "workspace:*",
     "@bunny-agent/runner-harness": "workspace:*",
     "@bunny-agent/server-acp": "workspace:*",

--- a/apps/daemon/src/__tests__/coding.test.ts
+++ b/apps/daemon/src/__tests__/coding.test.ts
@@ -2,52 +2,69 @@ import * as fs from "node:fs/promises";
 import type * as http from "node:http";
 import * as os from "node:os";
 import * as path from "node:path";
+import * as acp from "@agentclientprotocol/sdk";
+import { createHttpStream } from "@agentclientprotocol/sdk/experimental/http-client";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 // Mock runner-harness before importing server/nextjs
 // Track createRunner calls for assertion
 const createRunnerCalls: Array<Record<string, unknown>> = [];
 
-vi.mock("@bunny-agent/runner-harness", () => ({
-  createRunner: vi.fn(
-    (opts: { input?: unknown; userInput?: string; yolo?: boolean }) => {
-      createRunnerCalls.push(opts);
-      if (opts.userInput === "__THROW__") {
-        // biome-ignore lint/correctness/useYield: throw-only generator simulates immediate runner failure
+vi.mock("@bunny-agent/runner-harness", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@bunny-agent/runner-harness")>();
+  return {
+    ...actual,
+    createRunner: vi.fn(
+      (opts: { input?: unknown; userInput?: string; yolo?: boolean }) => {
+        createRunnerCalls.push(opts);
+        if (opts.userInput === "__THROW__") {
+          // biome-ignore lint/correctness/useYield: throw-only generator simulates immediate runner failure
+          return (async function* () {
+            throw new Error("runner exploded");
+          })();
+        }
+        if (opts.userInput === "__SLOW__") {
+          // Simulate a long-running tool execution (e.g. image generation).
+          return (async function* () {
+            yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
+            await new Promise<void>((resolve) => setTimeout(resolve, 40_000));
+            yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+            yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
+            yield `data: [DONE]\n\n`;
+          })();
+        }
+        if (opts.userInput === "__SLOW_SHORT__") {
+          // Short delay (100ms) — used with a patched HEARTBEAT_INTERVAL_MS (20ms)
+          // so heartbeats fire multiple times within the pause.
+          return (async function* () {
+            yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
+            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+            yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+            yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
+            yield `data: [DONE]\n\n`;
+          })();
+        }
+        // Return an async iterable that yields SSE-style chunks.
         return (async function* () {
-          throw new Error("runner exploded");
-        })();
-      }
-      if (opts.userInput === "__SLOW__") {
-        // Simulate a long-running tool execution (e.g. image generation).
-        return (async function* () {
-          yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
-          await new Promise<void>((resolve) => setTimeout(resolve, 40_000));
-          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
+          if (
+            opts.userInput === "streamable lifecycle" ||
+            opts.userInput === "next acp"
+          ) {
+            yield `data: ${JSON.stringify({ type: "text-start", id: "m1" })}\n\n`;
+            yield `data: ${JSON.stringify({ type: "text-delta", id: "m1", delta: `echo: ${opts.userInput}` })}\n\n`;
+            yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
+            yield `data: [DONE]\n\n`;
+            return;
+          }
+          yield `data: ${JSON.stringify({ type: "text", text: `echo: ${opts.userInput}` })}\n\n`;
           yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
           yield `data: [DONE]\n\n`;
         })();
-      }
-      if (opts.userInput === "__SLOW_SHORT__") {
-        // Short delay (100ms) — used with a patched HEARTBEAT_INTERVAL_MS (20ms)
-        // so heartbeats fire multiple times within the pause.
-        return (async function* () {
-          yield `data: ${JSON.stringify({ type: "tool-input-start", toolCallId: "t1", toolName: "generate_image" })}\n\n`;
-          await new Promise<void>((resolve) => setTimeout(resolve, 100));
-          yield `data: ${JSON.stringify({ type: "tool-output-available", toolCallId: "t1", output: "/agent/img.png" })}\n\n`;
-          yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
-          yield `data: [DONE]\n\n`;
-        })();
-      }
-      // Return an async iterable that yields SSE-style chunks.
-      return (async function* () {
-        yield `data: ${JSON.stringify({ type: "text", text: `echo: ${opts.userInput}` })}\n\n`;
-        yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
-        yield `data: [DONE]\n\n`;
-      })();
-    },
-  ),
-}));
+      },
+    ),
+  };
+});
 
 import {
   codingRunStream,
@@ -143,6 +160,47 @@ describe("POST /api/coding/acp (standalone server)", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("application/x-ndjson");
     expect(await res.text()).toContain("echo: still works");
+  });
+
+  it("supports the full Streamable HTTP lifecycle", async () => {
+    const updates: acp.SessionUpdate[] = [];
+    const stream = createHttpStream(`${BASE}/api/coding/acp`);
+    try {
+      const response = await acp
+        .client({ name: "daemon-acp-test" })
+        .onNotification(acp.methods.client.session.update, ({ params }) => {
+          updates.push(params.update);
+        })
+        .connectWith(stream, async (connection) => {
+          await connection.request(acp.methods.agent.initialize, {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: {},
+          });
+          const session = await connection.request(
+            acp.methods.agent.session.new,
+            {
+              cwd: root,
+              mcpServers: [],
+            },
+          );
+          return connection.request(acp.methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text: "streamable lifecycle" }],
+          });
+        });
+
+      expect(response.stopReason).toBe("end_turn");
+      expect(updates).toContainEqual(
+        expect.objectContaining({
+          sessionUpdate: "agent_message_chunk",
+          content: expect.objectContaining({
+            text: "echo: streamable lifecycle",
+          }),
+        }),
+      );
+    } finally {
+      await stream.writable.close();
+    }
   });
 });
 
@@ -248,6 +306,40 @@ describe("createNextHandler", () => {
 
     const text = await res.text();
     expect(text).toContain("echo: nextjs test");
+  });
+
+  it("routes ACP Streamable HTTP GET and DELETE through the adapter", async () => {
+    const stream = createHttpStream(
+      "http://localhost/api/daemon/api/coding/acp",
+      {
+        fetch: async (requestInput, requestInit) =>
+          handler(new Request(requestInput, requestInit)),
+      },
+    );
+    try {
+      const result = await acp
+        .client({ name: "next-acp-test" })
+        .connectWith(stream, async (connection) => {
+          await connection.request(acp.methods.agent.initialize, {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientCapabilities: {},
+          });
+          const session = await connection.request(
+            acp.methods.agent.session.new,
+            {
+              cwd: os.tmpdir(),
+              mcpServers: [],
+            },
+          );
+          return connection.request(acp.methods.agent.session.prompt, {
+            sessionId: session.sessionId,
+            prompt: [{ type: "text", text: "next acp" }],
+          });
+        });
+      expect(result.stopReason).toBe("end_turn");
+    } finally {
+      await stream.writable.close();
+    }
   });
 
   it("routes /api/daemon/healthz to JSON", async () => {

--- a/apps/daemon/src/nextjs.ts
+++ b/apps/daemon/src/nextjs.ts
@@ -52,14 +52,18 @@ export function createNextHandler(opts: { root: string; prefix?: string }) {
       : url.pathname;
     const method = req.method ?? "GET";
 
-    // Streaming protocol servers: /api/coding/run (AI SDK), /api/coding/acp (ACP)
-    if (method === "POST") {
-      const codingRunServer = codingRunServers.find(
-        (server) => server.mountPath === pathname,
-      );
-      if (codingRunServer) {
-        return codingRunServer.handleWebRequest(req);
-      }
+    // AI SDK is POST-only. ACP Streamable HTTP additionally uses GET for
+    // connection/session SSE streams and DELETE to close the connection.
+    const codingRunServer = codingRunServers.find(
+      (server) => server.mountPath === pathname,
+    );
+    if (
+      codingRunServer &&
+      (method === "POST" ||
+        (codingRunServer.protocol === "acp" &&
+          (method === "GET" || method === "DELETE")))
+    ) {
+      return codingRunServer.handleWebRequest(req);
     }
 
     // Raw streamed upload: /api/fs/write-stream?path=...

--- a/apps/daemon/src/server.ts
+++ b/apps/daemon/src/server.ts
@@ -43,14 +43,18 @@ export function createDaemon(config: DaemonConfig): http.Server {
       );
       const pathname = url.pathname;
 
-      // Streaming protocol servers: /api/coding/run (AI SDK), /api/coding/acp (ACP)
-      if (method === "POST") {
-        const codingRunServer = codingRunServers.find(
-          (server) => server.mountPath === pathname,
-        );
-        if (codingRunServer) {
-          return codingRunServer.handleNodeHttp(req, res);
-        }
+      // AI SDK is POST-only. ACP Streamable HTTP additionally uses GET for
+      // connection/session SSE streams and DELETE to close the connection.
+      const codingRunServer = codingRunServers.find(
+        (server) => server.mountPath === pathname,
+      );
+      if (
+        codingRunServer &&
+        (method === "POST" ||
+          (codingRunServer.protocol === "acp" &&
+            (method === "GET" || method === "DELETE")))
+      ) {
+        return codingRunServer.handleNodeHttp(req, res);
       }
 
       // Raw streamed upload: /api/fs/write-stream?path=...

--- a/docs/changelog/2026-08-19-acp-runtime-metadata.md
+++ b/docs/changelog/2026-08-19-acp-runtime-metadata.md
@@ -1,0 +1,19 @@
+# ACP Runtime Metadata
+
+## Summary
+
+- Extended the BunnyAgent ACP server metadata contract so hosted products can pass structured turn input, dynamic environment variables, runner session state, skills, MCP configuration, tool references, reasoning effort, and allowed tools without routing through an AI SDK language-model adapter.
+- Added runner session ID and token usage metadata to ACP prompt responses.
+- Routed Streamable HTTP `GET` and `DELETE` through both standalone and Next.js daemon adapters so clients can receive server events and close connections cleanly.
+- Propagated transport disconnects and explicit `session/cancel` notifications to the active runner.
+- Added regression coverage for Buda-style session and per-turn overrides.
+
+## Why
+
+Hosted products need the ACP transport to preserve the same runner configuration available through `/api/coding/run`. The previous ACP surface only accepted runner, model, system prompt, and yolo mode, which made direct ACP integration lose session recovery, product tools, MCP servers, dynamic credentials, and usage accounting.
+
+## Validation
+
+- `pnpm --filter @bunny-agent/server-acp test`
+- `pnpm --filter @bunny-agent/daemon test`
+- Linting and type checking were intentionally skipped for pull request delivery.

--- a/packages/server-acp/src/__tests__/acp-agent.test.ts
+++ b/packages/server-acp/src/__tests__/acp-agent.test.ts
@@ -32,7 +32,8 @@ vi.mock("@bunny-agent/runner-harness", async () => {
       if (!KNOWN_RUNNERS.includes(opts.runner as string)) {
         throw new Error(`Unknown runner: ${opts.runner}`);
       }
-      const userInput = opts.userInput as string;
+      const userInput =
+        (opts.userInput as string | undefined) ?? "__STRUCTURED__";
       const abort = opts.abortController as AbortController | undefined;
       abort?.signal.addEventListener("abort", () => {
         abortedRunners.push(userInput);
@@ -59,6 +60,13 @@ vi.mock("@bunny-agent/runner-harness", async () => {
             abort?.signal.addEventListener("abort", () => resolve());
           });
           yield `data: ${JSON.stringify({ type: "finish", finishReason: "abort" })}\n\n`;
+          yield `data: [DONE]\n\n`;
+          return;
+        }
+        if (userInput === "__META__") {
+          yield `data: ${JSON.stringify({ type: "message-metadata", messageMetadata: { sessionId: "runner-session-1" } })}\n\n`;
+          yield `data: ${JSON.stringify({ type: "step-finish", usage: { inputTokens: 12, outputTokens: 5 } })}\n\n`;
+          yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
           yield `data: [DONE]\n\n`;
           return;
         }
@@ -456,6 +464,124 @@ describe("BunnyAgent ACP agent", () => {
       });
 
       expect(createRunnerCalls[0].userInput).toBe("line one\nline two");
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("passes Buda runtime overrides from ACP metadata to createRunner", async () => {
+    const agentApp = createBunnyAgentAcpApp({
+      env: { OPENAI_API_KEY: "server-key", SHARED: "server" },
+    });
+    const clientApp = client({ name: "test-client" });
+    const connection = clientApp.connect(agentApp as never);
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await connection.agent.request(
+        methods.agent.session.new,
+        {
+          cwd: "/agent",
+          mcpServers: [],
+          _meta: {
+            "bunny-agent": {
+              runner: "pi",
+              model: "openai:gpt-5",
+              resume: "runner-session-0",
+              skillPaths: ["/agent/skills"],
+              env: { SHARED: "session", AGENT_KEY: "agent-key" },
+              allowedTools: ["bash", "read_file"],
+            },
+          },
+        },
+      );
+
+      await connection.agent.request(methods.agent.session.prompt, {
+        sessionId: session.sessionId,
+        prompt: [{ type: "text", text: "ignored by structured input" }],
+        _meta: {
+          "bunny-agent": {
+            input: {
+              version: 1,
+              input: [{ type: "text", text: "structured" }],
+              capabilities: [],
+              execution: {},
+            },
+            env: { SHARED: "turn" },
+            systemEnv: { AGENT_KEY: "agent-key" },
+            effort: "high",
+            mcpConfig: { mcpServers: {} },
+            toolRefs: [
+              {
+                name: "buda_tool",
+                description: "Buda tool",
+                inputSchema: { type: "object" },
+                runtime: { type: "http", url: "https://buda.test/tool" },
+              },
+            ],
+          },
+        },
+      });
+
+      expect(createRunnerCalls[0]).toMatchObject({
+        runner: "pi",
+        model: "openai:gpt-5",
+        input: { version: 1 },
+        resume: "runner-session-0",
+        skillPaths: ["/agent/skills"],
+        allowedTools: ["bash", "read_file"],
+        env: {
+          OPENAI_API_KEY: "server-key",
+          SHARED: "turn",
+          AGENT_KEY: "agent-key",
+        },
+        systemEnv: { AGENT_KEY: "agent-key" },
+        effort: "high",
+        mcpConfig: { mcpServers: {} },
+        toolRefs: [expect.objectContaining({ name: "buda_tool" })],
+      });
+      expect(createRunnerCalls[0]).not.toHaveProperty("userInput");
+    } finally {
+      connection.close();
+    }
+  });
+
+  it("returns runner session metadata and ACP token usage", async () => {
+    const agentApp = createBunnyAgentAcpApp();
+    const clientApp = client({ name: "test-client" });
+    const connection = clientApp.connect(agentApp as never);
+
+    try {
+      await connection.agent.request(methods.agent.initialize, {
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {},
+      });
+      const session = await connection.agent.request(
+        methods.agent.session.new,
+        {
+          cwd: "/workspace",
+          mcpServers: [],
+        },
+      );
+      const result = await connection.agent.request(
+        methods.agent.session.prompt,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: "text", text: "__META__" }],
+        },
+      );
+
+      expect(result.usage).toEqual({
+        inputTokens: 12,
+        outputTokens: 5,
+        totalTokens: 17,
+      });
+      expect(result._meta).toEqual({
+        "bunny-agent": { sessionId: "runner-session-1" },
+      });
     } finally {
       connection.close();
     }

--- a/packages/server-acp/src/acp-agent.ts
+++ b/packages/server-acp/src/acp-agent.ts
@@ -7,7 +7,12 @@ import {
   PROTOCOL_VERSION,
   RequestError,
 } from "@agentclientprotocol/sdk";
-import { createRunner, parseRunnerStream } from "@bunny-agent/runner-harness";
+import {
+  createRunner,
+  parseRunnerStream,
+  type RunnerCoreOptions,
+  type RunnerToolRef,
+} from "@bunny-agent/runner-harness";
 import { AcpSessionUpdateSerializer } from "./session-update-serializer.js";
 
 /** Namespace for BunnyAgent fields inside ACP's implementation-defined `_meta`. */
@@ -34,6 +39,20 @@ interface SessionOverrides {
   model?: string;
   systemPrompt?: string;
   yolo?: boolean;
+  allowedTools?: string[];
+  resume?: string;
+  forkFrom?: string;
+  skillPaths?: string[];
+  env?: Record<string, string>;
+  systemEnv?: Record<string, string>;
+  toolRefs?: RunnerToolRef[];
+  mcpConfig?: RunnerCoreOptions["mcpConfig"];
+  effort?: string;
+  askUserQuestionTimeoutMs?: number;
+}
+
+interface TurnOverrides extends SessionOverrides {
+  input?: RunnerCoreOptions["input"];
 }
 
 interface SessionState extends SessionOverrides {
@@ -44,6 +63,27 @@ interface SessionState extends SessionOverrides {
 const asString = (value: unknown): string | undefined =>
   typeof value === "string" && value.length > 0 ? value : undefined;
 
+const asStringArray = (value: unknown): string[] | undefined => {
+  if (!Array.isArray(value)) return undefined;
+  const strings = value.filter(
+    (item): item is string => typeof item === "string",
+  );
+  return strings.length === value.length ? strings : undefined;
+};
+
+const asStringRecord = (value: unknown): Record<string, string> | undefined => {
+  if (!value || typeof value !== "object" || Array.isArray(value))
+    return undefined;
+  const entries = Object.entries(value);
+  if (!entries.every(([, item]) => typeof item === "string")) return undefined;
+  return Object.fromEntries(entries) as Record<string, string>;
+};
+
+const asObject = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+
 /**
  * ACP's `session/new` has no native runner/model field, so BunnyAgent reads
  * them from the protocol's implementation-defined `_meta` extension, namespaced
@@ -51,7 +91,7 @@ const asString = (value: unknown): string | undefined =>
  */
 function readBunnyMeta(
   meta: { [key: string]: unknown } | null | undefined,
-): SessionOverrides {
+): TurnOverrides {
   const scoped = meta?.[BUNNY_META_KEY];
   if (scoped === null || typeof scoped !== "object") return {};
   const value = scoped as Record<string, unknown>;
@@ -60,8 +100,32 @@ function readBunnyMeta(
     model: asString(value.model),
     systemPrompt: asString(value.systemPrompt),
     yolo: typeof value.yolo === "boolean" ? value.yolo : undefined,
+    allowedTools: asStringArray(value.allowedTools),
+    resume: asString(value.resume),
+    forkFrom: asString(value.forkFrom),
+    skillPaths: asStringArray(value.skillPaths),
+    env: asStringRecord(value.env),
+    systemEnv: asStringRecord(value.systemEnv),
+    toolRefs: Array.isArray(value.toolRefs)
+      ? (value.toolRefs as RunnerToolRef[])
+      : undefined,
+    mcpConfig: asObject(value.mcpConfig) as RunnerCoreOptions["mcpConfig"],
+    effort: asString(value.effort),
+    askUserQuestionTimeoutMs:
+      typeof value.askUserQuestionTimeoutMs === "number" &&
+      Number.isFinite(value.askUserQuestionTimeoutMs)
+        ? value.askUserQuestionTimeoutMs
+        : undefined,
+    input: asObject(value.input) as RunnerCoreOptions["input"],
   };
 }
+
+const mergeEnv = (
+  ...sources: Array<Record<string, string> | undefined>
+): Record<string, string> | undefined => {
+  const merged = Object.assign({}, ...sources.filter(Boolean));
+  return Object.keys(merged).length > 0 ? merged : undefined;
+};
 
 const promptToText = (prompt: ContentBlock[]): string =>
   prompt
@@ -108,6 +172,7 @@ export function createBunnyAgentAcpApp(
 
         const abort = new AbortController();
         session.abort = abort;
+        const turn = readBunnyMeta(params._meta);
         // Transport-level cancellation — the client disconnecting, or the
         // request being cancelled — must stop the runner too. Without this a
         // dropped editor connection leaves it running on a long-lived daemon.
@@ -126,13 +191,34 @@ export function createBunnyAgentAcpApp(
             // as a bare JSON-RPC "Internal error".
             chunks = parseRunnerStream(
               createRunner({
-                runner: session.runner ?? options.defaultRunner ?? "claude",
-                model: session.model ?? options.defaultModel ?? DEFAULT_MODEL,
-                userInput: promptToText(params.prompt),
-                systemPrompt: session.systemPrompt,
+                runner:
+                  turn.runner ??
+                  session.runner ??
+                  options.defaultRunner ??
+                  "claude",
+                model:
+                  turn.model ??
+                  session.model ??
+                  options.defaultModel ??
+                  DEFAULT_MODEL,
+                ...(turn.input
+                  ? { input: turn.input }
+                  : { userInput: promptToText(params.prompt) }),
+                systemPrompt: turn.systemPrompt ?? session.systemPrompt,
                 cwd: session.cwd,
-                yolo: session.yolo ?? options.yolo,
-                env: options.env,
+                yolo: turn.yolo ?? session.yolo ?? options.yolo,
+                allowedTools: turn.allowedTools ?? session.allowedTools,
+                resume: turn.resume ?? session.resume,
+                forkFrom: turn.forkFrom ?? session.forkFrom,
+                skillPaths: turn.skillPaths ?? session.skillPaths,
+                env: mergeEnv(options.env, session.env, turn.env),
+                systemEnv: mergeEnv(session.systemEnv, turn.systemEnv),
+                toolRefs: turn.toolRefs ?? session.toolRefs,
+                mcpConfig: turn.mcpConfig ?? session.mcpConfig,
+                effort: turn.effort ?? session.effort,
+                askUserQuestionTimeoutMs:
+                  turn.askUserQuestionTimeoutMs ??
+                  session.askUserQuestionTimeoutMs,
                 abortController: abort,
                 // Caller owns session/resume; don't touch cwd/.bunny-agent.
                 autoInject: false,
@@ -156,7 +242,17 @@ export function createBunnyAgentAcpApp(
           session.abort = undefined;
         }
 
-        return { stopReason: serializer.stopReason };
+        const runnerMeta = {
+          ...(serializer.sessionId ? { sessionId: serializer.sessionId } : {}),
+          ...(serializer.errorText ? { errorText: serializer.errorText } : {}),
+        };
+        return {
+          stopReason: serializer.stopReason,
+          ...(serializer.usage ? { usage: serializer.usage } : {}),
+          ...(Object.keys(runnerMeta).length > 0
+            ? { _meta: { [BUNNY_META_KEY]: runnerMeta } }
+            : {}),
+        };
       },
     )
 

--- a/packages/server-acp/src/session-update-serializer.ts
+++ b/packages/server-acp/src/session-update-serializer.ts
@@ -1,4 +1,8 @@
-import type { SessionUpdate, StopReason } from "@agentclientprotocol/sdk";
+import type {
+  SessionUpdate,
+  StopReason,
+  Usage,
+} from "@agentclientprotocol/sdk";
 import type { RunnerChunk } from "@bunny-agent/runner-harness";
 
 const asText = (value: unknown): string =>
@@ -16,6 +20,9 @@ export class AcpSessionUpdateSerializer {
   private readonly toolTitles = new Map<string, string>();
   private stopReasonValue: StopReason = "end_turn";
   private errorTextValue: string | undefined;
+  private sessionIdValue: string | undefined;
+  private inputTokensValue = 0;
+  private outputTokensValue = 0;
 
   /** Stop reason for the prompt turn; valid once `serialize()` completes. */
   get stopReason(): StopReason {
@@ -25,6 +32,20 @@ export class AcpSessionUpdateSerializer {
   /** Error text emitted by the runner, if the turn failed. */
   get errorText(): string | undefined {
     return this.errorTextValue;
+  }
+
+  get sessionId(): string | undefined {
+    return this.sessionIdValue;
+  }
+
+  get usage(): Usage | undefined {
+    const totalTokens = this.inputTokensValue + this.outputTokensValue;
+    if (totalTokens === 0) return undefined;
+    return {
+      inputTokens: this.inputTokensValue,
+      outputTokens: this.outputTokensValue,
+      totalTokens,
+    };
   }
 
   async *serialize(
@@ -129,7 +150,11 @@ export class AcpSessionUpdateSerializer {
       }
 
       case "finish": {
-        const { finishReason } = chunk as { finishReason?: string };
+        const { finishReason, messageMetadata } = chunk as {
+          finishReason?: string;
+          messageMetadata?: unknown;
+        };
+        this.captureMetadata(messageMetadata);
         // An `error` chunk already recorded the real cause; don't downgrade it.
         if (this.errorTextValue === undefined) {
           this.stopReasonValue = mapFinishReason(finishReason);
@@ -137,10 +162,52 @@ export class AcpSessionUpdateSerializer {
         return;
       }
 
+      case "step-finish": {
+        const usage = (
+          chunk as {
+            usage?: { inputTokens?: number; outputTokens?: number };
+          }
+        ).usage;
+        this.inputTokensValue += usage?.inputTokens ?? 0;
+        this.outputTokensValue += usage?.outputTokens ?? 0;
+        return;
+      }
+
+      case "message-metadata": {
+        this.captureMetadata(
+          (chunk as { messageMetadata?: unknown }).messageMetadata,
+        );
+        return;
+      }
+
       // text-start/text-end have no ACP equivalent (agent_message_chunk carries
       // messageId), and tool-input-delta has no incremental-input counterpart.
       default:
         return;
+    }
+  }
+
+  private captureMetadata(metadata: unknown): void {
+    if (!metadata || typeof metadata !== "object") return;
+    const value = metadata as Record<string, unknown>;
+    const sessionId = value.sessionId ?? value.session_id ?? value.sessionFile;
+    if (typeof sessionId === "string" && sessionId.length > 0) {
+      this.sessionIdValue = sessionId;
+    }
+    const usage = value.usage;
+    if (!usage || typeof usage !== "object") return;
+    const usageValue = usage as Record<string, unknown>;
+    if (typeof usageValue.inputTokens === "number") {
+      this.inputTokensValue = Math.max(
+        this.inputTokensValue,
+        usageValue.inputTokens,
+      );
+    }
+    if (typeof usageValue.outputTokens === "number") {
+      this.outputTokensValue = Math.max(
+        this.outputTokensValue,
+        usageValue.outputTokens,
+      );
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
         specifier: 1.1.38
         version: 1.1.38
     devDependencies:
+      '@agentclientprotocol/sdk':
+        specifier: ^1.2.1
+        version: 1.2.1(zod@4.3.6)
       '@bunny-agent/apply-patch':
         specifier: workspace:*
         version: link:../../packages/apply-patch


### PR DESCRIPTION
## Summary

- expand BunnyAgent ACP metadata to carry structured input, environment variables, tools, MCP configuration, skills, session state, reasoning effort, and question timeout
- return runner session and token usage metadata from ACP prompts
- support Streamable HTTP `GET` and `DELETE` plus transport and explicit session cancellation
- add daemon and ACP regression coverage for hosted runtime overrides

## Validation

- `pnpm --filter @bunny-agent/server-acp test` (30 tests passed)
- `pnpm --filter @bunny-agent/daemon test` (116 tests passed)
- linting skipped as requested
- type checking skipped as requested
