### PR TITLE
fix(pi): preserve Gemini length termination

### DIFF
--- a/docs/changelog/2026-08-24-pi-gemini-length-handling.md
+++ b/docs/changelog/2026-08-24-pi-gemini-length-handling.md
@@ -1,0 +1,27 @@
+# Preserve Pi length termination for Gemini 3.7 Flash
+
+## Summary
+
+- Use the published Gemini 3.7 Flash context and output limits when Pi dynamically registers the LiteLLM model alias.
+- Preserve Pi's `length` stop reason in the AI SDK stream instead of reporting a normal `stop` completion.
+- Add focused regression coverage for model capability resolution and length-terminated streams.
+
+## Context
+
+Buda routes `openai:gemini-3.7-flash` through an OpenAI-compatible LiteLLM proxy backed by Vertex AI. Because the alias is not in Pi's built-in model catalog, Bunny previously registered it with generic `128000` context and `8192` output limits. Pi sent that output limit to LiteLLM, causing reasoning-heavy responses to end with `stopReason: "length"` after 8192 generated tokens.
+
+The stream converter then reported every non-error `agent_end` event as `finishReason: "stop"`, so callers could not distinguish truncated output from a complete response.
+
+## Implementation
+
+- Added a dynamic model profile resolver with Gemini 3.7 Flash set to a `1048576` token context window and `65536` maximum output tokens.
+- Marked Gemini 3.7 Flash as reasoning-capable even when the caller accepts Vertex's default thinking level instead of specifying an effort.
+- Read the final assistant message's Pi stop reason during `agent_end` conversion and map `length` to the AI SDK `length` finish reason.
+- Included the raw Pi stop reason as `messageMetadata.providerStopReason` for downstream diagnostics.
+
+## Verification
+
+- Built `@bunny-agent/runner-pi` and its workspace dependencies.
+- Ran the complete runner-pi test suite: 15 files and 189 tests passed.
+- Ran the runner-pi TypeScript type check successfully.
+- Ran Biome checks on all changed TypeScript files successfully.

--- a/packages/runner-pi/src/__tests__/pi-runner.parse-model-spec.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.parse-model-spec.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   parseModelSpec,
+  resolveDynamicModelProfile,
   resolveImageModelName,
   stripLLMThoughtSignaturesFromSessionManager,
 } from "../pi-runner.js";
@@ -44,6 +45,35 @@ describe("parseModelSpec", () => {
       provider: "openai",
       modelName: "gpt-4o",
     });
+  });
+});
+
+describe("resolveDynamicModelProfile", () => {
+  it("uses the published Gemini 3.7 Flash limits", () => {
+    expect(resolveDynamicModelProfile("gemini-3.7-flash")).toEqual({
+      contextWindow: 1_048_576,
+      maxTokens: 65_536,
+      reasoning: true,
+    });
+  });
+
+  it("matches known model aliases case-insensitively", () => {
+    expect(resolveDynamicModelProfile("GEMINI-3.7-FLASH")).toEqual({
+      contextWindow: 1_048_576,
+      maxTokens: 65_536,
+      reasoning: true,
+    });
+  });
+
+  it("retains the generic profile for unknown aliases", () => {
+    expect(resolveDynamicModelProfile("custom-model")).toEqual({
+      contextWindow: 128_000,
+      maxTokens: 8_192,
+      reasoning: false,
+    });
+    expect(resolveDynamicModelProfile("custom-model", "high").reasoning).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/runner-pi/src/__tests__/stream-converter.test.ts
+++ b/packages/runner-pi/src/__tests__/stream-converter.test.ts
@@ -77,6 +77,53 @@ describe("PiAISDKStreamConverter text-delta passthrough", () => {
   });
 });
 
+describe("PiAISDKStreamConverter finish reason", () => {
+  it("preserves length termination after partial text", () => {
+    const conv = makeConverter();
+    conv.handleEvent(textStart(), false);
+    conv.handleEvent(textDelta("Partial response"), false);
+
+    const chunks = conv.handleEvent(
+      {
+        type: "agent_end",
+        messages: [
+          {
+            role: "assistant",
+            stopReason: "length",
+          },
+        ],
+      } as AgentSessionEvent,
+      false,
+    );
+    const events = eventsOf(chunks);
+
+    expect(events.map((event) => event.type)).toEqual(["text-end", "finish"]);
+    expect(events[1]).toEqual({
+      type: "finish",
+      finishReason: "length",
+      messageMetadata: { providerStopReason: "length" },
+    });
+    expect(chunks).toContain("data: [DONE]\n\n");
+  });
+
+  it("keeps normal assistant termination as stop", () => {
+    const conv = makeConverter();
+    const chunks = conv.handleEvent(
+      {
+        type: "agent_end",
+        messages: [{ role: "assistant", stopReason: "stop" }],
+      } as AgentSessionEvent,
+      false,
+    );
+
+    expect(eventsOf(chunks)).toContainEqual({
+      type: "finish",
+      finishReason: "stop",
+      messageMetadata: { providerStopReason: "stop" },
+    });
+  });
+});
+
 describe("PiAISDKStreamConverter tool output", () => {
   it("emits structured answers for ask-user-question results", () => {
     const conv = makeConverter();

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -52,6 +52,28 @@ import { getUsageFromAgentEndMessages } from "./usage-metadata.js";
 const LOG_PREFIX = "[bunny-agent:pi]";
 const LLM_THOUGHT_SIGNATURE_SEPARATOR = "__thought__";
 
+export interface DynamicModelProfile {
+  contextWindow: number;
+  maxTokens: number;
+  reasoning: boolean;
+}
+
+const DEFAULT_DYNAMIC_MODEL_PROFILE = {
+  contextWindow: 128_000,
+  maxTokens: 8_192,
+} as const;
+
+const DYNAMIC_MODEL_PROFILES: Record<
+  string,
+  Omit<DynamicModelProfile, "reasoning"> & { reasoning?: boolean }
+> = {
+  "gemini-3.7-flash": {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+  },
+};
+
 export interface PiRunnerOptions {
   model?: string;
   systemPrompt?: string;
@@ -126,6 +148,19 @@ export interface PiRunnerOptions {
 
 export interface PiRunner {
   run(userInput: string | AgentTurnInputV1): AsyncIterable<string>;
+}
+
+export function resolveDynamicModelProfile(
+  modelName: string,
+  effort?: string,
+): DynamicModelProfile {
+  const profile = DYNAMIC_MODEL_PROFILES[modelName.toLowerCase()];
+  return {
+    contextWindow:
+      profile?.contextWindow ?? DEFAULT_DYNAMIC_MODEL_PROFILE.contextWindow,
+    maxTokens: profile?.maxTokens ?? DEFAULT_DYNAMIC_MODEL_PROFILE.maxTokens,
+    reasoning: profile?.reasoning ?? Boolean(effort && effort !== "off"),
+  };
 }
 
 export async function disposePiSession(
@@ -440,6 +475,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
                 `Set ${baseUrlEnvKey} (or OPENAI_BASE_URL) to auto-register it.`,
             );
           }
+          const profile = resolveDynamicModelProfile(modelName, options.effort);
           // Pi resolves `apiKey` via resolveConfigValue: env var name -> process.env, else literal.
           modelRuntime.registerProvider(provider, {
             baseUrl,
@@ -449,15 +485,15 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
               {
                 id: modelName,
                 name: modelName,
-                reasoning: !!options.effort && options.effort !== "off",
+                reasoning: profile.reasoning,
                 thinkingLevelMap: { off: null, xhigh: "xhigh" } as Record<
                   string,
                   string | null
                 >,
                 input: ["text", "image"],
                 cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-                contextWindow: 128000,
-                maxTokens: 8192,
+                contextWindow: profile.contextWindow,
+                maxTokens: profile.maxTokens,
               },
             ],
           });

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -97,6 +97,18 @@ function sseData(obj: Record<string, unknown>): string {
   return "data: " + JSON.stringify(obj) + "\n\n";
 }
 
+export function getProviderStopReasonFromAgentEndMessages(
+  messages: Array<{ role: string; stopReason?: string }>,
+): string | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role === "assistant" && message.stopReason) {
+      return message.stopReason;
+    }
+  }
+  return undefined;
+}
+
 export class PiAISDKStreamConverter {
   private readonly messageId =
     "msg_" + Date.now() + "_" + Math.random().toString(36).slice(2);
@@ -203,12 +215,18 @@ export class PiAISDKStreamConverter {
           event.messages,
         );
         if (errorMsg) chunks.push(...this.finishError(errorMsg));
-        else
+        else {
+          const providerStopReason = getProviderStopReasonFromAgentEndMessages(
+            event.messages,
+          );
           chunks.push(
             ...this.finishSuccess(
               this.options.getUsageFromAgentEndMessages(event.messages),
+              providerStopReason === "length" ? "length" : "stop",
+              providerStopReason,
             ),
           );
+        }
       }
       return chunks;
     }
@@ -264,9 +282,14 @@ export class PiAISDKStreamConverter {
     return [sseData({ type: "text-end", id })];
   }
 
-  private finishSuccess(usage?: Usage): string[] {
+  private finishSuccess(
+    usage?: Usage,
+    finishReason: "stop" | "length" = "stop",
+    providerStopReason?: string,
+  ): string[] {
     const chunks = [...this.endTextStreamIfOpen()];
     const raw: Record<string, Record<string, unknown>> = {};
+    const messageMetadata: Record<string, unknown> = {};
     // Capture chat-level usage before tool tally may overwrite the same key.
     let chatUsage: Record<string, unknown> | undefined;
     if (usage) {
@@ -282,10 +305,16 @@ export class PiAISDKStreamConverter {
     }
     const finishPayload: Record<string, unknown> = {
       type: "finish",
-      finishReason: "stop",
+      finishReason,
     };
     if (usage) {
-      finishPayload.messageMetadata = { usage: { ...chatUsage, raw } };
+      messageMetadata.usage = { ...chatUsage, raw };
+    }
+    if (providerStopReason) {
+      messageMetadata.providerStopReason = providerStopReason;
+    }
+    if (Object.keys(messageMetadata).length > 0) {
+      finishPayload.messageMetadata = messageMetadata;
     }
     chunks.push(sseData(finishPayload), "data: [DONE]\n\n");
     this.hasFinished = true;


### PR DESCRIPTION
## Description

Pi dynamically registered the LiteLLM alias `openai:gemini-3.7-flash` with a generic 8,192-token output limit. This caused Pi to send `max_tokens: 8192` to LLM and allowed reasoning-heavy Vertex responses to terminate before producing a complete answer.

This change:

- registers Gemini 3.7 Flash with a 1,048,576-token context window and a 65,536-token maximum output
- marks the model as reasoning-capable without requiring an explicit effort setting
- maps Pi `stopReason: "length"` to AI SDK `finishReason: "length"`
- exposes the raw provider stop reason in finish message metadata
- preserves the generic profile for unknown LLM aliases

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Performance improvement


## How Has This Been Tested?

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [x] Documentation updated

## Test Results

- `corepack pnpm --filter @bunny-agent/runner-pi... build`
- `corepack pnpm --filter @bunny-agent/runner-pi test`: 15 files and 189 tests passed
- `corepack pnpm --filter @bunny-agent/runner-pi typecheck`
- Focused Biome check passed for all changed TypeScript files

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have added a changeset (if affecting published packages)

## Additional Notes

`@bunny-agent/runner-pi` is private, so this change does not add a package changeset. Downstream callers should consume `finishReason: "length"` if they need to distinguish truncated output from a complete response.
