### PR TITLE
fix: run nginx as non-root agent

### DIFF
--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -159,7 +159,7 @@ RUN printf '%s\n' \
     'error_log /tmp/nginx/error.log;' \
     'events {}' \
     'http {' \
-    '    access_log /tmp/nginx/access.log;' \
+    '    access_log off;' \
     '    client_body_temp_path /tmp/nginx/client_body;' \
     '    proxy_temp_path /tmp/nginx/proxy;' \
     '    fastcgi_temp_path /tmp/nginx/fastcgi;' \

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -153,7 +153,24 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 # Create CDP (Chrome DevTools Protocol) startup script
 # Use nginx to proxy and rewrite Host header to localhost,
 # bypassing Chromium's Host header security check
-RUN echo 'server {\n\
+RUN printf '%s\n' \
+    'worker_processes auto;' \
+    'pid /tmp/nginx/nginx.pid;' \
+    'error_log /tmp/nginx/error.log;' \
+    'events {}' \
+    'http {' \
+    '    access_log /tmp/nginx/access.log;' \
+    '    client_body_temp_path /tmp/nginx/client_body;' \
+    '    proxy_temp_path /tmp/nginx/proxy;' \
+    '    fastcgi_temp_path /tmp/nginx/fastcgi;' \
+    '    uwsgi_temp_path /tmp/nginx/uwsgi;' \
+    '    scgi_temp_path /tmp/nginx/scgi;' \
+    '    include /etc/nginx/mime.types;' \
+    '    default_type application/octet-stream;' \
+    '    sendfile on;' \
+    '    include /etc/nginx/conf.d/*.conf;' \
+    '}' > /etc/nginx/nginx.conf && \
+    echo 'server {\n\
     listen 9222;\n\
     location / {\n\
         proxy_pass http://127.0.0.1:9223;\n\
@@ -175,7 +192,9 @@ for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\
   sleep 0.5\n\
 done\n\
-sudo nginx\n\
+mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi /tmp/nginx/uwsgi /tmp/nginx/scgi\n\
+nginx -t\n\
+nginx\n\
 echo "CDP available on 0.0.0.0:9222 (nginx proxy rewriting Host to localhost)"' > /usr/local/bin/start-cdp && \
     chmod +x /usr/local/bin/start-cdp
 

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -135,7 +135,24 @@ RUN for i in 1 2 3; do \
     rm -rf /var/lib/apt/lists/* && break || sleep 5; \
     done
 
-RUN echo 'server {\n\
+RUN printf '%s\n' \
+    'worker_processes auto;' \
+    'pid /tmp/nginx/nginx.pid;' \
+    'error_log /tmp/nginx/error.log;' \
+    'events {}' \
+    'http {' \
+    '    access_log /tmp/nginx/access.log;' \
+    '    client_body_temp_path /tmp/nginx/client_body;' \
+    '    proxy_temp_path /tmp/nginx/proxy;' \
+    '    fastcgi_temp_path /tmp/nginx/fastcgi;' \
+    '    uwsgi_temp_path /tmp/nginx/uwsgi;' \
+    '    scgi_temp_path /tmp/nginx/scgi;' \
+    '    include /etc/nginx/mime.types;' \
+    '    default_type application/octet-stream;' \
+    '    sendfile on;' \
+    '    include /etc/nginx/conf.d/*.conf;' \
+    '}' > /etc/nginx/nginx.conf && \
+    echo 'server {\n\
     listen 9222;\n\
     location / {\n\
         proxy_pass http://127.0.0.1:9223;\n\
@@ -156,6 +173,8 @@ for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\
   sleep 0.5\n\
 done\n\
+mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi /tmp/nginx/uwsgi /tmp/nginx/scgi\n\
+nginx -t\n\
 nginx\n\
 echo "CDP available on 0.0.0.0:9222 (nginx proxy rewriting Host to localhost)"' > /usr/local/bin/start-cdp && \
     chmod +x /usr/local/bin/start-cdp

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -141,7 +141,7 @@ RUN printf '%s\n' \
     'error_log /tmp/nginx/error.log;' \
     'events {}' \
     'http {' \
-    '    access_log /tmp/nginx/access.log;' \
+    '    access_log off;' \
     '    client_body_temp_path /tmp/nginx/client_body;' \
     '    proxy_temp_path /tmp/nginx/proxy;' \
     '    fastcgi_temp_path /tmp/nginx/fastcgi;' \

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -126,7 +126,24 @@ RUN for i in 1 2 3; do \
     rm -rf /var/lib/apt/lists/* && break || sleep 5; \
     done
 
-RUN echo 'server {\n\
+RUN printf '%s\n' \
+    'worker_processes auto;' \
+    'pid /tmp/nginx/nginx.pid;' \
+    'error_log /tmp/nginx/error.log;' \
+    'events {}' \
+    'http {' \
+    '    access_log /tmp/nginx/access.log;' \
+    '    client_body_temp_path /tmp/nginx/client_body;' \
+    '    proxy_temp_path /tmp/nginx/proxy;' \
+    '    fastcgi_temp_path /tmp/nginx/fastcgi;' \
+    '    uwsgi_temp_path /tmp/nginx/uwsgi;' \
+    '    scgi_temp_path /tmp/nginx/scgi;' \
+    '    include /etc/nginx/mime.types;' \
+    '    default_type application/octet-stream;' \
+    '    sendfile on;' \
+    '    include /etc/nginx/conf.d/*.conf;' \
+    '}' > /etc/nginx/nginx.conf && \
+    echo 'server {\n\
     listen 9222;\n\
     location / {\n\
         proxy_pass http://127.0.0.1:9223;\n\
@@ -147,6 +164,8 @@ for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\
   sleep 0.5\n\
 done\n\
+mkdir -p /tmp/nginx/client_body /tmp/nginx/proxy /tmp/nginx/fastcgi /tmp/nginx/uwsgi /tmp/nginx/scgi\n\
+nginx -t\n\
 nginx\n\
 echo "CDP available on 0.0.0.0:9222 (nginx proxy rewriting Host to localhost)"' > /usr/local/bin/start-cdp && \
     chmod +x /usr/local/bin/start-cdp

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -132,7 +132,7 @@ RUN printf '%s\n' \
     'error_log /tmp/nginx/error.log;' \
     'events {}' \
     'http {' \
-    '    access_log /tmp/nginx/access.log;' \
+    '    access_log off;' \
     '    client_body_temp_path /tmp/nginx/client_body;' \
     '    proxy_temp_path /tmp/nginx/proxy;' \
     '    fastcgi_temp_path /tmp/nginx/fastcgi;' \

--- a/docs/changelog/2026-08-28-non-root-nginx-runtime.md
+++ b/docs/changelog/2026-08-28-non-root-nginx-runtime.md
@@ -1,6 +1,6 @@
 # Non-root Nginx runtime
 
 - Configured the CDP Nginx proxy to run as the `agent` user without `sudo` or a privileged master process.
-- Moved the Nginx PID, access log, error log, and all temporary files under `/tmp/nginx`.
+- Disabled access logging and moved the Nginx PID, error log, and all temporary files under `/tmp/nginx`.
 - Added runtime directory creation and configuration validation before Nginx starts.
 - Applied the non-root configuration consistently across the published, local, and generated Dockerfiles.

--- a/docs/changelog/2026-08-28-non-root-nginx-runtime.md
+++ b/docs/changelog/2026-08-28-non-root-nginx-runtime.md
@@ -1,0 +1,6 @@
+# Non-root Nginx runtime
+
+- Configured the CDP Nginx proxy to run as the `agent` user without `sudo` or a privileged master process.
+- Moved the Nginx PID, access log, error log, and all temporary files under `/tmp/nginx`.
+- Added runtime directory creation and configuration validation before Nginx starts.
+- Applied the non-root configuration consistently across the published, local, and generated Dockerfiles.


### PR DESCRIPTION
## Summary

- configure the CDP Nginx proxy without a privileged master process
- store the PID, error log, and temporary files under /tmp/nginx
- disable Nginx access logging so error.log is the only log file
- validate the Nginx configuration before startup in all three Dockerfiles

## Testing

- docker build --check for Dockerfile
- docker build --check for Dockerfile.local
- docker build --check for the rendered Dockerfile.template
- verified nginx -t and startup as non-root UID 1000
- verified a request creates error.log and does not create access.log
- git diff --check