### PR TITLE
fix: preserve structured storage-full errors

### DIFF
--- a/.changeset/structured-storage-errors.md
+++ b/.changeset/structured-storage-errors.md
@@ -1,0 +1,6 @@
+---
+"@bunny-agent/manager": patch
+"@bunny-agent/sdk": patch
+---
+
+Emit and restore a stable `WORKSPACE_STORAGE_FULL` error code for disk quota failures.

--- a/docs/changelog/2026-09-02-structured-storage-full-errors.md
+++ b/docs/changelog/2026-09-02-structured-storage-full-errors.md
@@ -1,0 +1,7 @@
+# Structured workspace storage errors
+
+- Added a shared BunnyAgent error normalizer for `EDQUOT`, `ENOSPC`, errno `-122`/`-28`, and known legacy runtime messages.
+- Emit the stable `WORKSPACE_STORAGE_FULL` code and a path-free user-safe message from Pi, the runner harness, and the daemon error envelope.
+- Preserve typed Pi prompt errors until normalization instead of reducing them to message strings.
+- Restore daemon error codes as `BunnyAgentStreamError.code` in the SDK, including compatibility with older daemon text-only streams.
+- Added focused tests for system fields, legacy text, provider quota false positives, SSE output, daemon envelopes, and SDK round trips.

--- a/packages/manager/src/__tests__/errors.test.ts
+++ b/packages/manager/src/__tests__/errors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeBunnyAgentError,
+  WORKSPACE_STORAGE_FULL_ERROR_CODE,
+  WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+} from "../errors.js";
+
+describe("normalizeBunnyAgentError", () => {
+  it.each([
+    "EDQUOT",
+    "ENOSPC",
+  ])("normalizes the %s system code without exposing paths", (code) => {
+    const error = Object.assign(new Error("write failed at /agent/private"), {
+      code,
+      path: "/agent/private",
+    });
+
+    expect(normalizeBunnyAgentError(error)).toEqual({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+  });
+
+  it.each([
+    -122,
+    -28,
+    "-122",
+    "-28",
+  ])("normalizes numeric errno %s", (errno) => {
+    expect(normalizeBunnyAgentError({ errno })).toEqual({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+  });
+
+  it("is idempotent for a normalized error", () => {
+    const normalized = normalizeBunnyAgentError({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+    expect(normalized).toEqual({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+  });
+
+  it.each([
+    "Unknown system error -122",
+    "Unknown system error -122, close",
+    "EDQUOT: disk quota exceeded, write",
+    "ENOSPC: no space left on device, write",
+  ])("normalizes the legacy message %j", (message) => {
+    expect(normalizeBunnyAgentError(new Error(message))).toEqual({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+  });
+
+  it("inspects the typed cause chain", () => {
+    const cause = Object.assign(new Error("write failed"), { code: "ENOSPC" });
+    expect(
+      normalizeBunnyAgentError(new Error("session failed", { cause })),
+    ).toEqual({
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    });
+  });
+
+  it.each([
+    "Quota exceeded for model tokens",
+    "API quota exceeded",
+    "Usage limit exceeded",
+  ])("does not misclassify a provider quota message %j", (message) => {
+    expect(normalizeBunnyAgentError(new Error(message))).toEqual({
+      errorText: message,
+    });
+  });
+});

--- a/packages/manager/src/errors.ts
+++ b/packages/manager/src/errors.ts
@@ -1,0 +1,97 @@
+export const WORKSPACE_STORAGE_FULL_ERROR_CODE =
+  "WORKSPACE_STORAGE_FULL" as const;
+export const WORKSPACE_STORAGE_FULL_ERROR_TEXT = "Workspace storage is full.";
+
+export type BunnyAgentErrorCode = typeof WORKSPACE_STORAGE_FULL_ERROR_CODE;
+
+export interface BunnyAgentErrorPayload {
+  errorText: string;
+  errorCode?: BunnyAgentErrorCode;
+}
+
+interface ErrorLike {
+  cause?: unknown;
+  code?: unknown;
+  errorCode?: unknown;
+  errno?: unknown;
+  message?: unknown;
+}
+
+const STORAGE_FULL_CODES = new Set([
+  "EDQUOT",
+  "ENOSPC",
+  WORKSPACE_STORAGE_FULL_ERROR_CODE,
+]);
+const STORAGE_FULL_ERRNOS = new Set([-122, -28]);
+const STORAGE_FULL_MESSAGE_PATTERNS = [
+  /\bunknown system error -122\b/i,
+  /\bdisk quota exceeded\b/i,
+  /\bno space left on device\b/i,
+];
+
+function isErrorLike(value: unknown): value is ErrorLike {
+  return typeof value === "object" && value !== null;
+}
+
+function getErrorText(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (isErrorLike(error) && typeof error.message === "string") {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isStorageFullError(error: unknown): boolean {
+  const visited = new Set<unknown>();
+  let current: unknown = error;
+
+  while (current !== undefined && current !== null && !visited.has(current)) {
+    visited.add(current);
+
+    if (isErrorLike(current)) {
+      const code =
+        typeof current.errorCode === "string"
+          ? current.errorCode
+          : current.code;
+      if (
+        typeof code === "string" &&
+        STORAGE_FULL_CODES.has(code.toUpperCase())
+      ) {
+        return true;
+      }
+      const errno =
+        typeof current.errno === "string" &&
+        /^-?(?:28|122)$/.test(current.errno)
+          ? Number(current.errno)
+          : current.errno;
+      if (typeof errno === "number" && STORAGE_FULL_ERRNOS.has(errno)) {
+        return true;
+      }
+    }
+
+    const message = getErrorText(current);
+    if (
+      STORAGE_FULL_MESSAGE_PATTERNS.some((pattern) => pattern.test(message))
+    ) {
+      return true;
+    }
+
+    current = isErrorLike(current) ? current.cause : undefined;
+  }
+
+  return false;
+}
+
+/** Convert runtime failures into the stable BunnyAgent wire error shape. */
+export function normalizeBunnyAgentError(
+  error: unknown,
+): BunnyAgentErrorPayload {
+  if (isStorageFullError(error)) {
+    return {
+      errorCode: WORKSPACE_STORAGE_FULL_ERROR_CODE,
+      errorText: WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+    };
+  }
+
+  return { errorText: getErrorText(error) };
+}

--- a/packages/manager/src/index.ts
+++ b/packages/manager/src/index.ts
@@ -15,6 +15,12 @@ export { isBunnyAgentDaemonHealthy } from "./daemon-health.js";
 export type { RunnerEnvParams, RunnerType } from "./env.js";
 // Env helpers
 export { buildRunnerEnv } from "./env.js";
+export type { BunnyAgentErrorCode, BunnyAgentErrorPayload } from "./errors.js";
+export {
+  normalizeBunnyAgentError,
+  WORKSPACE_STORAGE_FULL_ERROR_CODE,
+  WORKSPACE_STORAGE_FULL_ERROR_TEXT,
+} from "./errors.js";
 // Local adapters live in their own packages, mirroring the cloud adapters:
 // @bunny-agent/sandbox-local (LocalMachine — NO isolation) and
 // @bunny-agent/sandbox-srt (SrtSandbox — OS-level isolation via

--- a/packages/runner-harness/src/__tests__/stream.test.ts
+++ b/packages/runner-harness/src/__tests__/stream.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { parseRunnerStream } from "../stream.js";
+
+describe("parseRunnerStream", () => {
+  it("normalizes a thrown storage-full error", async () => {
+    const stream = (async function* () {
+      yield 'data: {"type":"start"}\n\n';
+      throw Object.assign(new Error("ENOSPC at /agent/private"), {
+        code: "ENOSPC",
+        path: "/agent/private",
+      });
+    })();
+
+    const chunks = [];
+    for await (const chunk of parseRunnerStream(stream)) chunks.push(chunk);
+
+    expect(chunks).toEqual([
+      { type: "start" },
+      {
+        type: "error",
+        errorCode: "WORKSPACE_STORAGE_FULL",
+        errorText: "Workspace storage is full.",
+      },
+    ]);
+  });
+});

--- a/packages/runner-harness/src/stream.ts
+++ b/packages/runner-harness/src/stream.ts
@@ -1,3 +1,5 @@
+import { normalizeBunnyAgentError } from "@bunny-agent/manager";
+
 /**
  * Stream utilities: parse runner AsyncIterable<string> (SSE lines) into
  * typed chunks. Uses rawValue fallback so non-standard fields (isError,
@@ -39,7 +41,7 @@ export type RunnerChunk =
       finishReason?: string;
       usage?: { inputTokens?: number; outputTokens?: number };
     }
-  | { type: "error"; errorText: string }
+  | { type: "error"; errorText: string; errorCode?: string }
   | { type: "message-metadata"; messageMetadata: unknown }
   // passthrough for anything else
   | { type: string; [key: string]: unknown };
@@ -97,9 +99,6 @@ export async function* parseRunnerStream(
       }
     }
   } catch (e: unknown) {
-    yield {
-      type: "error",
-      errorText: e instanceof Error ? e.message : String(e),
-    };
+    yield { type: "error", ...normalizeBunnyAgentError(e) };
   }
 }

--- a/packages/runner-pi/src/__tests__/stream-converter.test.ts
+++ b/packages/runner-pi/src/__tests__/stream-converter.test.ts
@@ -182,3 +182,32 @@ describe("PiAISDKStreamConverter tool output", () => {
     );
   });
 });
+
+describe("PiAISDKStreamConverter errors", () => {
+  it("emits a structured storage-full error without exposing the path", () => {
+    const conv = makeConverter();
+    const error = Object.assign(
+      new Error("ENOSPC: no space left on device, write /agent/private"),
+      {
+        code: "ENOSPC",
+        path: "/agent/private",
+      },
+    );
+
+    expect(eventsOf(conv.forceError(error))).toContainEqual({
+      type: "error",
+      errorCode: "WORKSPACE_STORAGE_FULL",
+      errorText: "Workspace storage is full.",
+    });
+  });
+
+  it("preserves an unrelated provider error", () => {
+    const conv = makeConverter();
+    expect(
+      eventsOf(conv.forceError(new Error("API quota exceeded"))),
+    ).toContainEqual({
+      type: "error",
+      errorText: "API quota exceeded",
+    });
+  });
+});

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -744,11 +744,7 @@ export function createPiRunner(options: PiRunnerOptions = {}): PiRunner {
           }
 
           if (promptError !== undefined) {
-            const message =
-              promptError instanceof Error
-                ? promptError.message
-                : "Pi agent run failed.";
-            for (const chunk of streamConverter.forceError(message)) {
+            for (const chunk of streamConverter.forceError(promptError)) {
               yield chunk;
             }
             return;

--- a/packages/runner-pi/src/stream-converter.ts
+++ b/packages/runner-pi/src/stream-converter.ts
@@ -1,3 +1,4 @@
+import { normalizeBunnyAgentError } from "@bunny-agent/manager";
 import type { Usage } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
 import type { ToolDetailsWithUsage } from "./tool-details.js";
@@ -29,9 +30,10 @@ const ASK_USER_QUESTION_TOOL_NAMES = new Set([
 ]);
 const ASK_USER_QUESTION_TIMEOUT_ANSWER_KEY = "__bunny_agent_timeout__";
 
-function emitStreamError(errorText: string): string[] {
+function emitStreamError(error: unknown): string[] {
+  const payload = normalizeBunnyAgentError(error);
   const errorLine =
-    "data: " + JSON.stringify({ type: "error", errorText }) + "\n\n";
+    "data: " + JSON.stringify({ type: "error", ...payload }) + "\n\n";
   const finishLine =
     "data: " +
     JSON.stringify({ type: "finish", finishReason: "error" }) +
@@ -123,9 +125,9 @@ export class PiAISDKStreamConverter {
     return this.hasFinished;
   }
 
-  forceError(errorText: string): string[] {
+  forceError(error: unknown): string[] {
     if (this.hasFinished) return [];
-    return [...this.ensureStart(), ...this.finishError(errorText)];
+    return [...this.ensureStart(), ...this.finishError(error)];
   }
 
   handleEvent(event: AgentSessionEvent, aborted: boolean): string[] {
@@ -321,8 +323,8 @@ export class PiAISDKStreamConverter {
     return chunks;
   }
 
-  private finishError(errorText: string): string[] {
+  private finishError(error: unknown): string[] {
     this.hasFinished = true;
-    return emitStreamError(errorText);
+    return emitStreamError(error);
   }
 }

--- a/packages/sdk/src/__tests__/storage-errors.test.ts
+++ b/packages/sdk/src/__tests__/storage-errors.test.ts
@@ -1,0 +1,82 @@
+import type {
+  BunnyAgentCodingRunBody,
+  ExecOptions,
+  SandboxAdapter,
+  SandboxHandle,
+} from "@bunny-agent/manager";
+import { streamText } from "ai";
+import { describe, expect, it } from "vitest";
+import { createBunnyAgent } from "../provider/bunny-agent-provider";
+import { BunnyAgentStreamError } from "../provider/errors";
+
+describe("BunnyAgent storage errors", () => {
+  it("restores a structured daemon error as a typed SDK error", async () => {
+    const error = await readStreamError([
+      'data: {"type":"error","errorCode":"WORKSPACE_STORAGE_FULL","errorText":"Workspace storage is full."}\n\n',
+      'data: {"type":"finish","finishReason":"error"}\n\n',
+      "data: [DONE]\n\n",
+    ]);
+
+    expect(error).toBeInstanceOf(BunnyAgentStreamError);
+    expect(error).toMatchObject({
+      code: "WORKSPACE_STORAGE_FULL",
+      message: "Workspace storage is full.",
+    });
+  });
+
+  it("normalizes a storage-full error from an older daemon", async () => {
+    const error = await readStreamError([
+      'data: {"type":"error","errorText":"ENOSPC: no space left on device, write /agent/private"}\n\n',
+      'data: {"type":"finish","finishReason":"error"}\n\n',
+      "data: [DONE]\n\n",
+    ]);
+
+    expect(error).toMatchObject({
+      code: "WORKSPACE_STORAGE_FULL",
+      message: "Workspace storage is full.",
+    });
+    expect((error as Error).message).not.toContain("/agent/private");
+  });
+});
+
+async function readStreamError(chunks: string[]): Promise<unknown> {
+  const bunnyAgent = createBunnyAgent({
+    sandbox: createStreamingSandbox(chunks),
+    daemonUrl: "http://127.0.0.1:3080",
+    runnerType: "pi",
+  });
+  const result = streamText({
+    model: bunnyAgent("openai:gpt-5"),
+    prompt: "test",
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === "error") return part.error;
+  }
+
+  throw new Error("Expected the stream to emit an error part.");
+}
+
+function createStreamingSandbox(chunks: string[]): SandboxAdapter {
+  const handle: SandboxHandle = {
+    getSandboxId: () => null,
+    getVolumes: () => null,
+    getWorkdir: () => "/workspace",
+    exec: async function* () {},
+    upload: async () => {},
+    readFile: async () => "",
+    destroy: async () => {},
+    streamCodingRun: async function* (
+      _body: BunnyAgentCodingRunBody,
+      _opts?: ExecOptions,
+    ) {
+      for (const chunk of chunks) yield new TextEncoder().encode(chunk);
+    },
+  };
+
+  return {
+    attach: async () => handle,
+    getHandle: () => handle,
+    getWorkdir: () => "/workspace",
+  };
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -74,6 +74,7 @@ export type {
 // Provider exports
 export {
   BunnyAgentLanguageModel,
+  BunnyAgentStreamError,
   bunnyHttpTool,
   bunnySandboxTool,
   createBunnyAgent,

--- a/packages/sdk/src/provider/bunny-agent-language-model.ts
+++ b/packages/sdk/src/provider/bunny-agent-language-model.ts
@@ -17,10 +17,12 @@ import {
   BunnyAgent,
   type BunnyAgentCodingRunBody,
   type Message,
+  normalizeBunnyAgentError,
   type RunnerSpec,
   streamCodingRunFromSandbox,
   type ToolRef,
 } from "@bunny-agent/manager";
+import { BunnyAgentStreamError } from "./errors";
 import { getProviderLogger } from "./logging";
 import { compileToolRefsFromLanguageModelTools } from "./tool-refs";
 import type {
@@ -739,10 +741,19 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
     // daemon NDJSON errors may arrive as: {"error":"..."} (without type)
     if (!parsedType && typeof parsed.error === "string") {
       this.receivedFinish = true;
+      const rawErrorCode =
+        typeof parsed.errorCode === "string" ? parsed.errorCode : undefined;
+      const normalized = normalizeBunnyAgentError({
+        errorCode: rawErrorCode,
+        message: parsed.error,
+      });
       return [
         {
           type: "error",
-          error: new Error(parsed.error),
+          error: new BunnyAgentStreamError(
+            normalized.errorText,
+            normalized.errorCode ?? rawErrorCode,
+          ),
         },
       ];
     }
@@ -933,12 +944,21 @@ export class BunnyAgentLanguageModel implements LanguageModelV3 {
       }
       case "error": {
         this.receivedFinish = true;
+        const errorText =
+          (parsed.errorText as string) ||
+          (parsed.error as string) ||
+          "Unknown stream error";
+        const rawErrorCode =
+          typeof parsed.errorCode === "string" ? parsed.errorCode : undefined;
+        const normalized = normalizeBunnyAgentError({
+          errorCode: rawErrorCode,
+          message: errorText,
+        });
         parts.push({
           type: "error",
-          error: new Error(
-            (parsed.errorText as string) ||
-              (parsed.error as string) ||
-              "Unknown stream error",
+          error: new BunnyAgentStreamError(
+            normalized.errorText,
+            normalized.errorCode ?? rawErrorCode,
           ),
         });
         break;

--- a/packages/sdk/src/provider/errors.ts
+++ b/packages/sdk/src/provider/errors.ts
@@ -1,0 +1,10 @@
+/** Error emitted by a BunnyAgent runner stream. */
+export class BunnyAgentStreamError extends Error {
+  readonly code?: string;
+
+  constructor(message: string, code?: string) {
+    super(message);
+    this.name = "BunnyAgentStreamError";
+    if (code !== undefined) this.code = code;
+  }
+}

--- a/packages/sdk/src/provider/index.ts
+++ b/packages/sdk/src/provider/index.ts
@@ -17,6 +17,7 @@ export type { BunnyAgentLanguageModelOptions } from "./bunny-agent-language-mode
 export { BunnyAgentLanguageModel } from "./bunny-agent-language-model";
 export type { BunnyAgentProvider } from "./bunny-agent-provider";
 export { createBunnyAgent } from "./bunny-agent-provider";
+export { BunnyAgentStreamError } from "./errors";
 export type { SubmitAnswerOptions } from "./question-processor";
 export { submitAnswer } from "./question-processor";
 export {

--- a/packages/server-ai-sdk/package.json
+++ b/packages/server-ai-sdk/package.json
@@ -20,6 +20,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@bunny-agent/manager": "workspace:*",
     "@bunny-agent/runner-harness": "workspace:*"
   },
   "devDependencies": {

--- a/packages/server-ai-sdk/src/__tests__/coding-run.test.ts
+++ b/packages/server-ai-sdk/src/__tests__/coding-run.test.ts
@@ -10,6 +10,12 @@ vi.mock("@bunny-agent/runner-harness", () => ({
       if (userInput === "__THROW__") {
         throw new Error("runner exploded");
       }
+      if (userInput === "__STORAGE_FULL__") {
+        throw Object.assign(
+          new Error("ENOSPC: no space left on device, write /agent/private"),
+          { code: "ENOSPC", path: "/agent/private" },
+        );
+      }
       yield `data: ${JSON.stringify({ type: "text-delta", id: "m1", delta: `echo: ${userInput}` })}\n\n`;
       yield `data: ${JSON.stringify({ type: "finish", finishReason: "stop" })}\n\n`;
       yield `data: [DONE]\n\n`;
@@ -65,6 +71,26 @@ describe("codingRunChunks", () => {
         `data: ${JSON.stringify({ type: "finish", finishReason: "error" })}\n\n` +
         `data: [DONE]\n\n`,
     );
+  });
+
+  it("emits a structured storage-full envelope without exposing paths", async () => {
+    const out = await drain(
+      codingRunChunks(
+        { userInput: "__STORAGE_FULL__" },
+        {},
+        new AbortController(),
+      ),
+    );
+    expect(out).toBe(
+      `data: ${JSON.stringify({
+        type: "error",
+        errorCode: "WORKSPACE_STORAGE_FULL",
+        errorText: "Workspace storage is full.",
+      })}\n\n` +
+        `data: ${JSON.stringify({ type: "finish", finishReason: "error" })}\n\n` +
+        `data: [DONE]\n\n`,
+    );
+    expect(out).not.toContain("/agent/private");
   });
 
   it("reports validation failures through the same envelope", async () => {

--- a/packages/server-ai-sdk/src/coding-run.ts
+++ b/packages/server-ai-sdk/src/coding-run.ts
@@ -1,4 +1,5 @@
 import type * as http from "node:http";
+import { normalizeBunnyAgentError } from "@bunny-agent/manager";
 import {
   createRunner,
   type RunnerCoreOptions,
@@ -74,11 +75,11 @@ export function setHeartbeatIntervalMs(ms: number): void {
 }
 
 const errorEnvelope = (err: unknown): string => {
-  const msg = err instanceof Error ? err.message : String(err);
+  const payload = normalizeBunnyAgentError(err);
   // Keep output format consistent with runner-cli (SSE `data:` events),
   // so the SDK can parse errors uniformly.
   return (
-    `data: ${JSON.stringify({ type: "error", errorText: msg })}\n\n` +
+    `data: ${JSON.stringify({ type: "error", ...payload })}\n\n` +
     `data: ${JSON.stringify({ type: "finish", finishReason: "error" })}\n\n` +
     `data: [DONE]\n\n`
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -924,6 +924,9 @@ importers:
 
   packages/server-ai-sdk:
     dependencies:
+      '@bunny-agent/manager':
+        specifier: workspace:*
+        version: link:../manager
       '@bunny-agent/runner-harness':
         specifier: workspace:*
         version: link:../runner-harness


### PR DESCRIPTION
## Problem

When a BunnyAgent workspace runs out of disk quota, EDQUOT, ENOSPC, and errno -122/-28 failures were reduced to plain error text. Callers could not reliably identify storage exhaustion, and raw filesystem paths could reach the user-facing error surface.

## Root Cause

The runner, daemon envelope, and SDK only preserved errorText and dropped the semantic error code between layers. Linux and Node.js also expose disk quota failures in several different shapes, which forced consumers to depend on fragile string matching.

## Changes

- Added shared error normalization in the manager for EDQUOT, ENOSPC, errno -122/-28, and legacy error messages from deployed images.
- Emit the stable WORKSPACE_STORAGE_FULL code with the path-free message Workspace storage is full.
- Preserve errorCode through the Pi runner, runner harness, and server-ai-sdk daemon envelope.
- Added BunnyAgentStreamError in the SDK and restore its code from both structured streams and legacy text-only streams.
- Explicitly exclude ordinary AI provider and API quota errors from storage-full classification.
- Added a changeset and focused cross-package regression tests.

## Validation

- 354 tests passed across manager, runner-harness, runner-pi, server-ai-sdk, and SDK.
- Type checks passed for all five affected packages.
- Scoped Biome checks and git diff --check passed for every changed file.
- Repository-wide lint is still blocked by the pre-existing untracked .worktrees/kapps-buda-sdk-upgrade/biome.json nested root configuration. This PR does not modify that directory.

## Release Notes

The structured error code takes effect after publishing the affected packages and rebuilding the BunnyAgent image. Buda also retains legacy text matching, so already deployed images receive the improved user-facing guidance.
