### PR TITLE
fix(docker): bound CDP Chromium storage

### DIFF
--- a/apps/daemon/README.md
+++ b/apps/daemon/README.md
@@ -216,11 +216,19 @@ Output: raw AI SDK UI NDJSON stream to stdout.
 # DNS-rebinding security check. Without this rewrite, external clients
 # (Host: container-ip:9222) are rejected even when the port is open.
 chromium --headless --no-sandbox \
+  --user-data-dir=/tmp/bunny-agent-chromium \
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \
+  --disk-cache-size=104857600 \
+  --media-cache-size=104857600 \
   --remote-debugging-port=9223 \
   --remote-allow-origins=* &
 nginx  # proxies :9222 → :9223 with Host rewrite
 exec bunny-agent-daemon
 ```
+
+The CDP browser uses an ephemeral profile under `/tmp` so browser state does not
+accumulate in `~/.config/chromium`. Disk and media caches are each capped at
+100 MiB.
 
 ```bash
 # Run an agent — SSE stream

--- a/apps/daemon/docs/entrypoint.example.sh
+++ b/apps/daemon/docs/entrypoint.example.sh
@@ -25,6 +25,10 @@ fi
 if [ -n "$CHROME_BIN" ]; then
   echo "Starting $CHROME_BIN CDP on internal :9223"
   "$CHROME_BIN" --headless --no-sandbox \
+    --user-data-dir=/tmp/bunny-agent-chromium \
+    --disk-cache-dir=/tmp/bunny-agent-chromium-cache \
+    --disk-cache-size=104857600 \
+    --media-cache-size=104857600 \
     --remote-debugging-port=9223 \
     --remote-allow-origins=* \
     2>/dev/null &

--- a/apps/daemon/docs/entrypoint.example.sh
+++ b/apps/daemon/docs/entrypoint.example.sh
@@ -53,6 +53,9 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_read_timeout 3600s;
+            proxy_send_timeout 3600s;
+            proxy_socket_keepalive on;
         }
     }
 }

--- a/apps/runner-cli/src/__tests__/build-image.test.ts
+++ b/apps/runner-cli/src/__tests__/build-image.test.ts
@@ -79,6 +79,12 @@ describe("buildImage", () => {
     const content = readFileSync(dockerfilePath, "utf8");
     expect(content).toContain("FROM node:24-slim");
     expect(content).toContain("@bunny-agent/runner-cli");
+    expect(content).toContain("--user-data-dir=/tmp/bunny-agent-chromium");
+    expect(content).toContain(
+      "--disk-cache-dir=/tmp/bunny-agent-chromium-cache",
+    );
+    expect(content).toContain("--disk-cache-size=104857600");
+    expect(content).toContain("--media-cache-size=104857600");
     expect(content).toContain('CMD ["sleep", "infinity"]');
   });
 

--- a/apps/runner-cli/src/__tests__/build-image.test.ts
+++ b/apps/runner-cli/src/__tests__/build-image.test.ts
@@ -85,6 +85,9 @@ describe("buildImage", () => {
     );
     expect(content).toContain("--disk-cache-size=104857600");
     expect(content).toContain("--media-cache-size=104857600");
+    expect(content).toContain("proxy_read_timeout 3600s;");
+    expect(content).toContain("proxy_send_timeout 3600s;");
+    expect(content).toContain("proxy_socket_keepalive on;");
     expect(content).toContain('CMD ["sleep", "infinity"]');
   });
 

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -187,6 +187,12 @@ set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
   --window-size=1280,800 --force-device-scale-factor=1 \\\n\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\
+\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
+\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
+\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -178,6 +178,9 @@ RUN printf '%s\n' \
         proxy_http_version 1.1;\n\
         proxy_set_header Upgrade $http_upgrade;\n\
         proxy_set_header Connection "upgrade";\n\
+        proxy_read_timeout 3600s;\n\
+        proxy_send_timeout 3600s;\n\
+        proxy_socket_keepalive on;\n\
     }\n\
 }' > /etc/nginx/conf.d/cdp-proxy.conf && \
     rm -f /etc/nginx/sites-enabled/default

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -168,6 +168,12 @@ RUN echo '#!/bin/bash\n\
 set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\
+\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
+\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
+\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -160,6 +160,9 @@ RUN printf '%s\n' \
         proxy_http_version 1.1;\n\
         proxy_set_header Upgrade $http_upgrade;\n\
         proxy_set_header Connection "upgrade";\n\
+        proxy_read_timeout 3600s;\n\
+        proxy_send_timeout 3600s;\n\
+        proxy_socket_keepalive on;\n\
     }\n\
 }' > /etc/nginx/conf.d/cdp-proxy.conf && \
     rm -f /etc/nginx/sites-enabled/default

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -159,6 +159,12 @@ RUN echo '#!/bin/bash\n\
 set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\
+\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
+\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
+\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -151,6 +151,9 @@ RUN printf '%s\n' \
         proxy_http_version 1.1;\n\
         proxy_set_header Upgrade $http_upgrade;\n\
         proxy_set_header Connection "upgrade";\n\
+        proxy_read_timeout 3600s;\n\
+        proxy_send_timeout 3600s;\n\
+        proxy_socket_keepalive on;\n\
     }\n\
 }' > /etc/nginx/conf.d/cdp-proxy.conf && \
     rm -f /etc/nginx/sites-enabled/default

--- a/docs/changelog/2026-09-04-cdp-chromium-storage.md
+++ b/docs/changelog/2026-09-04-cdp-chromium-storage.md
@@ -1,0 +1,18 @@
+# Limit CDP Chromium Storage Growth
+
+## Changes
+
+- Moved the CDP Chromium user profile from the default persistent configuration
+  directory to `/tmp/bunny-agent-chromium`.
+- Moved the Chromium disk cache to `/tmp/bunny-agent-chromium-cache`.
+- Capped the Chromium disk and media caches at 100 MiB each.
+- Applied the storage settings to the published, local, and template Docker
+  images and to the daemon entrypoint example.
+- Added a regression assertion to the runner CLI image build test.
+
+## Verification
+
+- Passed the runner CLI test suite (35 tests).
+- Passed Biome checks for the modified TypeScript test.
+- Passed the daemon example entrypoint shell syntax check.
+- Passed Dockerfile consistency and Git whitespace checks.

--- a/docs/changelog/2026-09-06-cdp-proxy-timeouts.md
+++ b/docs/changelog/2026-09-06-cdp-proxy-timeouts.md
@@ -1,0 +1,16 @@
+# Extend CDP Proxy Timeouts
+
+## Changes
+
+- Increased the nginx CDP proxy read and send timeouts to one hour.
+- Enabled TCP keepalive for the nginx connection to Chromium.
+- Applied the settings to the published, local, and template Docker images and
+  to the daemon entrypoint example.
+- Added regression assertions to the runner CLI image build test.
+
+## Verification
+
+- Passed the runner CLI test suite (35 tests).
+- Passed Biome checks for the modified TypeScript test.
+- Passed the daemon example entrypoint shell syntax check.
+- Passed CDP proxy configuration consistency and Git whitespace checks.


### PR DESCRIPTION
## Summary

- move the CDP Chromium profile and disk cache out of the persistent user configuration directory and into `/tmp`
- cap disk and media caches at 100 MiB each across published, local, and template Docker images
- update daemon documentation and add image-build regression coverage

## Testing

- `pnpm --filter @bunny-agent/runner-cli test -- src/__tests__/build-image.test.ts` (35 tests)
- `pnpm exec vitest run src/__tests__/build-image.test.ts` (7 focused tests)
- `pnpm exec biome check apps/runner-cli/src/__tests__/build-image.test.ts`
- `bash -n apps/daemon/docs/entrypoint.example.sh`
- `git diff --check`