### PR TITLE
fix(docker): repair Chromium argument continuations

### DIFF
--- a/apps/runner-cli/src/__tests__/build-image.test.ts
+++ b/apps/runner-cli/src/__tests__/build-image.test.ts
@@ -25,6 +25,25 @@ const mockedExecSync = vi.mocked(execSync);
 
 const TEST_DIR = join(process.cwd(), ".test-build-image");
 const BUILD_CONTEXT = join(TEST_DIR, ".docker-staging");
+const REPOSITORY_ROOT = join(process.cwd(), "../..");
+
+const CHROMIUM_STORAGE_ARGUMENTS = [
+  "--user-data-dir=/tmp/bunny-agent-chromium",
+  "--disk-cache-dir=/tmp/bunny-agent-chromium-cache",
+  "--disk-cache-size=104857600 --media-cache-size=104857600",
+];
+
+function expectValidChromiumArgumentContinuations(content: string): void {
+  const expectedSuffix = "\\".repeat(3) + "n\\";
+
+  for (const argument of CHROMIUM_STORAGE_ARGUMENTS) {
+    const line = content
+      .split("\n")
+      .find((candidate) => candidate.includes(argument));
+    expect(line, "missing Chromium argument: " + argument).toBeDefined();
+    expect(line?.endsWith(expectedSuffix), argument).toBe(true);
+  }
+}
 
 beforeEach(() => {
   mkdirSync(TEST_DIR, { recursive: true });
@@ -88,7 +107,24 @@ describe("buildImage", () => {
     expect(content).toContain("proxy_read_timeout 3600s;");
     expect(content).toContain("proxy_send_timeout 3600s;");
     expect(content).toContain("proxy_socket_keepalive on;");
+    expectValidChromiumArgumentContinuations(content);
     expect(content).toContain('CMD ["sleep", "infinity"]');
+  });
+
+  it("keeps Chromium argument continuations valid in every Dockerfile", () => {
+    const dockerfiles = [
+      "Dockerfile",
+      "Dockerfile.local",
+      "Dockerfile.template",
+    ];
+
+    for (const dockerfile of dockerfiles) {
+      const content = readFileSync(
+        join(REPOSITORY_ROOT, "docker/bunny-agent-claude", dockerfile),
+        "utf8",
+      );
+      expectValidChromiumArgumentContinuations(content);
+    }
   });
 
   it("uses --image override when provided", async () => {

--- a/docker/bunny-agent-claude/Dockerfile
+++ b/docker/bunny-agent-claude/Dockerfile
@@ -190,12 +190,9 @@ set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
   --window-size=1280,800 --force-device-scale-factor=1 \\\n\
-  --user-data-dir=/tmp/bunny-agent-chromium \\\
-\
-  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
-\
-  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
-\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\n\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\n\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\n\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docker/bunny-agent-claude/Dockerfile.local
+++ b/docker/bunny-agent-claude/Dockerfile.local
@@ -171,12 +171,9 @@ RUN echo '#!/bin/bash\n\
 set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
-  --user-data-dir=/tmp/bunny-agent-chromium \\\
-\
-  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
-\
-  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
-\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\n\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\n\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\n\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docker/bunny-agent-claude/Dockerfile.template
+++ b/docker/bunny-agent-claude/Dockerfile.template
@@ -162,12 +162,9 @@ RUN echo '#!/bin/bash\n\
 set -e\n\
 CHROME_BIN=$(node -e "console.log(require('"'"'playwright'"'"').chromium.executablePath())")\n\
 "$CHROME_BIN" --headless --no-sandbox --disable-gpu --disable-dev-shm-usage --disable-software-rasterizer \\\n\
-  --user-data-dir=/tmp/bunny-agent-chromium \\\
-\
-  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\
-\
-  --disk-cache-size=104857600 --media-cache-size=104857600 \\\
-\
+  --user-data-dir=/tmp/bunny-agent-chromium \\\n\
+  --disk-cache-dir=/tmp/bunny-agent-chromium-cache \\\n\
+  --disk-cache-size=104857600 --media-cache-size=104857600 \\\n\
   --remote-debugging-port=9223 --remote-allow-origins=* 2>/dev/null &\n\
 for i in $(seq 1 30); do\n\
   if curl -s http://127.0.0.1:9223/json/version > /dev/null 2>&1; then break; fi\n\

--- a/docs/changelog/2026-09-08-cdp-dockerfile-continuations.md
+++ b/docs/changelog/2026-09-08-cdp-dockerfile-continuations.md
@@ -1,0 +1,15 @@
+# Fix CDP Dockerfile Continuations
+
+## Changes
+
+- Fixed malformed line continuations in the Chromium startup command across
+  the published, local, and template Dockerfiles.
+- Added regression coverage that validates the escaped line ending of every
+  Chromium storage argument in all three Dockerfiles.
+
+## Verification
+
+- Passed the runner CLI test suite (36 tests).
+- Passed Biome checks for the modified TypeScript test.
+- Passed Docker BuildKit validation for the published Dockerfile.
+- Passed Git whitespace checks.


### PR DESCRIPTION
## Summary

- Fix malformed escaped line continuations in the Chromium startup command.
- Apply the correction to the published, local, and template Dockerfiles.
- Add regression coverage for the exact continuation suffix in all Dockerfile variants.

## Root cause

PR #419 added Chromium storage arguments without the literal newline escape required by the Dockerfile-generated shell script. Docker therefore parsed --disk-cache-dir as a new instruction during the v0.9.61-release.2 image build.

Failed job: https://github.com/buda-ai/bunny-agent/actions/runs/34183952990/job/101928444287

## Verification

- Runner CLI test suite: 36 tests passed.
- Biome check passed for the modified test.
- Docker BuildKit check passed with RUNNER_CLI_VERSION=0.9.61-release.2.
- Git whitespace check passed.