### PR TITLE
fix(runner-pi): add Gemini 3.8 dynamic profile

### DIFF
--- a/docs/changelog/2026-09-08-pi-gemini-3-8-profile.md
+++ b/docs/changelog/2026-09-08-pi-gemini-3-8-profile.md
@@ -1,0 +1,23 @@
+# Pi Gemini 3.8 Dynamic Model Profile
+
+## Changes
+
+- Added a `gemini-3.8-flash` dynamic model profile to runner-pi with the same
+  1,048,576-token context window, 65,536-token output limit, reasoning support,
+  and thinking-level compatibility map as `gemini-3.7-flash`.
+- Added regression coverage proving both Gemini Flash profiles remain identical,
+  model lookup remains case-insensitive, and unknown dynamic models retain the
+  existing 128,000-token context and 8,192-token output fallback.
+
+## Why
+
+Without an explicit profile, an OpenAI-compatible gateway route for Gemini 3.8
+was treated as an unknown dynamic model and restricted to the generic 8,192-token
+output limit. Long-running agent tasks could therefore terminate before the
+model's supported output capacity was reached.
+
+## Verification
+
+- `pnpm --filter @bunny-agent/runner-pi exec vitest run src/__tests__/pi-runner.parse-model-spec.test.ts`
+- `pnpm --filter @bunny-agent/runner-pi typecheck`
+- `pnpm exec biome check packages/runner-pi/src/pi-runner.ts packages/runner-pi/src/__tests__/pi-runner.parse-model-spec.test.ts`

--- a/packages/runner-pi/src/__tests__/pi-runner.parse-model-spec.test.ts
+++ b/packages/runner-pi/src/__tests__/pi-runner.parse-model-spec.test.ts
@@ -49,32 +49,30 @@ describe("parseModelSpec", () => {
 });
 
 describe("resolveDynamicModelProfile", () => {
-  it("uses the published Gemini 3.7 Flash limits", () => {
-    expect(resolveDynamicModelProfile("gemini-3.7-flash")).toEqual({
-      contextWindow: 1_048_576,
-      maxTokens: 65_536,
-      reasoning: true,
-      thinkingLevelMap: {
-        off: null,
-        minimal: null,
-        xhigh: null,
-        max: null,
-      },
-    });
+  const geminiFlashProfile = {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      xhigh: null,
+      max: null,
+    },
+  };
+
+  it.each([
+    "gemini-3.7-flash",
+    "gemini-3.8-flash",
+  ])("uses the same published Flash profile for %s", (modelName) => {
+    expect(resolveDynamicModelProfile(modelName)).toEqual(geminiFlashProfile);
   });
 
-  it("matches known model aliases case-insensitively", () => {
-    expect(resolveDynamicModelProfile("GEMINI-3.7-FLASH")).toEqual({
-      contextWindow: 1_048_576,
-      maxTokens: 65_536,
-      reasoning: true,
-      thinkingLevelMap: {
-        off: null,
-        minimal: null,
-        xhigh: null,
-        max: null,
-      },
-    });
+  it.each([
+    "GEMINI-3.7-FLASH",
+    "GEMINI-3.8-FLASH",
+  ])("matches %s case-insensitively", (modelName) => {
+    expect(resolveDynamicModelProfile(modelName)).toEqual(geminiFlashProfile);
   });
 
   it("retains the generic profile for unknown aliases", () => {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -82,6 +82,17 @@ const DYNAMIC_MODEL_PROFILES: Record<
       max: null,
     },
   },
+  "gemini-3.8-flash": {
+    contextWindow: 1_048_576,
+    maxTokens: 65_536,
+    reasoning: true,
+    thinkingLevelMap: {
+      off: null,
+      minimal: null,
+      xhigh: null,
+      max: null,
+    },
+  },
 };
 
 interface ModelIdentity {


### PR DESCRIPTION
## Summary

- add a gemini-3.8-flash dynamic model profile matching Gemini 3.7 Flash
- use a 1,048,576-token context window and 65,536-token output limit
- preserve the existing 128,000 / 8,192 fallback for unknown dynamic models
- add regression coverage for both aliases and case-insensitive lookup

## Why

Without an explicit profile, runner-pi treats the Gemini 3.8 Flash gateway alias as an unknown dynamic model and sends the generic 8,192-token output limit. Reasoning-heavy agent tasks can then terminate with a length stop before reaching the supported output capacity.

## Validation

- pnpm run -w lint
- pnpm -r --filter @bunny-agent/runner-pi typecheck
- pnpm -r --filter @bunny-agent/runner-pi test (16 files, 196 tests passed)
- git diff --check