### PR TITLE
feat(web): add host-local demo execution mode

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,7 +1,12 @@
 # Example chat + /api/ai — copy to `.env.local` in this directory (`apps/web`).
 # Next.js loads env files from `apps/web` when you run `pnpm dev` here.
 
-# Required for E2B sandbox (example app default).
+# The public demo defaults to E2B when this is unset.
+# Set to local only when the web service already runs inside a trusted sandbox.
+# Local mode executes agent commands with the web service process permissions.
+SANDBOX_PROVIDER=e2b
+
+# Required only when the resolved provider is E2B.
 E2B_API_KEY=
 
 AGENT_KEY=

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -29,6 +29,21 @@ pnpm dev
 
 Open http://localhost:3000
 
+### Demo Execution Mode
+
+The example chat uses E2B by default. When the web service is already deployed
+inside a trusted sandbox, run the agent directly in that environment:
+
+```bash
+SANDBOX_PROVIDER=local pnpm dev
+```
+
+Local mode does not require an E2B, Sandock, or Daytona key. It executes agent
+commands with the web service process permissions, so do not enable it on an
+untrusted or shared host. A runner/model credential must still be available in
+the server environment or browser settings unless the configured Bunny Agent
+daemon already supplies it.
+
 ### Build
 
 ```bash

--- a/apps/web/app/(example)/example/page.tsx
+++ b/apps/web/app/(example)/example/page.tsx
@@ -49,6 +49,7 @@ import {
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
+import { getMissingSandboxCredential } from "@/lib/example/sandbox-provider";
 import {
   getWebMcpRequestFields,
   MCP_CONFIG_UPDATED_EVENT,
@@ -59,9 +60,6 @@ import {
 import { AskUserQuestionUI } from "./claude-tools/AskUserQuestionUI";
 import { STORAGE_KEY } from "./settings/page";
 
-const REQUIRED_KEYS = ["E2B_API_KEY"];
-
-/** Matches /api/ai: in development the server defaults to local daemon unless opted out. */
 const templates = [
   { id: "default", name: "Default", description: "General-purpose assistant" },
   { id: "coder", name: "Coder", description: "Software development" },
@@ -261,8 +259,7 @@ function HomeContent() {
   }, []);
 
   useEffect(() => {
-    const allRequiredSet = REQUIRED_KEYS.every((key) => !!clientConfig[key]);
-    setConfigReady(allRequiredSet);
+    setConfigReady(getMissingSandboxCredential(clientConfig) === undefined);
   }, [clientConfig]);
 
   const chatBody = {

--- a/apps/web/app/(example)/example/settings/page.tsx
+++ b/apps/web/app/(example)/example/settings/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { getSandboxCredentialKey } from "@/lib/example/sandbox-provider";
 import {
   MCP_CONFIG_UPDATED_EVENT,
   MCP_STORAGE_KEY,
@@ -157,10 +158,16 @@ const ENV_CONFIGS: EnvConfig[] = [
   {
     name: "Sandbox Provider",
     key: "SANDBOX_PROVIDER",
-    description: "Choose sandbox: 'e2b', 'sandock', or 'daytona'. Default: e2b",
+    description:
+      "Use the deployment default or explicitly select a cloud sandbox. Local execution can only be enabled with SANDBOX_PROVIDER=local on the server.",
     required: false,
     category: "sandbox",
-    placeholder: "e2b",
+    placeholder: "Deployment default",
+    options: [
+      { value: "e2b", label: "E2B" },
+      { value: "sandock", label: "Sandock" },
+      { value: "daytona", label: "Daytona" },
+    ],
   },
   {
     name: "Runner",
@@ -356,10 +363,13 @@ export default function SettingsPage() {
     }
   };
 
-  // Check if all required fields are filled
-  const requiredConfigs = ENV_CONFIGS.filter((c) => c.required);
-  const allRequiredSet = requiredConfigs.every((c) => !!config[c.key]);
-  const missingRequired = requiredConfigs.filter((c) => !config[c.key]);
+  const sandboxCredentialKey = getSandboxCredentialKey(config.SANDBOX_PROVIDER);
+  const requiredConfigs = ENV_CONFIGS.filter(
+    (item) => item.required || item.key === sandboxCredentialKey,
+  );
+  const requiredConfigKeys = new Set(requiredConfigs.map((item) => item.key));
+  const allRequiredSet = requiredConfigs.every((item) => !!config[item.key]);
+  const missingRequired = requiredConfigs.filter((item) => !config[item.key]);
 
   const categories = {
     runner: {
@@ -459,6 +469,7 @@ export default function SettingsPage() {
               <div className="space-y-4">
                 {categoryConfigs.map((envConfig) => {
                   const hasValue = !!config[envConfig.key];
+                  const isRequired = requiredConfigKeys.has(envConfig.key);
                   return (
                     <div
                       key={envConfig.key}
@@ -470,7 +481,7 @@ export default function SettingsPage() {
                             <span className="font-medium text-foreground">
                               {envConfig.name}
                             </span>
-                            {envConfig.required ? (
+                            {isRequired ? (
                               hasValue ? (
                                 <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded bg-green-500/20 text-green-600 dark:text-green-400">
                                   <Check className="size-3" /> Set

--- a/apps/web/app/api/ai/route.ts
+++ b/apps/web/app/api/ai/route.ts
@@ -23,6 +23,11 @@ import {
   evictSandbox,
   getOrCreateSandbox,
 } from "@/lib/example/create-sandbox";
+import {
+  assertSandboxCredentials,
+  resolveSandboxProvider,
+  SandboxProviderConfigError,
+} from "@/lib/example/sandbox-provider";
 import { WebMcpConfigError, webMcpServersToConfig } from "@/lib/mcp-config";
 
 import { DEFAULT_RUNNER, type RunnerType } from "@/lib/runner";
@@ -98,7 +103,7 @@ export async function POST(request: Request) {
     SANDOCK_API_KEY,
     SANDOCK_BASE_URL,
     DAYTONA_API_KEY,
-    SANDBOX_PROVIDER = "e2b",
+    SANDBOX_PROVIDER,
     BRAVE_API_KEY,
     TAVILY_API_KEY,
     /** When true, provider may pass `daemonUrl` after an in-sandbox `/healthz` probe; otherwise CLI runner. */
@@ -106,6 +111,27 @@ export async function POST(request: Request) {
     REASONING_EFFORT,
     mcpServers,
   } = body;
+
+  let sandboxProvider: ReturnType<typeof resolveSandboxProvider>;
+  try {
+    sandboxProvider = resolveSandboxProvider(
+      SANDBOX_PROVIDER,
+      process.env.SANDBOX_PROVIDER,
+    );
+    assertSandboxCredentials(sandboxProvider, {
+      E2B_API_KEY,
+      SANDOCK_API_KEY,
+      DAYTONA_API_KEY,
+    });
+  } catch (error) {
+    if (error instanceof SandboxProviderConfigError) {
+      return new Response(error.message, {
+        status: 400,
+        headers: { "Content-Type": "text/plain" },
+      });
+    }
+    throw error;
+  }
 
   const useBunnyAgentDaemon =
     USE_BUNNY_AGENT_DAEMON === true ||
@@ -115,18 +141,30 @@ export async function POST(request: Request) {
     process.env.BUNNY_AGENT_USE_DAEMON === "1";
 
   const signal = request.signal;
+  const serverAuth: Record<string, string | undefined> =
+    sandboxProvider === "local" ? process.env : {};
 
-  // Same logic as @bunny-agent/runner-claude hasClaudeAuth (supports Bedrock proxy)
+  // Local execution may use credentials already configured on the host.
   const hasClaudeAuth =
     !!ANTHROPIC_API_KEY ||
+    !!serverAuth.ANTHROPIC_API_KEY ||
     !!AWS_BEARER_TOKEN_BEDROCK ||
+    !!serverAuth.AWS_BEARER_TOKEN_BEDROCK ||
     !!ANTHROPIC_AUTH_TOKEN ||
+    !!serverAuth.ANTHROPIC_AUTH_TOKEN ||
     !!LITELLM_MASTER_KEY ||
-    (CLAUDE_CODE_USE_BEDROCK === "1" && !!ANTHROPIC_BEDROCK_BASE_URL);
+    !!serverAuth.LITELLM_MASTER_KEY ||
+    ((CLAUDE_CODE_USE_BEDROCK ?? serverAuth.CLAUDE_CODE_USE_BEDROCK) === "1" &&
+      !!(ANTHROPIC_BEDROCK_BASE_URL ?? serverAuth.ANTHROPIC_BEDROCK_BASE_URL));
   const runnerType = ((RUNNER ?? DEFAULT_RUNNER).toLowerCase() ||
     DEFAULT_RUNNER) as RunnerType;
   // Pi supports multiple providers: OpenAI, Gemini, or Anthropic (same as Claude)
-  const hasPiAuth = !!OPENAI_API_KEY || !!GEMINI_API_KEY || hasClaudeAuth;
+  const hasPiAuth =
+    !!OPENAI_API_KEY ||
+    !!serverAuth.OPENAI_API_KEY ||
+    !!GEMINI_API_KEY ||
+    !!serverAuth.GEMINI_API_KEY ||
+    hasClaudeAuth;
   let mcpConfig: ReturnType<typeof webMcpServersToConfig>;
 
   // --- Validation -----------------------------------------------------------
@@ -151,27 +189,6 @@ export async function POST(request: Request) {
   } else if (!hasClaudeAuth) {
     return new Response(
       "Claude auth is required. Set one of: ANTHROPIC_API_KEY, AWS_BEARER_TOKEN_BEDROCK, ANTHROPIC_AUTH_TOKEN, LITELLM_MASTER_KEY, or Bedrock proxy (CLAUDE_CODE_USE_BEDROCK=1 + ANTHROPIC_BEDROCK_BASE_URL). Configure in Settings.",
-      { status: 400, headers: { "Content-Type": "text/plain" } },
-    );
-  }
-
-  if (SANDBOX_PROVIDER === "e2b" && !E2B_API_KEY) {
-    return new Response("E2B_API_KEY is required when using E2B sandbox.", {
-      status: 400,
-      headers: { "Content-Type": "text/plain" },
-    });
-  }
-
-  if (SANDBOX_PROVIDER === "sandock" && !SANDOCK_API_KEY) {
-    return new Response(
-      "SANDOCK_API_KEY is required when using Sandock sandbox.",
-      { status: 400, headers: { "Content-Type": "text/plain" } },
-    );
-  }
-
-  if (SANDBOX_PROVIDER === "daytona" && !DAYTONA_API_KEY) {
-    return new Response(
-      "DAYTONA_API_KEY is required when using Daytona sandbox.",
       { status: 400, headers: { "Content-Type": "text/plain" } },
     );
   }
@@ -252,7 +269,7 @@ export async function POST(request: Request) {
 
   // --- Sandbox (cached per chat) --------------------------------------------
   const sandboxParams: CreateSandboxParams = {
-    SANDBOX_PROVIDER,
+    SANDBOX_PROVIDER: sandboxProvider,
     runnerType,
     E2B_API_KEY,
     SANDOCK_API_KEY,
@@ -354,7 +371,7 @@ export async function POST(request: Request) {
           { cwd: handle.getWorkdir(), signal },
         );
         console.info("[api/ai] daemon health check", {
-          sandboxProvider: SANDBOX_PROVIDER,
+          sandboxProvider,
           sandboxId: handle.getSandboxId(),
           daemonUrl: DEFAULT_BUNNY_AGENT_DAEMON_URL,
           daemonOk,

--- a/apps/web/app/api/answer/route.ts
+++ b/apps/web/app/api/answer/route.ts
@@ -3,6 +3,10 @@ import {
   type CreateSandboxParams,
   getOrCreateSandbox,
 } from "@/lib/example/create-sandbox";
+import {
+  resolveSandboxProvider,
+  SandboxProviderConfigError,
+} from "@/lib/example/sandbox-provider";
 
 /**
  * POST /api/answer
@@ -45,8 +49,24 @@ export async function POST(request: Request) {
     );
   }
 
+  let sandboxProvider: ReturnType<typeof resolveSandboxProvider>;
+  try {
+    sandboxProvider = resolveSandboxProvider(
+      b.SANDBOX_PROVIDER as string | undefined,
+      process.env.SANDBOX_PROVIDER,
+    );
+  } catch (error) {
+    return Response.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 400 },
+    );
+  }
+
   const sandboxParams: CreateSandboxParams = {
-    SANDBOX_PROVIDER: b.SANDBOX_PROVIDER as string | undefined,
+    SANDBOX_PROVIDER: sandboxProvider,
     E2B_API_KEY: b.E2B_API_KEY as string | undefined,
     SANDOCK_API_KEY: b.SANDOCK_API_KEY as string | undefined,
     DAYTONA_API_KEY: b.DAYTONA_API_KEY as string | undefined,
@@ -70,7 +90,9 @@ export async function POST(request: Request) {
         success: false,
         error: error instanceof Error ? error.message : "Unknown error",
       },
-      { status: 500 },
+      {
+        status: error instanceof SandboxProviderConfigError ? 400 : 500,
+      },
     );
   }
 }

--- a/apps/web/lib/example/create-sandbox.ts
+++ b/apps/web/lib/example/create-sandbox.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import type { DaytonaSandboxOptions } from "@bunny-agent/sandbox-daytona";
 import { E2BSandbox } from "@bunny-agent/sandbox-e2b";
@@ -9,6 +10,11 @@ import {
   type SandboxAdapter,
 } from "@bunny-agent/sdk";
 import type { RunnerType } from "@/lib/runner";
+import {
+  assertSandboxCredentials,
+  resolveLocalRunnerCommand,
+  type SandboxProvider,
+} from "./sandbox-provider";
 
 const MONOREPO_ROOT = path.resolve(process.cwd(), "../..");
 const TEMPLATES_PATH = path.join(MONOREPO_ROOT, "templates");
@@ -73,7 +79,7 @@ function sandockImageNeedsBundledEntrypoint(image: string): boolean {
 }
 
 export interface CreateSandboxParams {
-  SANDBOX_PROVIDER?: string;
+  SANDBOX_PROVIDER?: SandboxProvider;
   /** Runner type for buildRunnerEnv (e.g. pi needs ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL mapping). */
   runnerType?: RunnerType;
   E2B_API_KEY?: string;
@@ -217,10 +223,16 @@ async function buildSandbox(
     TAVILY_API_KEY,
     inherit: extraEnv,
   });
-  if (SANDBOX_PROVIDER === "daytona" && DAYTONA_API_KEY) {
+  assertSandboxCredentials(SANDBOX_PROVIDER, {
+    E2B_API_KEY,
+    SANDOCK_API_KEY,
+    DAYTONA_API_KEY,
+  });
+
+  if (SANDBOX_PROVIDER === "daytona") {
     const { DaytonaSandbox } = await import("@bunny-agent/sandbox-daytona");
     const opts: DaytonaSandboxOptions & { snapshot?: string } = {
-      apiKey: DAYTONA_API_KEY,
+      apiKey: DAYTONA_API_KEY!,
       templatesPath: path.join(TEMPLATES_PATH, template),
       volumeName: sandboxName,
       volumeMountPath: "/workspace",
@@ -234,12 +246,12 @@ async function buildSandbox(
     return new DaytonaSandbox(opts) as unknown as SandboxAdapter;
   }
 
-  if (SANDBOX_PROVIDER === "sandock" && SANDOCK_API_KEY) {
+  if (SANDBOX_PROVIDER === "sandock") {
     const cacheKey = sandboxCacheKey(params);
     const cachedId = getCachedSandboxId(cacheKey);
     const image = params.SANDBOX_IMAGE ?? SANDBOX_IMAGE;
     return new SandockSandbox({
-      apiKey: SANDOCK_API_KEY,
+      apiKey: SANDOCK_API_KEY!,
       ...(SANDOCK_BASE_URL ? { baseUrl: SANDOCK_BASE_URL } : {}),
       image,
       skipBootstrap: true,
@@ -261,9 +273,9 @@ async function buildSandbox(
     });
   }
 
-  if (SANDBOX_PROVIDER === "e2b" && E2B_API_KEY) {
+  if (SANDBOX_PROVIDER === "e2b") {
     return new E2BSandbox({
-      apiKey: E2B_API_KEY,
+      apiKey: E2B_API_KEY!,
       templatesPath: path.join(TEMPLATES_PATH, template),
       name: sandboxName,
       env: baseEnv,
@@ -271,16 +283,23 @@ async function buildSandbox(
     });
   }
 
-  const localWorkdir =
-    params.localWorkdir ?? path.join(process.cwd(), "workspace");
-  return new LocalMachine({
-    workdir: localWorkdir,
-    templatesPath: path.join(TEMPLATES_PATH, template),
-    env: {
-      ...baseEnv,
-      DEBUG: "true",
-      API_TIMEOUT_MS: "3000",
-    },
-    runnerCommand: ["node", RUNNER_BUNDLE_PATH, "run"],
-  });
+  if (SANDBOX_PROVIDER === "local") {
+    const localWorkdir =
+      params.localWorkdir ?? path.join(process.cwd(), "workspace");
+    return new LocalMachine({
+      workdir: localWorkdir,
+      templatesPath: path.join(TEMPLATES_PATH, template),
+      env: {
+        ...baseEnv,
+        DEBUG: "true",
+        API_TIMEOUT_MS: "3000",
+      },
+      runnerCommand: resolveLocalRunnerCommand(
+        RUNNER_BUNDLE_PATH,
+        existsSync(RUNNER_BUNDLE_PATH),
+      ),
+    });
+  }
+
+  throw new Error(`Unsupported sandbox provider: ${SANDBOX_PROVIDER}`);
 }

--- a/apps/web/lib/example/sandbox-provider.test.ts
+++ b/apps/web/lib/example/sandbox-provider.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertSandboxCredentials,
+  getMissingSandboxCredential,
+  getSandboxCredentialKey,
+  resolveLocalRunnerCommand,
+  resolveSandboxProvider,
+  SandboxProviderConfigError,
+} from "./sandbox-provider";
+
+describe("resolveSandboxProvider", () => {
+  it("keeps E2B as the deployment default", () => {
+    expect(resolveSandboxProvider()).toBe("e2b");
+  });
+
+  it("uses server-enabled local execution when the request has no override", () => {
+    expect(resolveSandboxProvider(undefined, "local")).toBe("local");
+  });
+
+  it("allows an explicit cloud provider to override the deployment default", () => {
+    expect(resolveSandboxProvider("sandock", "local")).toBe("sandock");
+  });
+
+  it("rejects client attempts to enable local execution", () => {
+    expect(() => resolveSandboxProvider("local", "e2b")).toThrow(
+      /Local execution is disabled/,
+    );
+  });
+
+  it("rejects unknown request and server providers", () => {
+    expect(() => resolveSandboxProvider("docker", "e2b")).toThrow(
+      SandboxProviderConfigError,
+    );
+    expect(() => resolveSandboxProvider(undefined, "docker")).toThrow(
+      /Unsupported server sandbox provider/,
+    );
+  });
+});
+
+describe("sandbox credentials", () => {
+  it.each([
+    ["e2b", "E2B_API_KEY"],
+    ["sandock", "SANDOCK_API_KEY"],
+    ["daytona", "DAYTONA_API_KEY"],
+  ] as const)("requires the matching key for %s", (provider, key) => {
+    expect(getSandboxCredentialKey(provider)).toBe(key);
+    expect(() => assertSandboxCredentials(provider, {})).toThrow(
+      `${key} is required`,
+    );
+    expect(() =>
+      assertSandboxCredentials(provider, { [key]: "configured" }),
+    ).not.toThrow();
+  });
+
+  it("does not require a cloud key for local or deployment-default UI state", () => {
+    expect(getSandboxCredentialKey("local")).toBeUndefined();
+    expect(getSandboxCredentialKey(undefined)).toBeUndefined();
+    expect(() => assertSandboxCredentials("local", {})).not.toThrow();
+  });
+  it("reports missing credentials only for an explicit cloud selection", () => {
+    expect(getMissingSandboxCredential({})).toBeUndefined();
+    expect(getMissingSandboxCredential({ SANDBOX_PROVIDER: "e2b" })).toBe(
+      "E2B_API_KEY",
+    );
+    expect(
+      getMissingSandboxCredential({
+        SANDBOX_PROVIDER: "e2b",
+        E2B_API_KEY: "configured",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("resolveLocalRunnerCommand", () => {
+  it("uses the monorepo runner bundle when it is available", () => {
+    expect(
+      resolveLocalRunnerCommand("/repo/apps/runner-cli/bundle.mjs", true),
+    ).toEqual(["node", "/repo/apps/runner-cli/bundle.mjs", "run"]);
+  });
+
+  it("uses the installed CLI in deployment images without the bundle", () => {
+    expect(resolveLocalRunnerCommand("/missing/bundle.mjs", false)).toEqual([
+      "bunny-agent",
+      "run",
+    ]);
+  });
+});

--- a/apps/web/lib/example/sandbox-provider.ts
+++ b/apps/web/lib/example/sandbox-provider.ts
@@ -1,0 +1,93 @@
+export const SANDBOX_PROVIDERS = [
+  "local",
+  "e2b",
+  "sandock",
+  "daytona",
+] as const;
+
+export type SandboxProvider = (typeof SANDBOX_PROVIDERS)[number];
+export type CloudSandboxProvider = Exclude<SandboxProvider, "local">;
+
+const CLOUD_SANDBOX_CREDENTIALS: Record<CloudSandboxProvider, string> = {
+  e2b: "E2B_API_KEY",
+  sandock: "SANDOCK_API_KEY",
+  daytona: "DAYTONA_API_KEY",
+};
+
+export class SandboxProviderConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SandboxProviderConfigError";
+  }
+}
+
+function parseSandboxProvider(
+  value: string | undefined,
+  source: "request" | "server",
+): SandboxProvider | undefined {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized) return undefined;
+  if (SANDBOX_PROVIDERS.includes(normalized as SandboxProvider)) {
+    return normalized as SandboxProvider;
+  }
+
+  throw new SandboxProviderConfigError(
+    `Unsupported ${source} sandbox provider "${value}". Expected one of: ${SANDBOX_PROVIDERS.join(", ")}.`,
+  );
+}
+
+/** Resolve a request provider without allowing clients to enable host execution. */
+export function resolveSandboxProvider(
+  requestedProvider?: string,
+  serverProvider?: string,
+): SandboxProvider {
+  const requested = parseSandboxProvider(requestedProvider, "request");
+  const configured = parseSandboxProvider(serverProvider, "server");
+
+  if (requested === "local" && configured !== "local") {
+    throw new SandboxProviderConfigError(
+      "Local execution is disabled. Set SANDBOX_PROVIDER=local on the server to enable it.",
+    );
+  }
+
+  return requested ?? configured ?? "e2b";
+}
+
+export function getSandboxCredentialKey(
+  provider: string | undefined,
+): string | undefined {
+  if (!provider) return undefined;
+  const normalized = provider.trim().toLowerCase();
+  if (normalized === "local") return undefined;
+  if (normalized in CLOUD_SANDBOX_CREDENTIALS) {
+    return CLOUD_SANDBOX_CREDENTIALS[normalized as CloudSandboxProvider];
+  }
+  return undefined;
+}
+export function getMissingSandboxCredential(
+  config: Record<string, string | undefined>,
+): string | undefined {
+  const credentialKey = getSandboxCredentialKey(config.SANDBOX_PROVIDER);
+  return credentialKey && !config[credentialKey] ? credentialKey : undefined;
+}
+
+export function assertSandboxCredentials(
+  provider: SandboxProvider,
+  credentials: Record<string, string | undefined>,
+): void {
+  const credentialKey = getSandboxCredentialKey(provider);
+  if (credentialKey && !credentials[credentialKey]) {
+    throw new SandboxProviderConfigError(
+      `${credentialKey} is required when using ${provider} sandbox.`,
+    );
+  }
+}
+
+export function resolveLocalRunnerCommand(
+  runnerBundlePath: string,
+  bundleExists: boolean,
+): string[] {
+  return bundleExists
+    ? ["node", runnerBundlePath, "run"]
+    : ["bunny-agent", "run"];
+}

--- a/docs/changelog/2026-09-02-web-demo-local-execution.md
+++ b/docs/changelog/2026-09-02-web-demo-local-execution.md
@@ -1,0 +1,33 @@
+# Web Demo Local Execution Mode
+
+## Changes
+
+- Added shared Bunny demo sandbox-provider parsing and cloud credential validation.
+- Kept E2B as the fallback provider while allowing deployments to select direct
+  host execution with the server-side `SANDBOX_PROVIDER=local` setting.
+- Prevented browser requests from enabling local execution unless the deployment
+  has explicitly enabled it.
+- Added unit coverage for provider precedence, local-mode authorization, invalid
+  providers, and provider-specific cloud credentials.
+
+- Changed the sandbox factory to construct `LocalMachine` only for the explicit
+  local provider and to reject missing cloud credentials instead of silently
+  falling back to host execution.
+- Made direct execution use the monorepo runner bundle when present and the
+  installed `bunny-agent` command in deployment images otherwise.
+
+- Updated both demo API routes to resolve the deployment provider consistently,
+  accept host model credentials only in local mode, and return configuration
+  failures as HTTP 400 responses.
+- Updated Settings and chat readiness so deployment-default mode requires no
+  browser sandbox key while explicit cloud selections require their matching key.
+- Documented how to enable local mode and its host-execution security boundary.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/web test`
+- `pnpm --filter @bunny-agent/web types:check`
+- `pnpm exec biome check <changed TypeScript files>`
+- `pnpm --filter @bunny-agent/web... build`
+- Started the demo with `SANDBOX_PROVIDER=local` on port 3040 and confirmed
+  `GET /example` returns HTTP 200.


### PR DESCRIPTION
## Summary

- add a server-controlled `local` execution mode for the Bunny web demo
- reuse `LocalMachine` without requiring E2B, Sandock, or Daytona credentials
- prevent browser clients from enabling host execution unless the server opts in with `SANDBOX_PROVIDER=local`
- make Settings and chat readiness require credentials only for explicitly selected cloud providers
- fall back to the installed `bunny-agent` CLI when the monorepo runner bundle is unavailable

## Security

Local execution runs agent commands with the web service process permissions. It is disabled unless the deployment explicitly sets `SANDBOX_PROVIDER=local`.

## Verification

- `pnpm --filter @bunny-agent/web test`
- `pnpm --filter @bunny-agent/web types:check`
- `pnpm exec biome check <changed TypeScript files>`
- `pnpm --filter @bunny-agent/web... build`
- started with `SANDBOX_PROVIDER=local` on port 3040; `GET /example` returned HTTP 200